### PR TITLE
fix: set minrelaytxfee=0 for Boltz chain swaps

### DIFF
--- a/NArk.Tests.End2End/Infrastructure/cors.nginx.conf
+++ b/NArk.Tests.End2End/Infrastructure/cors.nginx.conf
@@ -11,6 +11,17 @@ server {
         proxy_read_timeout 86400s;
     }
 
+    # Boltzr (Rust sidecar) endpoints — restore/rescue are served on port 9005, not 9001
+    location ~ ^/v2/swap/restore {
+        proxy_pass http://boltz:9005;
+        proxy_set_header Host $host;
+    }
+
+    location ~ ^/v2/swap/rescue {
+        proxy_pass http://boltz:9005;
+        proxy_set_header Host $host;
+    }
+
     location / {
         add_header 'Access-Control-Allow-Origin' '*' always;
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE' always;

--- a/NArk.Tests.End2End/SwapManagementServiceTests.cs
+++ b/NArk.Tests.End2End/SwapManagementServiceTests.cs
@@ -206,23 +206,6 @@ public class SwapManagementServiceTests
     [Test]
     public async Task CanRestoreSwapsFromBoltz()
     {
-        // The restore endpoint (POST /v2/swap/restore) is not yet implemented in
-        // boltz/boltz:latest (v3.12.x) — swagger spec documents it but the route
-        // handler is missing. Mark inconclusive until Boltz ships it.
-        using var probe = new HttpClient { Timeout = TimeSpan.FromSeconds(3) };
-        HttpStatusCode? probeStatus = null;
-        try
-        {
-            var resp = await probe.PostAsync(
-                $"{SharedSwapInfrastructure.BoltzEndpoint}/v2/swap/restore",
-                new StringContent("{}", System.Text.Encoding.UTF8, "application/json"));
-            probeStatus = resp.StatusCode;
-        }
-        catch { /* connection error — endpoint unreachable, let test proceed and fail naturally */ }
-
-        if (probeStatus == HttpStatusCode.NotFound)
-            Assert.Inconclusive("Boltz /v2/swap/restore endpoint not available (v3.12.x)");
-
         var testingPrerequisite = await FundedWalletHelper.GetFundedWallet();
         var chainTimeProvider = new ChainTimeProvider(Network.RegTest, SharedArkInfrastructure.NbxplorerEndpoint);
         var swapStorage = new InMemorySwapStorage();


### PR DESCRIPTION
## Summary
- Boltz constructs BTC lockup transactions with fee rates below Bitcoin Core's default `minrelaytxfee` (0.2 sat/vB < 1.0 sat/vB), causing ARK→BTC chain swaps to fail
- After nigiri starts, inject `minrelaytxfee=0.0` into bitcoin.conf and restart the bitcoin container
- Fixes `CanDoArkToBtcChainSwap` E2E test failure

## Context
Follow-up to PR #24 (Aspire → Nigiri migration). This fix was identified after the merge when the chain swap test failed in CI with:
```
Failed to lockup 49719 BTC for Chain Swap: Fee rate (0.200 sat/vB) is lower than the minimum fee rate setting (1.000 sat/vB)
```

## Test plan
- [ ] CI e2e job passes with `CanDoArkToBtcChainSwap` passing