### PR TITLE
feat: add EF Core storage SDK and documentation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,12 @@
     <RepositoryUrl>https://github.com/arkade-os/dotnet-sdk</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright (c) 2026 Ark Labs</Copyright>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">
       <PrivateAssets>all</PrivateAssets>

--- a/NArk.Abstractions/Blockchain/IChainTimeProvider.cs
+++ b/NArk.Abstractions/Blockchain/IChainTimeProvider.cs
@@ -1,6 +1,13 @@
 namespace NArk.Abstractions.Blockchain;
 
+/// <summary>
+/// Provides the current Bitcoin blockchain height and timestamp.
+/// Used to determine VTXO spendability based on timelock conditions.
+/// </summary>
 public interface IChainTimeProvider
 {
+    /// <summary>
+    /// Returns the current chain time (block height and timestamp).
+    /// </summary>
     Task<TimeHeight> GetChainTime(CancellationToken cancellationToken = default);
 }

--- a/NArk.Abstractions/Fees/IFeeEstimator.cs
+++ b/NArk.Abstractions/Fees/IFeeEstimator.cs
@@ -2,8 +2,17 @@ using NArk.Abstractions.Intents;
 
 namespace NArk.Abstractions.Fees;
 
+/// <summary>
+/// Estimates Ark transaction fees in satoshis.
+/// </summary>
 public interface IFeeEstimator
 {
+    /// <summary>
+    /// Estimates the fee for spending the given coins to the given outputs.
+    /// </summary>
     public Task<long> EstimateFeeAsync(ArkCoin[] coins, ArkTxOut[] outputs, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Estimates the fee for an intent specification (used during intent generation).
+    /// </summary>
     public Task<long> EstimateFeeAsync(ArkIntentSpec spec, CancellationToken cancellationToken = default);
 }

--- a/NArk.Abstractions/NArk.Abstractions.csproj
+++ b/NArk.Abstractions/NArk.Abstractions.csproj
@@ -5,6 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>
+        <PackageDescription>Interfaces and domain types for the Ark protocol .NET SDK. Includes storage abstractions, wallet interfaces, and core domain records (ArkCoin, ArkVtxo, ArkContract, ArkAddress).</PackageDescription>
     </PropertyGroup>
 
     <ItemGroup>

--- a/NArk.Abstractions/Safety/ISafetyService.cs
+++ b/NArk.Abstractions/Safety/ISafetyService.cs
@@ -2,9 +2,23 @@ using System.Collections.Immutable;
 
 namespace NArk.Abstractions.Safety;
 
+/// <summary>
+/// Provides distributed locking to prevent concurrent operations on the same resources
+/// (e.g., double-spending the same VTXO, concurrent batch signing for the same wallet).
+/// </summary>
 public interface ISafetyService
 {
+    /// <summary>
+    /// Attempts to acquire a time-limited lock. Returns true if acquired, false if already held.
+    /// </summary>
     Task<bool> TryLockByTimeAsync(string key, TimeSpan timeSpan);
+    /// <summary>
+    /// Acquires an exclusive lock on a single key. Dispose the result to release.
+    /// </summary>
     Task<CompositeDisposable> LockKeyAsync(string key, CancellationToken ct);
+    /// <summary>
+    /// Acquires exclusive locks on multiple keys atomically (sorted to prevent deadlocks).
+    /// Dispose the result to release all locks.
+    /// </summary>
     Task<CompositeDisposable> LockKeysAsync(ImmutableSortedSet<string> keys, CancellationToken ct);
 }

--- a/NArk.Abstractions/Scripts/IActiveScriptsProvider.cs
+++ b/NArk.Abstractions/Scripts/IActiveScriptsProvider.cs
@@ -1,8 +1,19 @@
 ﻿namespace NArk.Abstractions.Scripts;
 
+/// <summary>
+/// Provides the set of scripts (hex-encoded) that the VTXO synchronization service
+/// should actively monitor for incoming VTXOs. Both <c>IVtxoStorage</c> and
+/// <c>IContractStorage</c> implement this interface.
+/// </summary>
 public interface IActiveScriptsProvider
 {
+    /// <summary>
+    /// Raised when the set of active scripts changes (e.g., a new contract is derived).
+    /// </summary>
     event EventHandler? ActiveScriptsChanged;
 
+    /// <summary>
+    /// Returns the current set of scripts to monitor.
+    /// </summary>
     Task<HashSet<string>> GetActiveScripts(CancellationToken cancellationToken = default);
 }

--- a/NArk.Core/CoinSelector/ICoinSelector.cs
+++ b/NArk.Core/CoinSelector/ICoinSelector.cs
@@ -4,8 +4,19 @@ using NBitcoin;
 
 namespace NArk.Core.CoinSelector;
 
+/// <summary>
+/// Selects coins from a set of available coins to meet a target amount.
+/// Implement this to customize UTXO selection strategy (e.g., minimize fees, maximize privacy).
+/// </summary>
 public interface ICoinSelector
 {
+    /// <summary>
+    /// Selects coins to cover the target amount.
+    /// </summary>
+    /// <param name="availableCoins">All spendable coins.</param>
+    /// <param name="targetAmount">Amount to cover.</param>
+    /// <param name="dustThreshold">Minimum value for a change output.</param>
+    /// <param name="currentSubDustOutputs">Number of existing sub-dust outputs in the transaction.</param>
     IReadOnlyCollection<ArkCoin> SelectCoins(
         List<ArkCoin> availableCoins,
         Money targetAmount,

--- a/NArk.Core/Events/IEventHandler.cs
+++ b/NArk.Core/Events/IEventHandler.cs
@@ -1,6 +1,15 @@
 namespace NArk.Core.Events;
 
+/// <summary>
+/// Handles domain events raised by SDK services.
+/// Register implementations via DI to react to events such as
+/// <c>PostBatchSessionEvent</c>, <c>PostSweepActionEvent</c>, or <c>PostCoinsSpendActionEvent</c>.
+/// </summary>
+/// <typeparam name="TEvent">The event type to handle.</typeparam>
 public interface IEventHandler<in TEvent> where TEvent : class
 {
+    /// <summary>
+    /// Handles the event asynchronously.
+    /// </summary>
     Task HandleAsync(TEvent @event, CancellationToken cancellationToken = default);
 }

--- a/NArk.Core/NArk.Core.csproj
+++ b/NArk.Core/NArk.Core.csproj
@@ -5,6 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>
+        <PackageDescription>Core services for the Ark protocol .NET SDK. Includes spending, batch management, VTXO synchronization, sweeping, wallet infrastructure, and gRPC transport.</PackageDescription>
     </PropertyGroup>
 
     <ItemGroup>

--- a/NArk.Core/Services/ICoinService.cs
+++ b/NArk.Core/Services/ICoinService.cs
@@ -4,8 +4,18 @@ using NArk.Abstractions.VTXOs;
 
 namespace NArk.Core.Services;
 
+/// <summary>
+/// Resolves VTXOs into spendable <see cref="ArkCoin"/> instances by matching
+/// them with their contract metadata and wallet signing information.
+/// </summary>
 public interface ICoinService
 {
+    /// <summary>
+    /// Creates a spendable coin from a known contract entity and VTXO.
+    /// </summary>
     Task<ArkCoin> GetCoin(ArkContractEntity entity, ArkVtxo vtxo, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Creates a spendable coin from a VTXO by looking up the contract from storage.
+    /// </summary>
     Task<ArkCoin> GetCoin(ArkVtxo vtxo, string walletIdentifier, CancellationToken cancellationToken = default);
 }

--- a/NArk.Core/Services/IOnchainService.cs
+++ b/NArk.Core/Services/IOnchainService.cs
@@ -3,9 +3,20 @@ using NArk.Abstractions;
 
 namespace NArk.Core.Services;
 
+/// <summary>
+/// Service for moving funds from Ark back to the Bitcoin base layer via collaborative exits.
+/// </summary>
 public interface IOnchainService
 {
+    /// <summary>
+    /// Initiates a collaborative exit for the wallet, sending funds to a single on-chain output.
+    /// Returns the Bitcoin transaction ID.
+    /// </summary>
     Task<string> InitiateCollaborativeExit(string walletId, ArkTxOut output,
         CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Initiates a collaborative exit with explicit coin inputs and multiple on-chain outputs.
+    /// Returns the Bitcoin transaction ID.
+    /// </summary>
     Task<string> InitiateCollaborativeExit(ArkCoin[] inputs, ArkTxOut[] outputs, CancellationToken cancellationToken = default);
 }

--- a/NArk.Core/Services/ISpendingService.cs
+++ b/NArk.Core/Services/ISpendingService.cs
@@ -3,9 +3,23 @@ using NBitcoin;
 
 namespace NArk.Core.Services;
 
+/// <summary>
+/// Service for creating and submitting Ark off-chain spend transactions.
+/// </summary>
 public interface ISpendingService
 {
+    /// <summary>
+    /// Spends specific coins to the given outputs. Returns the Ark transaction ID.
+    /// </summary>
     Task<uint256> Spend(string walletId, ArkCoin[] inputs, ArkTxOut[] outputs, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Spends to the given outputs using automatic coin selection. Returns the Ark transaction ID.
+    /// </summary>
     Task<uint256> Spend(string walletId, ArkTxOut[] outputs, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns all spendable coins for the wallet (unspent, unlocked, and within timelock bounds).
+    /// </summary>
     Task<IReadOnlySet<ArkCoin>> GetAvailableCoins(string walletId, CancellationToken cancellationToken = default);
 }

--- a/NArk.Core/Sweeper/ISweepPolicy.cs
+++ b/NArk.Core/Sweeper/ISweepPolicy.cs
@@ -2,7 +2,15 @@ using NArk.Abstractions;
 
 namespace NArk.Core.Sweeper;
 
+/// <summary>
+/// Determines which coins should be consolidated (swept) into a single VTXO.
+/// Register multiple policies to combine different consolidation strategies
+/// (e.g., time-based expiry, dust collection, fee optimization).
+/// </summary>
 public interface ISweepPolicy
 {
+    /// <summary>
+    /// Yields coins that should be swept from the given set.
+    /// </summary>
     public IAsyncEnumerable<ArkCoin> SweepAsync(IEnumerable<ArkCoin> coins, CancellationToken cancellationToken = default);
 }

--- a/NArk.Core/Transformers/IContractTransformer.cs
+++ b/NArk.Core/Transformers/IContractTransformer.cs
@@ -4,8 +4,19 @@ using NArk.Abstractions.VTXOs;
 
 namespace NArk.Core.Transformers;
 
+/// <summary>
+/// Transforms a contract + VTXO pair into a spendable <see cref="ArkCoin"/>.
+/// Register multiple transformers to handle different contract types
+/// (payment contracts, hash-locked contracts, VHTLCs, etc.).
+/// </summary>
 public interface IContractTransformer
 {
+    /// <summary>
+    /// Returns true if this transformer can handle the given contract/VTXO pair.
+    /// </summary>
     Task<bool> CanTransform(string walletIdentifier, ArkContract contract, ArkVtxo vtxo);
+    /// <summary>
+    /// Transforms the contract/VTXO pair into a spendable coin with signing metadata.
+    /// </summary>
     Task<ArkCoin> Transform(string walletIdentifier, ArkContract contract, ArkVtxo vtxo);
 }

--- a/NArk.Storage.EfCore/NArk.Storage.EfCore.csproj
+++ b/NArk.Storage.EfCore/NArk.Storage.EfCore.csproj
@@ -5,6 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>
+        <PackageDescription>Entity Framework Core storage implementations for the Ark protocol .NET SDK. Provider-agnostic persistence for VTXOs, contracts, intents, swaps, and wallets.</PackageDescription>
     </PropertyGroup>
 
     <ItemGroup>

--- a/NArk.Swaps/Boltz/BtcHtlcScripts.cs
+++ b/NArk.Swaps/Boltz/BtcHtlcScripts.cs
@@ -44,7 +44,7 @@ public static class BtcHtlcScripts
         var taprootInternalKey = new TaprootInternalPubKey(internalKey.ToBytes());
 
         // Try [claim, refund] order first (standard Boltz ordering)
-        var spendInfo = new TapScript[] { claimLeaf, refundLeaf }.WithTree().Finalize(taprootInternalKey);
+        var spendInfo = TaprootSpendInfo.FromNodeInfo(taprootInternalKey, new TapScript[] { claimLeaf, refundLeaf }.BuildTree());
 
         // If we have an expected address, validate and try alternative ordering if needed
         if (expectedAddress != null && network != null)
@@ -56,7 +56,7 @@ public static class BtcHtlcScripts
             }
 
             Console.WriteLine($"[BtcHtlcScripts] [claim, refund] order mismatch, trying [refund, claim]...");
-            var altSpendInfo = new TapScript[] { refundLeaf, claimLeaf }.WithTree().Finalize(taprootInternalKey);
+            var altSpendInfo = TaprootSpendInfo.FromNodeInfo(taprootInternalKey, new TapScript[] { refundLeaf, claimLeaf }.BuildTree());
             if (ValidateAddress(altSpendInfo, expectedAddress, network))
             {
                 Console.WriteLine($"[BtcHtlcScripts] Address validated with [refund, claim] order");

--- a/NArk.Swaps/NArk.Swaps.csproj
+++ b/NArk.Swaps/NArk.Swaps.csproj
@@ -5,6 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>
+        <PackageDescription>Boltz swap integration for the Ark protocol .NET SDK. Enables BTC-to-Ark and Ark-to-BTC submarine and chain swaps.</PackageDescription>
     </PropertyGroup>
 
     <ItemGroup>

--- a/NArk/NArk.csproj
+++ b/NArk/NArk.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <IncludeBuildOutput>false</IncludeBuildOutput>
-        <IncludeContentInPack>false</IncludeContentInPack>
+        <PackageDescription>Meta-package for the Ark protocol .NET SDK. Pulls in NArk.Core (spending, batches, VTXO sync, wallets) and NArk.Swaps (Boltz integration).</PackageDescription>
     </PropertyGroup>
 
     <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,305 @@
+# NArk .NET SDK
+
+A .NET SDK for building applications on the [Ark protocol](https://ark-protocol.org) — a Bitcoin layer-2 that enables instant, low-cost off-chain transactions using virtual UTXOs (VTXOs).
+
+[![NuGet](https://img.shields.io/nuget/v/NArk.svg)](https://www.nuget.org/packages/NArk)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+## Packages
+
+| Package | Description |
+|---------|-------------|
+| **NArk.Abstractions** | Interfaces and domain types (`IVtxoStorage`, `IContractStorage`, `IWalletProvider`, `ArkCoin`, `ArkVtxo`, etc.) |
+| **NArk.Core** | Core services: spending, batch management, VTXO sync, sweeping, wallet infrastructure, gRPC transport |
+| **NArk.Swaps** | [Boltz](https://boltz.exchange) swap integration for BTC-to-Ark and Ark-to-BTC chain/submarine swaps |
+| **NArk.Storage.EfCore** | Entity Framework Core storage implementations (provider-agnostic — works with PostgreSQL, SQLite, etc.) |
+| **NArk** | Meta-package that pulls in `NArk.Core` + `NArk.Swaps` |
+
+## Quick Start
+
+### Install
+
+```bash
+dotnet add package NArk                    # Core + Swaps
+dotnet add package NArk.Storage.EfCore     # EF Core persistence
+```
+
+### Minimal Setup with Generic Host
+
+```csharp
+using NArk.Hosting;
+using NArk.Core.Wallet;
+using NArk.Storage.EfCore;
+using NArk.Storage.EfCore.Hosting;
+
+var builder = Host.CreateDefaultBuilder(args)
+    .AddArk()
+    .WithVtxoStorage<EfCoreVtxoStorage>()
+    .WithContractStorage<EfCoreContractStorage>()
+    .WithIntentStorage<EfCoreIntentStorage>()
+    .WithWalletProvider<DefaultWalletProvider>()
+    .WithSafetyService<YourSafetyService>()
+    .WithTimeProvider<YourChainTimeProvider>()
+    .OnMainnet()
+    .EnableSwaps();
+
+// Register your DbContext and EF Core storage
+builder.ConfigureServices((_, services) =>
+{
+    services.AddDbContextFactory<YourDbContext>(opts =>
+        opts.UseNpgsql(connectionString));
+
+    services.AddArkEfCoreStorage<YourDbContext>();
+});
+
+var app = builder.Build();
+await app.RunAsync();
+```
+
+### Setup with IServiceCollection (plugin/non-host scenarios)
+
+```csharp
+using NArk.Hosting;
+using NArk.Core.Wallet;
+using NArk.Storage.EfCore.Hosting;
+
+services.AddArkCoreServices();
+services.AddArkNetwork(ArkNetworkConfig.Mainnet);
+services.AddArkSwapServices();
+
+services.AddDbContextFactory<YourDbContext>(opts =>
+    opts.UseNpgsql(connectionString));
+
+services.AddArkEfCoreStorage<YourDbContext>();
+
+// Register remaining required services
+services.AddSingleton<IWalletProvider, DefaultWalletProvider>();
+services.AddSingleton<ISafetyService, YourSafetyService>();
+services.AddSingleton<IChainTimeProvider, YourChainTimeProvider>();
+```
+
+## Architecture
+
+```
+NArk (meta-package)
+ ├── NArk.Core
+ │    ├── Services (spending, batches, VTXO sync, sweeping, intents)
+ │    ├── Wallet (WalletFactory, signers, address providers)
+ │    ├── Hosting (DI extensions, ArkApplicationBuilder)
+ │    └── Transport (gRPC client for Ark server communication)
+ │
+ ├── NArk.Swaps
+ │    ├── Boltz client (submarine & chain swaps)
+ │    └── Swap management service
+ │
+ └── NArk.Abstractions
+      ├── Domain types (ArkCoin, ArkVtxo, ArkContract, ArkAddress, etc.)
+      ├── Storage interfaces (IVtxoStorage, IContractStorage, IIntentStorage)
+      └── Wallet interfaces (IWalletProvider, IArkadeWalletSigner)
+
+NArk.Storage.EfCore (optional, provider-agnostic persistence)
+ ├── EF Core entity mappings
+ ├── Storage implementations
+ └── DI extension: AddArkEfCoreStorage<TDbContext>()
+```
+
+## Wallet Management
+
+The SDK supports two wallet types:
+
+**HD Wallets** — BIP-39 mnemonic with BIP-86 taproot derivation (`m/86'/cointype'/0'`):
+
+```csharp
+var serverInfo = await transport.GetServerInfoAsync();
+var wallet = await WalletFactory.CreateWallet(
+    "abandon abandon abandon ... about",  // BIP-39 mnemonic
+    destination: null,
+    serverInfo);
+// wallet.WalletType == WalletType.HD
+```
+
+**Single-Key Wallets** — nostr `nsec` format (Bech32-encoded secp256k1 key):
+
+```csharp
+var wallet = await WalletFactory.CreateWallet(
+    "nsec1...",
+    destination: null,
+    serverInfo);
+// wallet.WalletType == WalletType.SingleKey
+```
+
+Save and load wallets through `IWalletStorage`:
+
+```csharp
+await walletStorage.SaveWallet(wallet);
+var loaded = await walletStorage.LoadWallet(wallet.Id);
+var all = await walletStorage.LoadAllWallets();
+```
+
+## Spending
+
+Use `ISpendingService` to send Ark transactions:
+
+```csharp
+// Automatic coin selection
+var txId = await spendingService.Spend(
+    walletId,
+    outputs: [new ArkTxOut(recipientAddress, Money.Satoshis(10_000))]);
+
+// Manual coin selection
+var coins = await spendingService.GetAvailableCoins(walletId);
+var txId = await spendingService.Spend(
+    walletId,
+    inputs: coins.Take(2).ToArray(),
+    outputs: [new ArkTxOut(recipientAddress, Money.Satoshis(5_000))]);
+```
+
+## Collaborative Exits (On-chain)
+
+Move funds from Ark back to the Bitcoin base layer:
+
+```csharp
+var btcTxId = await onchainService.InitiateCollaborativeExit(
+    walletId,
+    new ArkTxOut(bitcoinAddress, Money.Satoshis(50_000)));
+```
+
+## Contracts
+
+Derive receiving addresses and manage contracts:
+
+```csharp
+// Derive a new receive contract (generates a new Ark address)
+var contract = await contractService.DeriveContract(
+    walletId,
+    NextContractPurpose.Receive);
+
+// The contract's script can be converted to an ArkAddress for display
+```
+
+## EF Core Storage
+
+`NArk.Storage.EfCore` provides ready-made storage implementations. It is **provider-agnostic** — no dependency on Npgsql or any specific database driver.
+
+### DbContext Setup
+
+In your `DbContext.OnModelCreating`, call `ConfigureArkEntities`:
+
+```csharp
+public class MyDbContext : DbContext
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ConfigureArkEntities(opts =>
+        {
+            opts.Schema = "ark";           // default
+            // opts.WalletsTable = "Wallets";   // all table names configurable
+        });
+    }
+}
+```
+
+### Storage Options
+
+`ArkStorageOptions` controls schema, table names, and provider-specific behavior:
+
+```csharp
+services.AddArkEfCoreStorage<MyDbContext>(opts =>
+{
+    opts.Schema = "my_schema";
+
+    // PostgreSQL-specific text search on contract metadata
+    opts.ContractSearchProvider = (query, searchText) =>
+        query.Where(c => EF.Functions.ILike(c.Metadata, $"%{searchText}%"));
+});
+```
+
+### Entities
+
+| Entity | Table | Primary Key |
+|--------|-------|-------------|
+| `ArkWalletEntity` | `Wallets` | `Id` |
+| `ArkWalletContractEntity` | `WalletContracts` | `(Script, WalletId)` |
+| `VtxoEntity` | `Vtxos` | `(TransactionId, TransactionOutputIndex)` |
+| `ArkIntentEntity` | `Intents` | `IntentTxId` |
+| `ArkIntentVtxoEntity` | `IntentVtxos` | `(IntentTxId, VtxoTransactionId, VtxoTransactionOutputIndex)` |
+| `ArkSwapEntity` | `Swaps` | `(SwapId, WalletId)` |
+
+## Networks
+
+Pre-configured network environments:
+
+```csharp
+// Fluent builder
+builder.AddArk().OnMainnet();
+builder.AddArk().OnMutinynet();
+builder.AddArk().OnRegtest();
+builder.AddArk().OnCustomGrpcArk("http://my-ark-server:7070");
+
+// IServiceCollection
+services.AddArkNetwork(ArkNetworkConfig.Mainnet);
+services.AddArkNetwork(new ArkNetworkConfig(
+    ArkUri: "http://my-ark-server:7070",
+    BoltzUri: "http://my-boltz:9069/"));
+```
+
+## Swaps (Boltz Integration)
+
+Enable Bitcoin &harr; Ark swaps through [Boltz](https://boltz.exchange):
+
+```csharp
+// Fluent builder
+builder.AddArk()
+    .EnableSwaps()
+    // or with custom Boltz URL:
+    .OnCustomBoltz("https://api.boltz.exchange", websocketUrl: null);
+
+// IServiceCollection
+services.AddArkSwapServices();
+services.AddHttpClient<BoltzClient>();
+```
+
+The `SwapsManagementService` handles swap lifecycle automatically — monitoring status, cooperative claim signing, and VHTLC management.
+
+## Extensibility Points
+
+The SDK uses a pluggable architecture. Register your implementations for:
+
+| Interface | Purpose | Default |
+|-----------|---------|---------|
+| `IVtxoStorage` | VTXO persistence | `EfCoreVtxoStorage` |
+| `IContractStorage` | Contract persistence | `EfCoreContractStorage` |
+| `IIntentStorage` | Intent persistence | `EfCoreIntentStorage` |
+| `ISwapStorage` | Swap persistence | `EfCoreSwapStorage` |
+| `IWalletStorage` | Wallet persistence | `EfCoreWalletStorage` |
+| `IWalletProvider` | Wallet signer/address resolution | `DefaultWalletProvider` |
+| `ISafetyService` | Distributed locking | *Must implement* |
+| `IChainTimeProvider` | Current blockchain height/time | *Must implement* |
+| `IFeeEstimator` | Transaction fee estimation | `DefaultFeeEstimator` |
+| `ICoinSelector` | UTXO selection strategy | `DefaultCoinSelector` |
+| `ISweepPolicy` | VTXO consolidation rules | Register zero or more |
+| `IContractTransformer` | Custom contract &rarr; coin transforms | Register zero or more |
+| `IEventHandler<T>` | React to batch/sweep/spend events | Register zero or more |
+
+## Local Development
+
+The SDK uses [.NET Aspire](https://learn.microsoft.com/en-us/dotnet/aspire/) for local orchestration with Docker containers (arkd, Bitcoin Core, Boltz, etc.):
+
+```bash
+cd NArk.AppHost
+dotnet run
+```
+
+### Running Tests
+
+```bash
+# Unit tests
+dotnet test NArk.Tests
+
+# End-to-end tests (requires Docker)
+dotnet test NArk.Tests.End2End
+```
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary

- Add `NArk.Storage.EfCore` package with provider-agnostic EF Core storage implementations (VTXOs, contracts, intents, swaps, wallets)
- Move wallet infrastructure (WalletFactory, signers, address providers) from EfCore to `NArk.Core.Wallet`
- Add comprehensive README with quick start, architecture, and API documentation
- Add XML docs to all undocumented public interfaces
- Add NuGet packaging metadata (PackageDescription, GenerateDocumentationFile, PackageReadmeFile)

## Test plan

- [ ] `dotnet build NArk.sln` passes with 0 errors
- [ ] `dotnet pack` produces all 5 nupkg files with README and XML docs included
- [ ] Existing E2E tests pass (require arkd container)