### PR TITLE
SwapsMgmt: import contract before saving swap

### DIFF
--- a/NArk.Core/Services/CoinService.cs
+++ b/NArk.Core/Services/CoinService.cs
@@ -42,7 +42,7 @@ public class CoinService(IClientTransport clientTransport, IContractStorage cont
         logger?.LogDebug("Getting PSBT signer for vtxo by script {TxId}:{Index}", vtxo.TransactionId, vtxo.TransactionOutputIndex);
         var contracts = await contractStorage.LoadContractsByScripts([vtxo.Script], [walletIdentifier], cancellationToken);
 
-        if (contracts.SingleOrDefault() is not { } contract)
+        if (contracts.FirstOrDefault() is not { } contract)
         {
             logger?.LogWarning("Could not find contract for vtxo {TxId}:{Index}", vtxo.TransactionId,
                 vtxo.TransactionOutputIndex);

--- a/NArk.Swaps/Services/SwapsManagementService.cs
+++ b/NArk.Swaps/Services/SwapsManagementService.cs
@@ -379,6 +379,7 @@ public class SwapsManagementService : IAsyncDisposable
         var swap = await _boltzService.CreateSubmarineSwap(invoice,
             await addressProvider!.GetNextSigningDescriptor(cancellationToken),
             cancellationToken);
+        await _contractService.ImportContract(walletId, swap.Contract, ContractActivityState.AwaitingFundsBeforeDeactivate, cancellationToken: cancellationToken);
         await _swapsStorage.SaveSwap(
             walletId,
             new ArkSwap(
@@ -397,7 +398,6 @@ public class SwapsManagementService : IAsyncDisposable
             ), cancellationToken);
         try
         {
-            await _contractService.ImportContract(walletId, swap.Contract, ContractActivityState.AwaitingFundsBeforeDeactivate, cancellationToken: cancellationToken);
             return autoPay
                 ? (await _spendingService.Spend(walletId,
                     [new ArkTxOut(ArkTxOutType.Vtxo, swap.Swap.ExpectedAmount, swap.Address)], cancellationToken))


### PR DESCRIPTION
Many storage implementations will use relation to relate swaps to their contracts. The current saving order breaks that. This commit fixes that.

This commit also contains a small unneeded constraint.