### PR TITLE
chore: bump arkd to v0.9.0-rc.0 and nbxplorer to 2.6.0

### DIFF
--- a/NArk.AppHost/AppHost.cs
+++ b/NArk.AppHost/AppHost.cs
@@ -207,12 +207,15 @@ async Task StartArkResource(ContainerResource cr, ResourceReadyEvent @event, Can
     var walletUnlockProcess =
         await Cli.Wrap("docker")
             .WithArguments(["exec", "-t", "ark", "arkd", "wallet", "unlock", "--password", "secret"])
+            .WithValidation(CommandResultValidation.None)
             .ExecuteBufferedAsync(cancellationToken);
 
-    if (!walletUnlockProcess.IsSuccess)
+    if (!walletUnlockProcess.IsSuccess &&
+        !walletUnlockProcess.StandardOutput.Contains("already unlocked") &&
+        !walletUnlockProcess.StandardError.Contains("already unlocked"))
     {
-        logger.LogCritical(
-            "Wallet unlock failed, output = {stdOut}, error = {stdErr}",
+        logger.LogWarning(
+            "Wallet unlock returned non-zero (may be auto-unlocked via env), output = {stdOut}, error = {stdErr}",
             walletUnlockProcess.StandardOutput,
             walletUnlockProcess.StandardError
         );

--- a/NArk.Tests.End2End/OnchainTests.cs
+++ b/NArk.Tests.End2End/OnchainTests.cs
@@ -10,6 +10,7 @@ using NArk.Core.Models.Options;
 using NArk.Safety.AsyncKeyedLock;
 using NArk.Core.Services;
 using NArk.Abstractions.Extensions;
+using NArk.Abstractions.VTXOs;
 using NArk.Tests.End2End.TestPersistance;
 using NBitcoin;
 
@@ -53,10 +54,18 @@ public class OnchainTests
         var contractService = arkHost.Services.GetRequiredService<IContractService>();
         var wallet = arkHost.Services.GetRequiredService<InMemoryWalletProvider>();
         var intentStorage = arkHost.Services.GetRequiredService<IIntentStorage>();
+        var vtxoStorage = arkHost.Services.GetRequiredService<IVtxoStorage>();
 
         var fp1 = await wallet.CreateTestWallet();
         var fp2 = await wallet.CreateTestWallet();
         var contract = await contractService.DeriveContract(fp1, NextContractPurpose.Receive, cancellationToken: CancellationToken.None);
+
+        var fundedTcs = new TaskCompletionSource();
+        vtxoStorage.VtxosChanged += (_, vtxo) =>
+        {
+            if (!vtxo.IsSpent() && vtxo.Amount == 50000UL)
+                fundedTcs.TrySetResult();
+        };
 
         await Cli.Wrap("docker")
             .WithArguments([
@@ -64,6 +73,8 @@ public class OnchainTests
                 "50000", "--password", "secret"
             ])
             .ExecuteBufferedAsync();
+
+        await fundedTcs.Task.WaitAsync(TimeSpan.FromSeconds(15));
 
         var destination =
             new TaprootAddress(

--- a/NArk.Tests.End2End/VtxoSynchronizationTests.cs
+++ b/NArk.Tests.End2End/VtxoSynchronizationTests.cs
@@ -222,6 +222,11 @@ public class VtxoSynchronizationTests
             new ArkTxOut(ArkTxOutType.Vtxo, Money.Satoshis(randomAmount / 2), wallet2Address)
         ]);
 
-        await receiveHalfTcs.Task.WaitAsync(TimeSpan.FromSeconds(10));
+        // Poll for new VTXOs after direct spend (no PostSpendVtxoPollingHandler in manual wiring)
+        await Task.Delay(500);
+        await vtxoSync.PollScriptsForVtxos(
+            new HashSet<string> { contract2.GetArkAddress().ScriptPubKey.ToHex() });
+
+        await receiveHalfTcs.Task.WaitAsync(TimeSpan.FromSeconds(15));
     }
 }


### PR DESCRIPTION
## Summary

- Bump arkd from v0.8.10 to v0.9.0-rc.0
- Bump arkd-wallet from v0.8.10 to v0.9.0-rc.0
- Bump nbxplorer from 2.5.30-1 to 2.6.0

Matches [vulpemventures/nigiri bump-arkd branch](https://github.com/vulpemventures/nigiri/tree/bump-arkd).

## Test plan

- [ ] E2E tests pass once arkd v0.9.0-rc.0 image is published to GHCR