### PR TITLE
feat: add LendaSwap provider

### DIFF
--- a/NArk.Swaps/Abstractions/SwapAsset.cs
+++ b/NArk.Swaps/Abstractions/SwapAsset.cs
@@ -8,4 +8,12 @@ public record SwapAsset(SwapNetwork Network, string AssetId)
 
     public static SwapAsset ArkAsset(string assetId)
         => new(SwapNetwork.Ark, assetId);
+
+    /// <summary>
+    /// ERC-20 token asset on an EVM chain — used by cross-chain providers
+    /// (LendaSwap) where <paramref name="contractAddress"/> is the 0x-prefixed
+    /// token contract address on the chosen <paramref name="chain"/>.
+    /// </summary>
+    public static SwapAsset Erc20(SwapNetwork chain, string contractAddress)
+        => new(chain, contractAddress);
 }

--- a/NArk.Swaps/Abstractions/SwapNetwork.cs
+++ b/NArk.Swaps/Abstractions/SwapNetwork.cs
@@ -5,4 +5,7 @@ public enum SwapNetwork
     Ark,
     BitcoinOnchain,
     Lightning,
+    EvmEthereum,
+    EvmPolygon,
+    EvmArbitrum,
 }

--- a/NArk.Swaps/Hosting/SwapServiceCollectionExtensions.cs
+++ b/NArk.Swaps/Hosting/SwapServiceCollectionExtensions.cs
@@ -6,6 +6,8 @@ using NArk.Swaps.Abstractions;
 using NArk.Swaps.Boltz;
 using NArk.Swaps.Boltz.Client;
 using NArk.Swaps.Boltz.Models;
+using NArk.Swaps.LendaSwap;
+using NArk.Swaps.LendaSwap.Client;
 using NArk.Swaps.Policies;
 using NArk.Swaps.Recovery;
 using NArk.Swaps.Services;
@@ -77,4 +79,20 @@ public static class SwapServiceCollectionExtensions
         return services;
     }
 
+    /// <summary>
+    /// Registers the LendaSwap provider and its dependencies.
+    /// Can be called separately if using manual provider registration.
+    /// </summary>
+    public static IServiceCollection AddLendaSwapProvider(
+        this IServiceCollection services, Action<LendaSwapOptions>? configure = null)
+    {
+        if (configure != null)
+            services.Configure(configure);
+
+        services.AddHttpClient<LendaSwapClient>();
+        services.AddSingleton<LendaSwapProvider>();
+        services.AddSingleton<ISwapProvider>(sp => sp.GetRequiredService<LendaSwapProvider>());
+
+        return services;
+    }
 }

--- a/NArk.Swaps/LendaSwap/Client/LendaSwapClient.Quotes.cs
+++ b/NArk.Swaps/LendaSwap/Client/LendaSwapClient.Quotes.cs
@@ -1,0 +1,52 @@
+using System.Net.Http.Json;
+using NArk.Swaps.LendaSwap.Models;
+
+namespace NArk.Swaps.LendaSwap.Client;
+
+public partial class LendaSwapClient
+{
+    /// <summary>
+    /// Lists available trading pairs and tokens.
+    /// </summary>
+    public virtual async Task<TokenListResponse?> GetTokensAsync(CancellationToken ct = default)
+    {
+        return await _httpClient.GetFromJsonAsync<TokenListResponse>("tokens", JsonOptions, ct);
+    }
+
+    /// <summary>
+    /// Gets a swap quote for the specified route and amount.
+    /// </summary>
+    /// <param name="sourceChain">Source chain identifier (e.g. "Arkade", "Lightning", "Bitcoin", "137").</param>
+    /// <param name="sourceToken">Source token identifier.</param>
+    /// <param name="targetChain">Target chain identifier.</param>
+    /// <param name="targetToken">Target token identifier.</param>
+    /// <param name="sourceAmount">Amount in source token (specify either source or target, not both).</param>
+    /// <param name="targetAmount">Amount in target token (specify either source or target, not both).</param>
+    /// <param name="ct">Cancellation token.</param>
+    public virtual async Task<QuoteResponse?> GetQuoteAsync(
+        string sourceChain,
+        string sourceToken,
+        string targetChain,
+        string targetToken,
+        long? sourceAmount = null,
+        long? targetAmount = null,
+        CancellationToken ct = default)
+    {
+        var queryParams = new List<string>
+        {
+            $"source_chain={Uri.EscapeDataString(sourceChain)}",
+            $"source_token={Uri.EscapeDataString(sourceToken)}",
+            $"target_chain={Uri.EscapeDataString(targetChain)}",
+            $"target_token={Uri.EscapeDataString(targetToken)}"
+        };
+
+        if (sourceAmount.HasValue)
+            queryParams.Add($"source_amount={sourceAmount.Value}");
+
+        if (targetAmount.HasValue)
+            queryParams.Add($"target_amount={targetAmount.Value}");
+
+        var url = $"quote?{string.Join("&", queryParams)}";
+        return await _httpClient.GetFromJsonAsync<QuoteResponse>(url, JsonOptions, ct);
+    }
+}

--- a/NArk.Swaps/LendaSwap/Client/LendaSwapClient.Quotes.cs
+++ b/NArk.Swaps/LendaSwap/Client/LendaSwapClient.Quotes.cs
@@ -23,6 +23,11 @@ public partial class LendaSwapClient
     /// <param name="sourceAmount">Amount in source token (specify either source or target, not both).</param>
     /// <param name="targetAmount">Amount in target token (specify either source or target, not both).</param>
     /// <param name="ct">Cancellation token.</param>
+    /// <param name="extraFees">
+    /// Optional per-swap fee surcharge in basis points (0..max_extra_fee_bps
+    /// configured on the matching developer key on the LendaSwap side).
+    /// Requests exceeding the per-key cap are rejected with 400.
+    /// </param>
     public virtual async Task<QuoteResponse?> GetQuoteAsync(
         string sourceChain,
         string sourceToken,
@@ -30,6 +35,7 @@ public partial class LendaSwapClient
         string targetToken,
         long? sourceAmount = null,
         long? targetAmount = null,
+        int? extraFees = null,
         CancellationToken ct = default)
     {
         var queryParams = new List<string>
@@ -45,6 +51,9 @@ public partial class LendaSwapClient
 
         if (targetAmount.HasValue)
             queryParams.Add($"target_amount={targetAmount.Value}");
+
+        if (extraFees.HasValue)
+            queryParams.Add($"extra_fees={extraFees.Value}");
 
         var url = $"quote?{string.Join("&", queryParams)}";
         return await _httpClient.GetFromJsonAsync<QuoteResponse>(url, JsonOptions, ct);

--- a/NArk.Swaps/LendaSwap/Client/LendaSwapClient.Status.cs
+++ b/NArk.Swaps/LendaSwap/Client/LendaSwapClient.Status.cs
@@ -1,0 +1,17 @@
+using System.Net.Http.Json;
+using NArk.Swaps.LendaSwap.Models;
+
+namespace NArk.Swaps.LendaSwap.Client;
+
+public partial class LendaSwapClient
+{
+    /// <summary>
+    /// Gets the current status and details of a swap.
+    /// </summary>
+    /// <param name="swapId">The swap identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public virtual async Task<LendaSwapResponse?> GetSwapStatusAsync(string swapId, CancellationToken ct = default)
+    {
+        return await _httpClient.GetFromJsonAsync<LendaSwapResponse>($"swap/{swapId}", JsonOptions, ct);
+    }
+}

--- a/NArk.Swaps/LendaSwap/Client/LendaSwapClient.Swaps.cs
+++ b/NArk.Swaps/LendaSwap/Client/LendaSwapClient.Swaps.cs
@@ -1,0 +1,36 @@
+using NArk.Swaps.LendaSwap.Models;
+
+namespace NArk.Swaps.LendaSwap.Client;
+
+public partial class LendaSwapClient
+{
+    /// <summary>
+    /// Creates a BTC to Arkade swap.
+    /// </summary>
+    public virtual async Task<LendaSwapResponse> CreateBtcToArkadeSwapAsync(
+        CreateBtcToArkadeRequest request, CancellationToken ct = default)
+    {
+        return await PostAsJsonAsync<CreateBtcToArkadeRequest, LendaSwapResponse>(
+            "swap/bitcoin/arkade", request, ct);
+    }
+
+    /// <summary>
+    /// Creates an Arkade to EVM swap.
+    /// </summary>
+    public virtual async Task<LendaSwapResponse> CreateArkadeToEvmSwapAsync(
+        CreateArkadeToEvmRequest request, CancellationToken ct = default)
+    {
+        return await PostAsJsonAsync<CreateArkadeToEvmRequest, LendaSwapResponse>(
+            "swap/arkade/evm", request, ct);
+    }
+
+    /// <summary>
+    /// Creates an EVM to Arkade swap.
+    /// </summary>
+    public virtual async Task<LendaSwapResponse> CreateEvmToArkadeSwapAsync(
+        CreateEvmToArkadeRequest request, CancellationToken ct = default)
+    {
+        return await PostAsJsonAsync<CreateEvmToArkadeRequest, LendaSwapResponse>(
+            "swap/evm/arkade", request, ct);
+    }
+}

--- a/NArk.Swaps/LendaSwap/Client/LendaSwapClient.Swaps.cs
+++ b/NArk.Swaps/LendaSwap/Client/LendaSwapClient.Swaps.cs
@@ -5,7 +5,7 @@ namespace NArk.Swaps.LendaSwap.Client;
 public partial class LendaSwapClient
 {
     /// <summary>
-    /// Creates a BTC to Arkade swap.
+    /// Creates a BTC on-chain to Arkade swap.
     /// </summary>
     public virtual async Task<LendaSwapResponse> CreateBtcToArkadeSwapAsync(
         CreateBtcToArkadeRequest request, CancellationToken ct = default)
@@ -15,7 +15,37 @@ public partial class LendaSwapClient
     }
 
     /// <summary>
-    /// Creates an Arkade to EVM swap.
+    /// Creates an Arkade to BTC on-chain swap.
+    /// </summary>
+    public virtual async Task<LendaSwapResponse> CreateArkadeToBtcSwapAsync(
+        CreateArkadeToBtcRequest request, CancellationToken ct = default)
+    {
+        return await PostAsJsonAsync<CreateArkadeToBtcRequest, LendaSwapResponse>(
+            "swap/arkade/bitcoin", request, ct);
+    }
+
+    /// <summary>
+    /// Creates a Lightning to Arkade swap.
+    /// </summary>
+    public virtual async Task<LendaSwapResponse> CreateLightningToArkadeSwapAsync(
+        CreateLightningToArkadeRequest request, CancellationToken ct = default)
+    {
+        return await PostAsJsonAsync<CreateLightningToArkadeRequest, LendaSwapResponse>(
+            "swap/lightning/arkade", request, ct);
+    }
+
+    /// <summary>
+    /// Creates an Arkade to Lightning swap.
+    /// </summary>
+    public virtual async Task<LendaSwapResponse> CreateArkadeToLightningSwapAsync(
+        CreateArkadeToLightningRequest request, CancellationToken ct = default)
+    {
+        return await PostAsJsonAsync<CreateArkadeToLightningRequest, LendaSwapResponse>(
+            "swap/arkade/lightning", request, ct);
+    }
+
+    /// <summary>
+    /// Creates an Arkade to EVM token swap.
     /// </summary>
     public virtual async Task<LendaSwapResponse> CreateArkadeToEvmSwapAsync(
         CreateArkadeToEvmRequest request, CancellationToken ct = default)
@@ -25,12 +55,52 @@ public partial class LendaSwapClient
     }
 
     /// <summary>
-    /// Creates an EVM to Arkade swap.
+    /// Creates an EVM token to Arkade swap.
     /// </summary>
     public virtual async Task<LendaSwapResponse> CreateEvmToArkadeSwapAsync(
         CreateEvmToArkadeRequest request, CancellationToken ct = default)
     {
         return await PostAsJsonAsync<CreateEvmToArkadeRequest, LendaSwapResponse>(
             "swap/evm/arkade", request, ct);
+    }
+
+    /// <summary>
+    /// Creates a Lightning to EVM token swap.
+    /// </summary>
+    public virtual async Task<LendaSwapResponse> CreateLightningToEvmSwapAsync(
+        CreateLightningToEvmRequest request, CancellationToken ct = default)
+    {
+        return await PostAsJsonAsync<CreateLightningToEvmRequest, LendaSwapResponse>(
+            "swap/lightning/evm", request, ct);
+    }
+
+    /// <summary>
+    /// Creates an EVM token to Lightning swap.
+    /// </summary>
+    public virtual async Task<LendaSwapResponse> CreateEvmToLightningSwapAsync(
+        CreateEvmToLightningRequest request, CancellationToken ct = default)
+    {
+        return await PostAsJsonAsync<CreateEvmToLightningRequest, LendaSwapResponse>(
+            "swap/evm/lightning", request, ct);
+    }
+
+    /// <summary>
+    /// Creates a BTC on-chain to EVM token swap.
+    /// </summary>
+    public virtual async Task<LendaSwapResponse> CreateBtcToEvmSwapAsync(
+        CreateBtcToEvmRequest request, CancellationToken ct = default)
+    {
+        return await PostAsJsonAsync<CreateBtcToEvmRequest, LendaSwapResponse>(
+            "swap/bitcoin/evm", request, ct);
+    }
+
+    /// <summary>
+    /// Creates an EVM token to BTC on-chain swap.
+    /// </summary>
+    public virtual async Task<LendaSwapResponse> CreateEvmToBtcSwapAsync(
+        CreateEvmToBtcRequest request, CancellationToken ct = default)
+    {
+        return await PostAsJsonAsync<CreateEvmToBtcRequest, LendaSwapResponse>(
+            "swap/evm/bitcoin", request, ct);
     }
 }

--- a/NArk.Swaps/LendaSwap/Client/LendaSwapClient.cs
+++ b/NArk.Swaps/LendaSwap/Client/LendaSwapClient.cs
@@ -1,0 +1,50 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Options;
+
+namespace NArk.Swaps.LendaSwap.Client;
+
+/// <summary>
+/// HTTP client for the LendaSwap API.
+/// Uses the partial class pattern — endpoint groups are in separate files.
+/// </summary>
+public partial class LendaSwapClient
+{
+    protected readonly HttpClient _httpClient;
+    protected readonly IOptions<LendaSwapOptions> _options;
+
+    internal static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public LendaSwapClient(HttpClient httpClient, IOptions<LendaSwapOptions> options)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+
+        _httpClient.BaseAddress = new Uri(options.Value.ApiUrl.TrimEnd('/') + "/");
+
+        if (!string.IsNullOrWhiteSpace(options.Value.ApiKey))
+        {
+            _httpClient.DefaultRequestHeaders.Add("X-API-Key", options.Value.ApiKey);
+        }
+    }
+
+    /// <summary>
+    /// Posts a value as JSON and deserializes the response.
+    /// </summary>
+    protected async Task<TReturn> PostAsJsonAsync<T, TReturn>(string uri, T value, CancellationToken ct = default)
+    {
+        var resp = await _httpClient.PostAsJsonAsync(uri, value, JsonOptions, ct);
+
+        if (resp.IsSuccessStatusCode)
+        {
+            return (await resp.Content.ReadFromJsonAsync<TReturn>(options: JsonOptions, ct))!;
+        }
+
+        var respStr = await resp.Content.ReadAsStringAsync(ct);
+        throw new HttpRequestException(respStr, null, resp.StatusCode);
+    }
+}

--- a/NArk.Swaps/LendaSwap/Client/LendaSwapClient.cs
+++ b/NArk.Swaps/LendaSwap/Client/LendaSwapClient.cs
@@ -26,9 +26,9 @@ public partial class LendaSwapClient
 
         _httpClient.BaseAddress = new Uri(options.Value.ApiUrl.TrimEnd('/') + "/");
 
-        if (!string.IsNullOrWhiteSpace(options.Value.ApiKey))
+        if (!string.IsNullOrWhiteSpace(options.Value.PublishableKey))
         {
-            _httpClient.DefaultRequestHeaders.Add("X-API-Key", options.Value.ApiKey);
+            _httpClient.DefaultRequestHeaders.Add("X-Publishable-Key", options.Value.PublishableKey);
         }
     }
 

--- a/NArk.Swaps/LendaSwap/LendaSwapOptions.cs
+++ b/NArk.Swaps/LendaSwap/LendaSwapOptions.cs
@@ -1,0 +1,7 @@
+namespace NArk.Swaps.LendaSwap;
+
+public class LendaSwapOptions
+{
+    public required string ApiUrl { get; set; }
+    public string? ApiKey { get; set; }
+}

--- a/NArk.Swaps/LendaSwap/LendaSwapOptions.cs
+++ b/NArk.Swaps/LendaSwap/LendaSwapOptions.cs
@@ -1,7 +1,22 @@
 namespace NArk.Swaps.LendaSwap;
 
+/// <summary>
+/// Configuration for the LendaSwap provider.
+/// </summary>
 public class LendaSwapOptions
 {
+    /// <summary>
+    /// Base URL of the LendaSwap API (e.g. "https://api.lendaswap.com").
+    /// </summary>
     public required string ApiUrl { get; set; }
-    public string? ApiKey { get; set; }
+
+    /// <summary>
+    /// Publishable API key for authentication. Sent as X-Publishable-Key header.
+    /// </summary>
+    public string? PublishableKey { get; set; }
+
+    /// <summary>
+    /// Optional referral/reflink code (lnds_* format) attached to swap requests.
+    /// </summary>
+    public string? ReflinkCode { get; set; }
 }

--- a/NArk.Swaps/LendaSwap/LendaSwapOptions.cs
+++ b/NArk.Swaps/LendaSwap/LendaSwapOptions.cs
@@ -16,7 +16,24 @@ public class LendaSwapOptions
     public string? PublishableKey { get; set; }
 
     /// <summary>
-    /// Optional referral/reflink code (lnds_* format) attached to swap requests.
+    /// Optional referral code (lnds_* format) sent as the client-level default
+    /// on every swap-create request. Each request DTO can override per-call via
+    /// its own <c>ReferralCode</c>. Mirrors the upstream ts-sdk's
+    /// <c>referralCode</c> client option (v0.2.34+); the older name
+    /// <c>ReflinkCode</c> is retained below as an obsolete alias.
     /// </summary>
-    public string? ReflinkCode { get; set; }
+    public string? ReferralCode { get; set; }
+
+    /// <summary>
+    /// Deprecated alias for <see cref="ReferralCode"/>. Matches the upstream
+    /// ts-sdk's deprecation-not-removal policy for <c>withOrgCode</c>/<c>reflink</c>;
+    /// writes flow through to <see cref="ReferralCode"/> so existing callers
+    /// keep working.
+    /// </summary>
+    [Obsolete("Use ReferralCode. Kept as an alias for backward compatibility.")]
+    public string? ReflinkCode
+    {
+        get => ReferralCode;
+        set => ReferralCode = value;
+    }
 }

--- a/NArk.Swaps/LendaSwap/LendaSwapProvider.cs
+++ b/NArk.Swaps/LendaSwap/LendaSwapProvider.cs
@@ -36,21 +36,39 @@ public class LendaSwapProvider : ISwapProvider
 
     // ─── Route Support ─────────────────────────────────────────
 
+    private static bool IsEvmNetwork(SwapNetwork n) =>
+        n is SwapNetwork.EvmEthereum or SwapNetwork.EvmPolygon or SwapNetwork.EvmArbitrum;
+
+    /// <inheritdoc />
     public bool SupportsRoute(SwapRoute route)
     {
         return route switch
         {
             // BTC Onchain <-> Ark
             { Source.Network: SwapNetwork.BitcoinOnchain, Destination.Network: SwapNetwork.Ark } => true,
+            { Source.Network: SwapNetwork.Ark, Destination.Network: SwapNetwork.BitcoinOnchain } => true,
 
-            // Ark <-> EVM chains
-            { Source.Network: SwapNetwork.Ark, Destination.Network: SwapNetwork.EvmEthereum or SwapNetwork.EvmPolygon or SwapNetwork.EvmArbitrum } => true,
-            { Source.Network: SwapNetwork.EvmEthereum or SwapNetwork.EvmPolygon or SwapNetwork.EvmArbitrum, Destination.Network: SwapNetwork.Ark } => true,
+            // Lightning <-> Ark
+            { Source.Network: SwapNetwork.Lightning, Destination.Network: SwapNetwork.Ark } => true,
+            { Source.Network: SwapNetwork.Ark, Destination.Network: SwapNetwork.Lightning } => true,
+
+            // Ark <-> EVM
+            { Source.Network: SwapNetwork.Ark } when IsEvmNetwork(route.Destination.Network) => true,
+            { Destination.Network: SwapNetwork.Ark } when IsEvmNetwork(route.Source.Network) => true,
+
+            // Lightning <-> EVM
+            { Source.Network: SwapNetwork.Lightning } when IsEvmNetwork(route.Destination.Network) => true,
+            { Destination.Network: SwapNetwork.Lightning } when IsEvmNetwork(route.Source.Network) => true,
+
+            // BTC Onchain <-> EVM
+            { Source.Network: SwapNetwork.BitcoinOnchain } when IsEvmNetwork(route.Destination.Network) => true,
+            { Destination.Network: SwapNetwork.BitcoinOnchain } when IsEvmNetwork(route.Source.Network) => true,
 
             _ => false
         };
     }
 
+    /// <inheritdoc />
     public async Task<IReadOnlyCollection<SwapRoute>> GetAvailableRoutesAsync(CancellationToken ct)
     {
         try
@@ -60,14 +78,16 @@ public class LendaSwapProvider : ISwapProvider
                 return Array.Empty<SwapRoute>();
 
             var routes = new List<SwapRoute>();
+            var hasBtc = tokens.BtcTokens.Exists(t => t.TokenId == "btc");
 
-            // BTC -> Ark (always available if BTC token exists)
-            if (tokens.BtcTokens.Exists(t => t.TokenId == "btc"))
+            if (hasBtc)
             {
                 routes.Add(new SwapRoute(SwapAsset.BtcOnchain, SwapAsset.ArkBtc));
+                routes.Add(new SwapRoute(SwapAsset.ArkBtc, SwapAsset.BtcOnchain));
+                routes.Add(new SwapRoute(SwapAsset.BtcLightning, SwapAsset.ArkBtc));
+                routes.Add(new SwapRoute(SwapAsset.ArkBtc, SwapAsset.BtcLightning));
             }
 
-            // For each EVM token, add Ark <-> EVM routes in both directions
             foreach (var evmToken in tokens.EvmTokens)
             {
                 var network = MapChainToNetwork(evmToken.Chain);
@@ -77,6 +97,14 @@ public class LendaSwapProvider : ISwapProvider
 
                 routes.Add(new SwapRoute(SwapAsset.ArkBtc, evmAsset));
                 routes.Add(new SwapRoute(evmAsset, SwapAsset.ArkBtc));
+                routes.Add(new SwapRoute(SwapAsset.BtcLightning, evmAsset));
+                routes.Add(new SwapRoute(evmAsset, SwapAsset.BtcLightning));
+
+                if (hasBtc)
+                {
+                    routes.Add(new SwapRoute(SwapAsset.BtcOnchain, evmAsset));
+                    routes.Add(new SwapRoute(evmAsset, SwapAsset.BtcOnchain));
+                }
             }
 
             return routes;

--- a/NArk.Swaps/LendaSwap/LendaSwapProvider.cs
+++ b/NArk.Swaps/LendaSwap/LendaSwapProvider.cs
@@ -1,0 +1,318 @@
+using Microsoft.Extensions.Logging;
+using NArk.Swaps.Abstractions;
+using NArk.Swaps.LendaSwap.Client;
+using NArk.Swaps.LendaSwap.Models;
+using NArk.Swaps.Models;
+
+namespace NArk.Swaps.LendaSwap;
+
+/// <summary>
+/// LendaSwap provider implementing ISwapProvider.
+/// Supports cross-chain swaps between Bitcoin, Arkade, and EVM chains.
+/// </summary>
+public class LendaSwapProvider : ISwapProvider
+{
+    public const string Id = "lendaswap";
+
+    private readonly LendaSwapClient _client;
+    private readonly ISwapStorage _swapStorage;
+    private readonly ILogger<LendaSwapProvider>? _logger;
+
+    private readonly CancellationTokenSource _shutdownCts = new();
+    private Task? _pollingTask;
+
+    public LendaSwapProvider(
+        LendaSwapClient client,
+        ISwapStorage swapStorage,
+        ILogger<LendaSwapProvider>? logger = null)
+    {
+        _client = client;
+        _swapStorage = swapStorage;
+        _logger = logger;
+    }
+
+    public string ProviderId => Id;
+    public string DisplayName => "LendaSwap";
+
+    // ─── Route Support ─────────────────────────────────────────
+
+    public bool SupportsRoute(SwapRoute route)
+    {
+        return route switch
+        {
+            // BTC Onchain <-> Ark
+            { Source.Network: SwapNetwork.BitcoinOnchain, Destination.Network: SwapNetwork.Ark } => true,
+
+            // Ark <-> EVM chains
+            { Source.Network: SwapNetwork.Ark, Destination.Network: SwapNetwork.EvmEthereum or SwapNetwork.EvmPolygon or SwapNetwork.EvmArbitrum } => true,
+            { Source.Network: SwapNetwork.EvmEthereum or SwapNetwork.EvmPolygon or SwapNetwork.EvmArbitrum, Destination.Network: SwapNetwork.Ark } => true,
+
+            _ => false
+        };
+    }
+
+    public async Task<IReadOnlyCollection<SwapRoute>> GetAvailableRoutesAsync(CancellationToken ct)
+    {
+        try
+        {
+            var tokens = await _client.GetTokensAsync(ct);
+            if (tokens == null)
+                return Array.Empty<SwapRoute>();
+
+            var routes = new List<SwapRoute>();
+
+            // BTC -> Ark (always available if BTC token exists)
+            if (tokens.BtcTokens.Exists(t => t.TokenId == "btc"))
+            {
+                routes.Add(new SwapRoute(SwapAsset.BtcOnchain, SwapAsset.ArkBtc));
+            }
+
+            // For each EVM token, add Ark <-> EVM routes in both directions
+            foreach (var evmToken in tokens.EvmTokens)
+            {
+                var network = MapChainToNetwork(evmToken.Chain);
+                if (network == null) continue;
+
+                var evmAsset = SwapAsset.Erc20(network.Value, evmToken.TokenId);
+
+                routes.Add(new SwapRoute(SwapAsset.ArkBtc, evmAsset));
+                routes.Add(new SwapRoute(evmAsset, SwapAsset.ArkBtc));
+            }
+
+            return routes;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Failed to fetch LendaSwap tokens, returning empty routes");
+            return Array.Empty<SwapRoute>();
+        }
+    }
+
+    // ─── Lifecycle ─────────────────────────────────────────────
+
+    public Task StartAsync(string walletId, CancellationToken ct)
+    {
+        _logger?.LogInformation("Starting LendaSwap provider");
+        var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, _shutdownCts.Token);
+        _pollingTask = PollActiveSwaps(TimeSpan.FromSeconds(30), linkedCts.Token);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken ct)
+    {
+        _logger?.LogInformation("Stopping LendaSwap provider");
+        return Task.CompletedTask;
+    }
+
+    // ─── Swap Creation ─────────────────────────────────────────
+
+    public Task<SwapResult> CreateSwapAsync(CreateSwapRequest request, CancellationToken ct)
+    {
+        // LendaSwap swap creation requires protocol-specific parameters (hash locks,
+        // public keys, etc.) that go beyond the generic CreateSwapRequest interface.
+        // Integration with the full wallet flow will be implemented in a follow-up.
+        throw new NotSupportedException(
+            "LendaSwap swap creation requires protocol-specific parameters. " +
+            "Use the LendaSwapClient directly for now.");
+    }
+
+    public Task RefundSwapAsync(string walletId, string swapId, CancellationToken ct)
+    {
+        // LendaSwap refunds are handled by monitoring swap status transitions.
+        throw new NotSupportedException(
+            "LendaSwap refunds are handled automatically via status monitoring.");
+    }
+
+    // ─── Limits & Quotes ───────────────────────────────────────
+
+    public async Task<SwapLimits> GetLimitsAsync(SwapRoute route, CancellationToken ct)
+    {
+        var (sourceChain, sourceToken, targetChain, targetToken) = MapRouteToApiParams(route);
+
+        var quote = await _client.GetQuoteAsync(
+            sourceChain, sourceToken, targetChain, targetToken,
+            sourceAmount: null, targetAmount: null, ct);
+
+        if (quote == null)
+            throw new InvalidOperationException($"Unable to fetch LendaSwap limits for route {route}");
+
+        return new SwapLimits
+        {
+            Route = route,
+            MinAmount = quote.MinAmount,
+            MaxAmount = quote.MaxAmount,
+            FeePercentage = quote.ProtocolFeeRate,
+            MinerFee = quote.NetworkFee
+        };
+    }
+
+    public async Task<SwapQuote> GetQuoteAsync(SwapRoute route, long amount, CancellationToken ct)
+    {
+        var (sourceChain, sourceToken, targetChain, targetToken) = MapRouteToApiParams(route);
+
+        var quote = await _client.GetQuoteAsync(
+            sourceChain, sourceToken, targetChain, targetToken,
+            sourceAmount: amount, ct: ct);
+
+        if (quote == null)
+            throw new InvalidOperationException($"Unable to fetch LendaSwap quote for route {route}");
+
+        var exchangeRate = decimal.TryParse(quote.ExchangeRate, System.Globalization.NumberStyles.Any,
+            System.Globalization.CultureInfo.InvariantCulture, out var rate) ? rate : 0m;
+
+        return new SwapQuote
+        {
+            Route = route,
+            SourceAmount = quote.SourceAmount,
+            DestinationAmount = quote.TargetAmount,
+            TotalFees = quote.ProtocolFee + quote.NetworkFee,
+            ExchangeRate = exchangeRate
+        };
+    }
+
+    // ─── Status Events ─────────────────────────────────────────
+
+    public event EventHandler<SwapStatusChangedEvent>? SwapStatusChanged;
+
+    // ─── Polling ───────────────────────────────────────────────
+
+    private async Task PollActiveSwaps(TimeSpan interval, CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                var allActiveSwaps = await _swapStorage.GetSwaps(
+                    active: true, cancellationToken: ct);
+                var activeSwaps = allActiveSwaps.Where(s => s.ProviderId == Id);
+
+                foreach (var swap in activeSwaps)
+                {
+                    try
+                    {
+                        var status = await _client.GetSwapStatusAsync(swap.SwapId, ct);
+                        if (status?.Status == null) continue;
+
+                        var newStatus = MapLendaSwapStatus(status.Status);
+                        if (swap.Status == newStatus) continue;
+
+                        _logger?.LogInformation(
+                            "Swap {SwapId}: status changed {OldStatus} -> {NewStatus} (LendaSwap: '{ApiStatus}')",
+                            swap.SwapId, swap.Status, newStatus, status.Status);
+
+                        var updatedSwap = swap with
+                        {
+                            Status = newStatus,
+                            UpdatedAt = DateTimeOffset.UtcNow
+                        };
+
+                        await _swapStorage.SaveSwap(swap.WalletId, updatedSwap, cancellationToken: ct);
+
+                        SwapStatusChanged?.Invoke(this, new SwapStatusChangedEvent(
+                            swap.SwapId, swap.WalletId, Id, newStatus));
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        _logger?.LogError(ex, "Swap {SwapId}: error polling LendaSwap status", swap.SwapId);
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger?.LogError(ex, "Error during LendaSwap polling cycle");
+            }
+
+            await Task.Delay(interval, ct);
+        }
+    }
+
+    // ─── Status Mapping ────────────────────────────────────────
+
+    public static ArkSwapStatus MapLendaSwapStatus(string status)
+    {
+        return status switch
+        {
+            "pending" or "clientfundingseen" or "clientfunded" or "serverfunded"
+                or "clientredeeming" => ArkSwapStatus.Pending,
+
+            "clientredeemed" or "serverredeemed" => ArkSwapStatus.Settled,
+
+            "clientrefunded" or "clientrefundedserverfunded"
+                or "clientrefundedserverrefunded" => ArkSwapStatus.Refunded,
+
+            "expired" or "clientinvalidfunded" or "clientfundedtoolate"
+                or "clientfundedserverrefunded"
+                or "clientredeemedandclientrefunded" => ArkSwapStatus.Failed,
+
+            _ => ArkSwapStatus.Unknown
+        };
+    }
+
+    // ─── Chain / Network Mapping ───────────────────────────────
+
+    public static SwapNetwork? MapChainToNetwork(string chain)
+    {
+        return chain switch
+        {
+            "Arkade" => SwapNetwork.Ark,
+            "Bitcoin" => SwapNetwork.BitcoinOnchain,
+            "Lightning" => SwapNetwork.Lightning,
+            "1" => SwapNetwork.EvmEthereum,
+            "137" => SwapNetwork.EvmPolygon,
+            "42161" => SwapNetwork.EvmArbitrum,
+            _ => null
+        };
+    }
+
+    public static string MapNetworkToChain(SwapNetwork network)
+    {
+        return network switch
+        {
+            SwapNetwork.Ark => "Arkade",
+            SwapNetwork.BitcoinOnchain => "Bitcoin",
+            SwapNetwork.Lightning => "Lightning",
+            SwapNetwork.EvmEthereum => "1",
+            SwapNetwork.EvmPolygon => "137",
+            SwapNetwork.EvmArbitrum => "42161",
+            _ => throw new ArgumentOutOfRangeException(nameof(network), network, "Unsupported network")
+        };
+    }
+
+    public static (string sourceChain, string sourceToken, string targetChain, string targetToken)
+        MapRouteToApiParams(SwapRoute route)
+    {
+        var sourceChain = MapNetworkToChain(route.Source.Network);
+        var targetChain = MapNetworkToChain(route.Destination.Network);
+
+        // For BTC/Ark networks, the token is always "btc"
+        // For EVM networks, the token is the contract address (AssetId)
+        var sourceToken = route.Source.Network is SwapNetwork.Ark or SwapNetwork.BitcoinOnchain or SwapNetwork.Lightning
+            ? "btc"
+            : route.Source.AssetId;
+
+        var targetToken = route.Destination.Network is SwapNetwork.Ark or SwapNetwork.BitcoinOnchain or SwapNetwork.Lightning
+            ? "btc"
+            : route.Destination.AssetId;
+
+        return (sourceChain, sourceToken, targetChain, targetToken);
+    }
+
+    // ─── Disposal ──────────────────────────────────────────────
+
+    public async ValueTask DisposeAsync()
+    {
+        _logger?.LogInformation("Disposing LendaSwap provider");
+
+        await _shutdownCts.CancelAsync();
+
+        try
+        {
+            if (_pollingTask is not null)
+                await _pollingTask;
+        }
+        catch
+        {
+            // ignored — task cancellation is expected
+        }
+    }
+}

--- a/NArk.Swaps/LendaSwap/LendaSwapProvider.cs
+++ b/NArk.Swaps/LendaSwap/LendaSwapProvider.cs
@@ -118,7 +118,7 @@ public class LendaSwapProvider : ISwapProvider
 
     // ─── Lifecycle ─────────────────────────────────────────────
 
-    public Task StartAsync(string walletId, CancellationToken ct)
+    public Task StartAsync(CancellationToken ct)
     {
         _logger?.LogInformation("Starting LendaSwap provider");
         var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, _shutdownCts.Token);
@@ -132,25 +132,6 @@ public class LendaSwapProvider : ISwapProvider
         return Task.CompletedTask;
     }
 
-    // ─── Swap Creation ─────────────────────────────────────────
-
-    public Task<SwapResult> CreateSwapAsync(CreateSwapRequest request, CancellationToken ct)
-    {
-        // LendaSwap swap creation requires protocol-specific parameters (hash locks,
-        // public keys, etc.) that go beyond the generic CreateSwapRequest interface.
-        // Integration with the full wallet flow will be implemented in a follow-up.
-        throw new NotSupportedException(
-            "LendaSwap swap creation requires protocol-specific parameters. " +
-            "Use the LendaSwapClient directly for now.");
-    }
-
-    public Task RefundSwapAsync(string walletId, string swapId, CancellationToken ct)
-    {
-        // LendaSwap refunds are handled by monitoring swap status transitions.
-        throw new NotSupportedException(
-            "LendaSwap refunds are handled automatically via status monitoring.");
-    }
-
     // ─── Limits & Quotes ───────────────────────────────────────
 
     public async Task<SwapLimits> GetLimitsAsync(SwapRoute route, CancellationToken ct)
@@ -159,7 +140,7 @@ public class LendaSwapProvider : ISwapProvider
 
         var quote = await _client.GetQuoteAsync(
             sourceChain, sourceToken, targetChain, targetToken,
-            sourceAmount: null, targetAmount: null, ct);
+            sourceAmount: null, targetAmount: null, ct: ct);
 
         if (quote == null)
             throw new InvalidOperationException($"Unable to fetch LendaSwap limits for route {route}");

--- a/NArk.Swaps/LendaSwap/Models/LendaSwapRequests.cs
+++ b/NArk.Swaps/LendaSwap/Models/LendaSwapRequests.cs
@@ -4,6 +4,9 @@ namespace NArk.Swaps.LendaSwap.Models;
 
 // ─── BTC to Arkade ─────────────────────────────────────────────
 
+/// <summary>
+/// Request to create a BTC on-chain to Arkade swap.
+/// </summary>
 public class CreateBtcToArkadeRequest
 {
     [JsonPropertyName("claim_pk")]
@@ -24,13 +27,106 @@ public class CreateBtcToArkadeRequest
     [JsonPropertyName("user_id")]
     public required string UserId { get; set; }
 
-    [JsonPropertyName("referral_code")]
+    [JsonPropertyName("reflink_code")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ReferralCode { get; set; }
+    public string? ReflinkCode { get; set; }
+}
+
+// ─── Arkade to BTC ─────────────────────────────────────────────
+
+/// <summary>
+/// Request to create an Arkade to BTC on-chain swap.
+/// </summary>
+public class CreateArkadeToBtcRequest
+{
+    [JsonPropertyName("hash_lock")]
+    public required string HashLock { get; set; }
+
+    [JsonPropertyName("refund_pk")]
+    public required string RefundPk { get; set; }
+
+    [JsonPropertyName("target_address")]
+    public required string TargetAddress { get; set; }
+
+    [JsonPropertyName("claiming_address")]
+    public required string ClaimingAddress { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required string UserId { get; set; }
+
+    [JsonPropertyName("amount_in")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? AmountIn { get; set; }
+
+    [JsonPropertyName("amount_out")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? AmountOut { get; set; }
+
+    [JsonPropertyName("reflink_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReflinkCode { get; set; }
+}
+
+// ─── Lightning to Arkade ───────────────────────────────────────
+
+/// <summary>
+/// Request to create a Lightning to Arkade swap.
+/// </summary>
+public class CreateLightningToArkadeRequest
+{
+    [JsonPropertyName("hash_lock")]
+    public required string HashLock { get; set; }
+
+    [JsonPropertyName("receiver_pk")]
+    public required string ReceiverPk { get; set; }
+
+    [JsonPropertyName("target_arkade_address")]
+    public required string TargetArkadeAddress { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required string UserId { get; set; }
+
+    [JsonPropertyName("amount_in")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? AmountIn { get; set; }
+
+    [JsonPropertyName("reflink_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReflinkCode { get; set; }
+}
+
+// ─── Arkade to Lightning ───────────────────────────────────────
+
+/// <summary>
+/// Request to create an Arkade to Lightning swap (generates a BOLT11 invoice).
+/// </summary>
+public class CreateArkadeToLightningRequest
+{
+    [JsonPropertyName("hash_lock")]
+    public required string HashLock { get; set; }
+
+    [JsonPropertyName("refund_pk")]
+    public required string RefundPk { get; set; }
+
+    [JsonPropertyName("claiming_address")]
+    public required string ClaimingAddress { get; set; }
+
+    [JsonPropertyName("bolt11_invoice")]
+    public required string Bolt11Invoice { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required string UserId { get; set; }
+
+    [JsonPropertyName("reflink_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReflinkCode { get; set; }
 }
 
 // ─── Arkade to EVM ─────────────────────────────────────────────
 
+/// <summary>
+/// Request to create an Arkade to EVM token swap.
+/// </summary>
 public class CreateArkadeToEvmRequest
 {
     [JsonPropertyName("hash_lock")]
@@ -66,13 +162,16 @@ public class CreateArkadeToEvmRequest
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Gasless { get; set; }
 
-    [JsonPropertyName("referral_code")]
+    [JsonPropertyName("reflink_code")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ReferralCode { get; set; }
+    public string? ReflinkCode { get; set; }
 }
 
 // ─── EVM to Arkade ─────────────────────────────────────────────
 
+/// <summary>
+/// Request to create an EVM token to Arkade swap.
+/// </summary>
 public class CreateEvmToArkadeRequest
 {
     [JsonPropertyName("hash_lock")]
@@ -104,7 +203,155 @@ public class CreateEvmToArkadeRequest
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public long? AmountOut { get; set; }
 
-    [JsonPropertyName("referral_code")]
+    [JsonPropertyName("reflink_code")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ReferralCode { get; set; }
+    public string? ReflinkCode { get; set; }
+}
+
+// ─── Lightning to EVM ──────────────────────────────────────────
+
+/// <summary>
+/// Request to create a Lightning to EVM token swap.
+/// </summary>
+public class CreateLightningToEvmRequest
+{
+    [JsonPropertyName("hash_lock")]
+    public required string HashLock { get; set; }
+
+    [JsonPropertyName("target_address")]
+    public required string TargetAddress { get; set; }
+
+    [JsonPropertyName("token_address")]
+    public required string TokenAddress { get; set; }
+
+    [JsonPropertyName("evm_chain_id")]
+    public required string EvmChainId { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required string UserId { get; set; }
+
+    [JsonPropertyName("amount_in")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? AmountIn { get; set; }
+
+    [JsonPropertyName("gasless")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Gasless { get; set; }
+
+    [JsonPropertyName("reflink_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReflinkCode { get; set; }
+}
+
+// ─── EVM to Lightning ──────────────────────────────────────────
+
+/// <summary>
+/// Request to create an EVM token to Lightning swap.
+/// </summary>
+public class CreateEvmToLightningRequest
+{
+    [JsonPropertyName("hash_lock")]
+    public required string HashLock { get; set; }
+
+    [JsonPropertyName("bolt11_invoice")]
+    public required string Bolt11Invoice { get; set; }
+
+    [JsonPropertyName("token_address")]
+    public required string TokenAddress { get; set; }
+
+    [JsonPropertyName("evm_chain_id")]
+    public required string EvmChainId { get; set; }
+
+    [JsonPropertyName("user_address")]
+    public required string UserAddress { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required string UserId { get; set; }
+
+    [JsonPropertyName("amount_in")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? AmountIn { get; set; }
+
+    [JsonPropertyName("reflink_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReflinkCode { get; set; }
+}
+
+// ─── BTC to EVM ────────────────────────────────────────────────
+
+/// <summary>
+/// Request to create a BTC on-chain to EVM token swap.
+/// </summary>
+public class CreateBtcToEvmRequest
+{
+    [JsonPropertyName("claim_pk")]
+    public required string ClaimPk { get; set; }
+
+    [JsonPropertyName("hash_lock")]
+    public required string HashLock { get; set; }
+
+    [JsonPropertyName("refund_pk")]
+    public required string RefundPk { get; set; }
+
+    [JsonPropertyName("target_address")]
+    public required string TargetAddress { get; set; }
+
+    [JsonPropertyName("token_address")]
+    public required string TokenAddress { get; set; }
+
+    [JsonPropertyName("evm_chain_id")]
+    public required string EvmChainId { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required string UserId { get; set; }
+
+    [JsonPropertyName("sats_receive")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? SatsReceive { get; set; }
+
+    [JsonPropertyName("gasless")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Gasless { get; set; }
+
+    [JsonPropertyName("reflink_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReflinkCode { get; set; }
+}
+
+// ─── EVM to BTC ────────────────────────────────────────────────
+
+/// <summary>
+/// Request to create an EVM token to BTC on-chain swap.
+/// </summary>
+public class CreateEvmToBtcRequest
+{
+    [JsonPropertyName("hash_lock")]
+    public required string HashLock { get; set; }
+
+    [JsonPropertyName("target_address")]
+    public required string TargetAddress { get; set; }
+
+    [JsonPropertyName("token_address")]
+    public required string TokenAddress { get; set; }
+
+    [JsonPropertyName("evm_chain_id")]
+    public required string EvmChainId { get; set; }
+
+    [JsonPropertyName("user_address")]
+    public required string UserAddress { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required string UserId { get; set; }
+
+    [JsonPropertyName("amount_in")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? AmountIn { get; set; }
+
+    [JsonPropertyName("amount_out")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? AmountOut { get; set; }
+
+    [JsonPropertyName("reflink_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReflinkCode { get; set; }
 }

--- a/NArk.Swaps/LendaSwap/Models/LendaSwapRequests.cs
+++ b/NArk.Swaps/LendaSwap/Models/LendaSwapRequests.cs
@@ -1,0 +1,110 @@
+using System.Text.Json.Serialization;
+
+namespace NArk.Swaps.LendaSwap.Models;
+
+// ─── BTC to Arkade ─────────────────────────────────────────────
+
+public class CreateBtcToArkadeRequest
+{
+    [JsonPropertyName("claim_pk")]
+    public required string ClaimPk { get; set; }
+
+    [JsonPropertyName("hash_lock")]
+    public required string HashLock { get; set; }
+
+    [JsonPropertyName("refund_pk")]
+    public required string RefundPk { get; set; }
+
+    [JsonPropertyName("sats_receive")]
+    public required long SatsReceive { get; set; }
+
+    [JsonPropertyName("target_arkade_address")]
+    public required string TargetArkadeAddress { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required string UserId { get; set; }
+
+    [JsonPropertyName("referral_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReferralCode { get; set; }
+}
+
+// ─── Arkade to EVM ─────────────────────────────────────────────
+
+public class CreateArkadeToEvmRequest
+{
+    [JsonPropertyName("hash_lock")]
+    public required string HashLock { get; set; }
+
+    [JsonPropertyName("refund_pk")]
+    public required string RefundPk { get; set; }
+
+    [JsonPropertyName("claiming_address")]
+    public required string ClaimingAddress { get; set; }
+
+    [JsonPropertyName("target_address")]
+    public required string TargetAddress { get; set; }
+
+    [JsonPropertyName("token_address")]
+    public required string TokenAddress { get; set; }
+
+    [JsonPropertyName("evm_chain_id")]
+    public required string EvmChainId { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required string UserId { get; set; }
+
+    [JsonPropertyName("amount_in")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? AmountIn { get; set; }
+
+    [JsonPropertyName("amount_out")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? AmountOut { get; set; }
+
+    [JsonPropertyName("gasless")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Gasless { get; set; }
+
+    [JsonPropertyName("referral_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReferralCode { get; set; }
+}
+
+// ─── EVM to Arkade ─────────────────────────────────────────────
+
+public class CreateEvmToArkadeRequest
+{
+    [JsonPropertyName("hash_lock")]
+    public required string HashLock { get; set; }
+
+    [JsonPropertyName("receiver_pk")]
+    public required string ReceiverPk { get; set; }
+
+    [JsonPropertyName("target_address")]
+    public required string TargetAddress { get; set; }
+
+    [JsonPropertyName("token_address")]
+    public required string TokenAddress { get; set; }
+
+    [JsonPropertyName("evm_chain_id")]
+    public required string EvmChainId { get; set; }
+
+    [JsonPropertyName("user_address")]
+    public required string UserAddress { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required string UserId { get; set; }
+
+    [JsonPropertyName("amount_in")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? AmountIn { get; set; }
+
+    [JsonPropertyName("amount_out")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? AmountOut { get; set; }
+
+    [JsonPropertyName("referral_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReferralCode { get; set; }
+}

--- a/NArk.Swaps/LendaSwap/Models/LendaSwapRequests.cs
+++ b/NArk.Swaps/LendaSwap/Models/LendaSwapRequests.cs
@@ -27,9 +27,13 @@ public class CreateBtcToArkadeRequest
     [JsonPropertyName("user_id")]
     public required string UserId { get; set; }
 
-    [JsonPropertyName("reflink_code")]
+    [JsonPropertyName("extra_fees")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ReflinkCode { get; set; }
+    public int? ExtraFees { get; set; }
+
+    [JsonPropertyName("referral_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReferralCode { get; set; }
 }
 
 // ─── Arkade to BTC ─────────────────────────────────────────────
@@ -62,9 +66,13 @@ public class CreateArkadeToBtcRequest
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public long? AmountOut { get; set; }
 
-    [JsonPropertyName("reflink_code")]
+    [JsonPropertyName("extra_fees")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ReflinkCode { get; set; }
+    public int? ExtraFees { get; set; }
+
+    [JsonPropertyName("referral_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReferralCode { get; set; }
 }
 
 // ─── Lightning to Arkade ───────────────────────────────────────
@@ -90,9 +98,13 @@ public class CreateLightningToArkadeRequest
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public long? AmountIn { get; set; }
 
-    [JsonPropertyName("reflink_code")]
+    [JsonPropertyName("extra_fees")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ReflinkCode { get; set; }
+    public int? ExtraFees { get; set; }
+
+    [JsonPropertyName("referral_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReferralCode { get; set; }
 }
 
 // ─── Arkade to Lightning ───────────────────────────────────────
@@ -117,9 +129,13 @@ public class CreateArkadeToLightningRequest
     [JsonPropertyName("user_id")]
     public required string UserId { get; set; }
 
-    [JsonPropertyName("reflink_code")]
+    [JsonPropertyName("extra_fees")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ReflinkCode { get; set; }
+    public int? ExtraFees { get; set; }
+
+    [JsonPropertyName("referral_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReferralCode { get; set; }
 }
 
 // ─── Arkade to EVM ─────────────────────────────────────────────
@@ -162,9 +178,13 @@ public class CreateArkadeToEvmRequest
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Gasless { get; set; }
 
-    [JsonPropertyName("reflink_code")]
+    [JsonPropertyName("extra_fees")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ReflinkCode { get; set; }
+    public int? ExtraFees { get; set; }
+
+    [JsonPropertyName("referral_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReferralCode { get; set; }
 }
 
 // ─── EVM to Arkade ─────────────────────────────────────────────
@@ -203,9 +223,13 @@ public class CreateEvmToArkadeRequest
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public long? AmountOut { get; set; }
 
-    [JsonPropertyName("reflink_code")]
+    [JsonPropertyName("extra_fees")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ReflinkCode { get; set; }
+    public int? ExtraFees { get; set; }
+
+    [JsonPropertyName("referral_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReferralCode { get; set; }
 }
 
 // ─── Lightning to EVM ──────────────────────────────────────────
@@ -238,9 +262,13 @@ public class CreateLightningToEvmRequest
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Gasless { get; set; }
 
-    [JsonPropertyName("reflink_code")]
+    [JsonPropertyName("extra_fees")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ReflinkCode { get; set; }
+    public int? ExtraFees { get; set; }
+
+    [JsonPropertyName("referral_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReferralCode { get; set; }
 }
 
 // ─── EVM to Lightning ──────────────────────────────────────────
@@ -272,9 +300,13 @@ public class CreateEvmToLightningRequest
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public long? AmountIn { get; set; }
 
-    [JsonPropertyName("reflink_code")]
+    [JsonPropertyName("extra_fees")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ReflinkCode { get; set; }
+    public int? ExtraFees { get; set; }
+
+    [JsonPropertyName("referral_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReferralCode { get; set; }
 }
 
 // ─── BTC to EVM ────────────────────────────────────────────────
@@ -313,9 +345,13 @@ public class CreateBtcToEvmRequest
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public bool? Gasless { get; set; }
 
-    [JsonPropertyName("reflink_code")]
+    [JsonPropertyName("extra_fees")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ReflinkCode { get; set; }
+    public int? ExtraFees { get; set; }
+
+    [JsonPropertyName("referral_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReferralCode { get; set; }
 }
 
 // ─── EVM to BTC ────────────────────────────────────────────────
@@ -351,7 +387,11 @@ public class CreateEvmToBtcRequest
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public long? AmountOut { get; set; }
 
-    [JsonPropertyName("reflink_code")]
+    [JsonPropertyName("extra_fees")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? ReflinkCode { get; set; }
+    public int? ExtraFees { get; set; }
+
+    [JsonPropertyName("referral_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReferralCode { get; set; }
 }

--- a/NArk.Swaps/LendaSwap/Models/LendaSwapResponses.cs
+++ b/NArk.Swaps/LendaSwap/Models/LendaSwapResponses.cs
@@ -1,0 +1,123 @@
+using System.Text.Json.Serialization;
+
+namespace NArk.Swaps.LendaSwap.Models;
+
+// ─── Token List ────────────────────────────────────────────────
+
+public class TokenListResponse
+{
+    [JsonPropertyName("btc_tokens")]
+    public List<TokenInfo> BtcTokens { get; set; } = [];
+
+    [JsonPropertyName("evm_tokens")]
+    public List<TokenInfo> EvmTokens { get; set; } = [];
+}
+
+public class TokenInfo
+{
+    [JsonPropertyName("token_id")]
+    public string TokenId { get; set; } = "";
+
+    [JsonPropertyName("symbol")]
+    public string Symbol { get; set; } = "";
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    [JsonPropertyName("decimals")]
+    public int Decimals { get; set; }
+
+    [JsonPropertyName("chain")]
+    public string Chain { get; set; } = "";
+}
+
+// ─── Quote ─────────────────────────────────────────────────────
+
+public class QuoteResponse
+{
+    [JsonPropertyName("exchange_rate")]
+    public string ExchangeRate { get; set; } = "";
+
+    [JsonPropertyName("protocol_fee")]
+    public long ProtocolFee { get; set; }
+
+    [JsonPropertyName("protocol_fee_rate")]
+    public decimal ProtocolFeeRate { get; set; }
+
+    [JsonPropertyName("network_fee")]
+    public long NetworkFee { get; set; }
+
+    [JsonPropertyName("gasless_network_fee")]
+    public long GaslessNetworkFee { get; set; }
+
+    [JsonPropertyName("source_amount")]
+    public long SourceAmount { get; set; }
+
+    [JsonPropertyName("target_amount")]
+    public long TargetAmount { get; set; }
+
+    [JsonPropertyName("min_amount")]
+    public long MinAmount { get; set; }
+
+    [JsonPropertyName("max_amount")]
+    public long MaxAmount { get; set; }
+}
+
+// ─── Swap Response ─────────────────────────────────────────────
+
+public class LendaSwapResponse
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = "";
+
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = "";
+
+    [JsonPropertyName("btc_htlc_address")]
+    public string? BtcHtlcAddress { get; set; }
+
+    [JsonPropertyName("arkade_vhtlc_address")]
+    public string? ArkadeVhtlcAddress { get; set; }
+
+    [JsonPropertyName("evm_htlc_address")]
+    public string? EvmHtlcAddress { get; set; }
+
+    [JsonPropertyName("source_amount")]
+    public long SourceAmount { get; set; }
+
+    [JsonPropertyName("target_amount")]
+    public long TargetAmount { get; set; }
+
+    [JsonPropertyName("protocol_fee")]
+    public long ProtocolFee { get; set; }
+
+    [JsonPropertyName("network_fee")]
+    public long NetworkFee { get; set; }
+
+    [JsonPropertyName("created_at")]
+    public string? CreatedAt { get; set; }
+
+    [JsonPropertyName("expires_at")]
+    public string? ExpiresAt { get; set; }
+
+    [JsonPropertyName("btc_locktime")]
+    public long? BtcLocktime { get; set; }
+
+    [JsonPropertyName("arkade_locktime")]
+    public long? ArkadeLocktime { get; set; }
+
+    [JsonPropertyName("evm_locktime")]
+    public long? EvmLocktime { get; set; }
+
+    [JsonPropertyName("hash_lock")]
+    public string? HashLock { get; set; }
+
+    [JsonPropertyName("server_pk")]
+    public string? ServerPk { get; set; }
+
+    [JsonPropertyName("evm_chain_id")]
+    public string? EvmChainId { get; set; }
+
+    [JsonPropertyName("token_address")]
+    public string? TokenAddress { get; set; }
+}

--- a/NArk.Tests.End2End/LendaSwapTests.cs
+++ b/NArk.Tests.End2End/LendaSwapTests.cs
@@ -1,0 +1,97 @@
+using Microsoft.Extensions.Options;
+using NArk.Swaps.Abstractions;
+using NArk.Swaps.LendaSwap;
+using NArk.Swaps.LendaSwap.Client;
+using NArk.Tests.End2End.TestPersistance;
+
+namespace NArk.Tests.End2End.Swaps;
+
+[TestFixture]
+public class LendaSwapTests
+{
+    /// <summary>
+    /// LendaSwap regtest endpoint. Override via LENDASWAP_URL env var.
+    /// </summary>
+    private static readonly Uri LendaSwapEndpoint = new(
+        Environment.GetEnvironmentVariable("LENDASWAP_URL") ?? "http://localhost:9080");
+
+    private static LendaSwapClient CreateClient()
+    {
+        var httpClient = new HttpClient { BaseAddress = LendaSwapEndpoint };
+        var options = Options.Create(new LendaSwapOptions
+        {
+            ApiUrl = LendaSwapEndpoint.ToString()
+        });
+        return new LendaSwapClient(httpClient, options);
+    }
+
+    private static bool IsLendaSwapAvailable()
+    {
+        try
+        {
+            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+            http.GetAsync($"{LendaSwapEndpoint}/tokens").GetAwaiter().GetResult();
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    [Test]
+    public async Task CanGetTokensFromLendaSwap()
+    {
+        if (!IsLendaSwapAvailable())
+            Assert.Inconclusive($"LendaSwap server not available at {LendaSwapEndpoint}");
+
+        var client = CreateClient();
+        var tokens = await client.GetTokensAsync();
+
+        Assert.That(tokens.BtcTokens, Is.Not.Null);
+        Assert.That(tokens.EvmTokens, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task CanGetQuoteFromLendaSwap()
+    {
+        if (!IsLendaSwapAvailable())
+            Assert.Inconclusive($"LendaSwap server not available at {LendaSwapEndpoint}");
+
+        var client = CreateClient();
+        var quote = await client.GetQuoteAsync(
+            sourceChain: "Bitcoin",
+            sourceToken: "btc",
+            targetChain: "Arkade",
+            targetToken: "btc",
+            sourceAmount: 100_000);
+
+        Assert.That(quote.SourceAmount, Is.GreaterThan(0));
+        Assert.That(quote.TargetAmount, Is.GreaterThan(0));
+        Assert.That(quote.MinAmount, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public async Task LendaSwapProvider_SupportsExpectedRoutes()
+    {
+        // This test doesn't need the server — tests route declarations
+        var client = CreateClient();
+        var provider = new LendaSwapProvider(client, new InMemorySwapStorage());
+
+        Assert.Multiple(() =>
+        {
+            // BTC → Ark
+            Assert.That(provider.SupportsRoute(
+                new SwapRoute(SwapAsset.BtcOnchain, SwapAsset.ArkBtc)), Is.True);
+
+            // Ark → Polygon USDC
+            Assert.That(provider.SupportsRoute(
+                new SwapRoute(SwapAsset.ArkBtc,
+                    SwapAsset.Erc20(SwapNetwork.EvmPolygon, "0x3c499c"))), Is.True);
+
+            // Ark → Lightning (not supported by LendaSwap)
+            Assert.That(provider.SupportsRoute(
+                new SwapRoute(SwapAsset.ArkBtc, SwapAsset.BtcLightning)), Is.False);
+        });
+    }
+}

--- a/NArk.Tests.End2End/LendaSwapTests.cs
+++ b/NArk.Tests.End2End/LendaSwapTests.cs
@@ -76,7 +76,7 @@ public class LendaSwapTests
     {
         // This test doesn't need the server — tests route declarations
         var client = CreateClient();
-        var provider = new LendaSwapProvider(client, new InMemorySwapStorage());
+        var provider = new LendaSwapProvider(client, TestStorage.CreateSwapStorage());
 
         Assert.Multiple(() =>
         {
@@ -89,9 +89,13 @@ public class LendaSwapTests
                 new SwapRoute(SwapAsset.ArkBtc,
                     SwapAsset.Erc20(SwapNetwork.EvmPolygon, "0x3c499c"))), Is.True);
 
-            // Ark → Lightning (not supported by LendaSwap)
+            // Lightning → Ark (now supported by LendaSwap)
             Assert.That(provider.SupportsRoute(
-                new SwapRoute(SwapAsset.ArkBtc, SwapAsset.BtcLightning)), Is.False);
+                new SwapRoute(SwapAsset.BtcLightning, SwapAsset.ArkBtc)), Is.True);
+
+            // Ark → Ark (not a valid route)
+            Assert.That(provider.SupportsRoute(
+                new SwapRoute(SwapAsset.ArkBtc, SwapAsset.ArkBtc)), Is.False);
         });
     }
 }

--- a/NArk.Tests/LendaSwapClientTests.cs
+++ b/NArk.Tests/LendaSwapClientTests.cs
@@ -39,13 +39,13 @@ public class LendaSwapClientTests
     }
 
     private static LendaSwapClient CreateClient(
-        MockHttpHandler handler, string? apiKey = null)
+        MockHttpHandler handler, string? publishableKey = null)
     {
         var httpClient = new HttpClient(handler);
         var options = Options.Create(new LendaSwapOptions
         {
             ApiUrl = BaseUrl,
-            ApiKey = apiKey
+            PublishableKey = publishableKey
         });
         return new LendaSwapClient(httpClient, options);
     }
@@ -244,30 +244,30 @@ public class LendaSwapClientTests
     // ─── API Key Header ────────────────────────────────────────
 
     [Test]
-    public async Task ApiKeyHeader_SentWhenConfigured()
+    public async Task PublishableKeyHeader_SentWhenConfigured()
     {
         const string json = """{ "btc_tokens": [], "evm_tokens": [] }""";
         var handler = new MockHttpHandler(HttpStatusCode.OK, json);
-        var client = CreateClient(handler, apiKey: "test-api-key-123");
+        var client = CreateClient(handler, publishableKey: "pk_test_123");
 
         await client.GetTokensAsync();
 
-        Assert.That(handler.LastRequest!.Headers.Contains("X-API-Key"), Is.True);
+        Assert.That(handler.LastRequest!.Headers.Contains("X-Publishable-Key"), Is.True);
         Assert.That(
-            handler.LastRequest.Headers.GetValues("X-API-Key").First(),
-            Is.EqualTo("test-api-key-123"));
+            handler.LastRequest.Headers.GetValues("X-Publishable-Key").First(),
+            Is.EqualTo("pk_test_123"));
     }
 
     [Test]
-    public async Task ApiKeyHeader_NotSentWhenNotConfigured()
+    public async Task PublishableKeyHeader_NotSentWhenNotConfigured()
     {
         const string json = """{ "btc_tokens": [], "evm_tokens": [] }""";
         var handler = new MockHttpHandler(HttpStatusCode.OK, json);
-        var client = CreateClient(handler, apiKey: null);
+        var client = CreateClient(handler, publishableKey: null);
 
         await client.GetTokensAsync();
 
-        Assert.That(handler.LastRequest!.Headers.Contains("X-API-Key"), Is.False);
+        Assert.That(handler.LastRequest!.Headers.Contains("X-Publishable-Key"), Is.False);
     }
 
     // ─── HTTP Error Handling ───────────────────────────────────
@@ -406,22 +406,62 @@ public class LendaSwapClientTests
     }
 
     [Test]
-    public void SupportsRoute_LightningToArk_False()
+    public void SupportsRoute_LightningToArk_True()
     {
         var provider = CreateProviderForRouteTests();
         var route = new SwapRoute(
             SwapAsset.BtcLightning,
             SwapAsset.ArkBtc);
-        Assert.That(provider.SupportsRoute(route), Is.False);
+        Assert.That(provider.SupportsRoute(route), Is.True);
     }
 
     [Test]
-    public void SupportsRoute_ArkToLightning_False()
+    public void SupportsRoute_ArkToLightning_True()
     {
         var provider = CreateProviderForRouteTests();
         var route = new SwapRoute(
             SwapAsset.ArkBtc,
             SwapAsset.BtcLightning);
+        Assert.That(provider.SupportsRoute(route), Is.True);
+    }
+
+    [Test]
+    public void SupportsRoute_ArkToBtcOnchain_True()
+    {
+        var provider = CreateProviderForRouteTests();
+        var route = new SwapRoute(
+            SwapAsset.ArkBtc,
+            SwapAsset.BtcOnchain);
+        Assert.That(provider.SupportsRoute(route), Is.True);
+    }
+
+    [Test]
+    public void SupportsRoute_LightningToEvmPolygon_True()
+    {
+        var provider = CreateProviderForRouteTests();
+        var route = new SwapRoute(
+            SwapAsset.BtcLightning,
+            SwapAsset.Erc20(SwapNetwork.EvmPolygon, "0xusdc"));
+        Assert.That(provider.SupportsRoute(route), Is.True);
+    }
+
+    [Test]
+    public void SupportsRoute_BtcOnchainToEvmEthereum_True()
+    {
+        var provider = CreateProviderForRouteTests();
+        var route = new SwapRoute(
+            SwapAsset.BtcOnchain,
+            SwapAsset.Erc20(SwapNetwork.EvmEthereum, "0xusdt"));
+        Assert.That(provider.SupportsRoute(route), Is.True);
+    }
+
+    [Test]
+    public void SupportsRoute_ArkToArk_False()
+    {
+        var provider = CreateProviderForRouteTests();
+        var route = new SwapRoute(
+            SwapAsset.ArkBtc,
+            SwapAsset.ArkBtc);
         Assert.That(provider.SupportsRoute(route), Is.False);
     }
 

--- a/NArk.Tests/LendaSwapClientTests.cs
+++ b/NArk.Tests/LendaSwapClientTests.cs
@@ -1,0 +1,531 @@
+using System.Net;
+using Microsoft.Extensions.Options;
+using NArk.Swaps.Abstractions;
+using NArk.Swaps.LendaSwap;
+using NArk.Swaps.LendaSwap.Client;
+using NArk.Swaps.LendaSwap.Models;
+using NArk.Swaps.Models;
+
+namespace NArk.Tests;
+
+[TestFixture]
+public class LendaSwapClientTests
+{
+    private const string BaseUrl = "https://api.lendaswap.com";
+
+    // ─── MockHttpHandler ───────────────────────────────────────
+
+    private class MockHttpHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _statusCode;
+        private readonly string _responseBody;
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        public MockHttpHandler(HttpStatusCode statusCode, string responseBody)
+        {
+            _statusCode = statusCode;
+            _responseBody = responseBody;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken ct)
+        {
+            LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent(_responseBody, System.Text.Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    private static LendaSwapClient CreateClient(
+        MockHttpHandler handler, string? apiKey = null)
+    {
+        var httpClient = new HttpClient(handler);
+        var options = Options.Create(new LendaSwapOptions
+        {
+            ApiUrl = BaseUrl,
+            ApiKey = apiKey
+        });
+        return new LendaSwapClient(httpClient, options);
+    }
+
+    // ─── GetTokensAsync ────────────────────────────────────────
+
+    [Test]
+    public async Task GetTokensAsync_DeserializesResponse()
+    {
+        const string json = """
+        {
+            "btc_tokens": [
+                {"token_id": "btc", "symbol": "BTC", "name": "Bitcoin", "decimals": 8, "chain": "Bitcoin"}
+            ],
+            "evm_tokens": [
+                {"token_id": "0x3c499c", "symbol": "USDC", "name": "USD Coin", "decimals": 6, "chain": "137"}
+            ]
+        }
+        """;
+
+        var handler = new MockHttpHandler(HttpStatusCode.OK, json);
+        var client = CreateClient(handler);
+
+        var result = await client.GetTokensAsync();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.BtcTokens, Has.Count.EqualTo(1));
+        Assert.That(result.BtcTokens[0].TokenId, Is.EqualTo("btc"));
+        Assert.That(result.BtcTokens[0].Symbol, Is.EqualTo("BTC"));
+        Assert.That(result.BtcTokens[0].Decimals, Is.EqualTo(8));
+        Assert.That(result.BtcTokens[0].Chain, Is.EqualTo("Bitcoin"));
+        Assert.That(result.EvmTokens, Has.Count.EqualTo(1));
+        Assert.That(result.EvmTokens[0].TokenId, Is.EqualTo("0x3c499c"));
+        Assert.That(result.EvmTokens[0].Symbol, Is.EqualTo("USDC"));
+        Assert.That(result.EvmTokens[0].Chain, Is.EqualTo("137"));
+
+        Assert.That(handler.LastRequest!.RequestUri!.PathAndQuery, Is.EqualTo("/tokens"));
+    }
+
+    // ─── GetQuoteAsync ─────────────────────────────────────────
+
+    [Test]
+    public async Task GetQuoteAsync_SendsCorrectQueryParams()
+    {
+        const string json = """
+        {
+            "exchange_rate": "96500.00",
+            "protocol_fee": 250,
+            "protocol_fee_rate": 0.0025,
+            "network_fee": 150,
+            "gasless_network_fee": 50,
+            "source_amount": 100000,
+            "target_amount": 96100,
+            "min_amount": 10000,
+            "max_amount": 10000000
+        }
+        """;
+
+        var handler = new MockHttpHandler(HttpStatusCode.OK, json);
+        var client = CreateClient(handler);
+
+        var result = await client.GetQuoteAsync(
+            "Bitcoin", "btc", "Arkade", "btc", sourceAmount: 100000);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.ExchangeRate, Is.EqualTo("96500.00"));
+        Assert.That(result.ProtocolFee, Is.EqualTo(250));
+        Assert.That(result.ProtocolFeeRate, Is.EqualTo(0.0025m));
+        Assert.That(result.NetworkFee, Is.EqualTo(150));
+        Assert.That(result.SourceAmount, Is.EqualTo(100000));
+        Assert.That(result.TargetAmount, Is.EqualTo(96100));
+        Assert.That(result.MinAmount, Is.EqualTo(10000));
+        Assert.That(result.MaxAmount, Is.EqualTo(10000000));
+
+        var uri = handler.LastRequest!.RequestUri!;
+        Assert.That(uri.PathAndQuery, Does.Contain("source_chain=Bitcoin"));
+        Assert.That(uri.PathAndQuery, Does.Contain("source_token=btc"));
+        Assert.That(uri.PathAndQuery, Does.Contain("target_chain=Arkade"));
+        Assert.That(uri.PathAndQuery, Does.Contain("target_token=btc"));
+        Assert.That(uri.PathAndQuery, Does.Contain("source_amount=100000"));
+    }
+
+    [Test]
+    public async Task GetQuoteAsync_OmitsNullAmountParams()
+    {
+        const string json = """
+        {
+            "exchange_rate": "1.00",
+            "protocol_fee": 0,
+            "protocol_fee_rate": 0,
+            "network_fee": 0,
+            "gasless_network_fee": 0,
+            "source_amount": 0,
+            "target_amount": 0,
+            "min_amount": 0,
+            "max_amount": 0
+        }
+        """;
+
+        var handler = new MockHttpHandler(HttpStatusCode.OK, json);
+        var client = CreateClient(handler);
+
+        await client.GetQuoteAsync("Arkade", "btc", "137", "0x3c499c");
+
+        var query = handler.LastRequest!.RequestUri!.Query;
+        Assert.That(query, Does.Not.Contain("source_amount"));
+        Assert.That(query, Does.Not.Contain("target_amount"));
+    }
+
+    // ─── CreateBtcToArkadeSwapAsync ────────────────────────────
+
+    [Test]
+    public async Task CreateBtcToArkadeSwapAsync_DeserializesResponse()
+    {
+        const string json = """
+        {
+            "id": "swap-123",
+            "status": "pending",
+            "btc_htlc_address": "bc1qexample",
+            "arkade_vhtlc_address": "tark1qexample",
+            "source_amount": 100000,
+            "target_amount": 96100,
+            "protocol_fee": 250,
+            "network_fee": 150,
+            "created_at": "2026-02-27T12:00:00Z",
+            "expires_at": "2026-02-27T13:00:00Z",
+            "btc_locktime": 144,
+            "arkade_locktime": 72,
+            "hash_lock": "abc123",
+            "server_pk": "02def456"
+        }
+        """;
+
+        var handler = new MockHttpHandler(HttpStatusCode.OK, json);
+        var client = CreateClient(handler);
+
+        var request = new CreateBtcToArkadeRequest
+        {
+            ClaimPk = "02aabbcc",
+            HashLock = "abc123",
+            RefundPk = "02ddeeff",
+            SatsReceive = 96100,
+            TargetArkadeAddress = "tark1qexample",
+            UserId = "user-1"
+        };
+
+        var result = await client.CreateBtcToArkadeSwapAsync(request);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Id, Is.EqualTo("swap-123"));
+        Assert.That(result.Status, Is.EqualTo("pending"));
+        Assert.That(result.BtcHtlcAddress, Is.EqualTo("bc1qexample"));
+        Assert.That(result.ArkadeVhtlcAddress, Is.EqualTo("tark1qexample"));
+        Assert.That(result.SourceAmount, Is.EqualTo(100000));
+        Assert.That(result.TargetAmount, Is.EqualTo(96100));
+        Assert.That(result.ProtocolFee, Is.EqualTo(250));
+        Assert.That(result.NetworkFee, Is.EqualTo(150));
+        Assert.That(result.BtcLocktime, Is.EqualTo(144));
+        Assert.That(result.ArkadeLocktime, Is.EqualTo(72));
+        Assert.That(result.HashLock, Is.EqualTo("abc123"));
+        Assert.That(result.ServerPk, Is.EqualTo("02def456"));
+
+        Assert.That(handler.LastRequest!.RequestUri!.PathAndQuery, Is.EqualTo("/swap/bitcoin/arkade"));
+        Assert.That(handler.LastRequest.Method, Is.EqualTo(HttpMethod.Post));
+    }
+
+    // ─── GetSwapStatusAsync ────────────────────────────────────
+
+    [Test]
+    public async Task GetSwapStatusAsync_DeserializesResponse()
+    {
+        const string json = """
+        {
+            "id": "swap-456",
+            "status": "clientredeemed",
+            "source_amount": 50000,
+            "target_amount": 48000,
+            "protocol_fee": 125,
+            "network_fee": 75
+        }
+        """;
+
+        var handler = new MockHttpHandler(HttpStatusCode.OK, json);
+        var client = CreateClient(handler);
+
+        var result = await client.GetSwapStatusAsync("swap-456");
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Id, Is.EqualTo("swap-456"));
+        Assert.That(result.Status, Is.EqualTo("clientredeemed"));
+
+        Assert.That(handler.LastRequest!.RequestUri!.PathAndQuery, Is.EqualTo("/swap/swap-456"));
+        Assert.That(handler.LastRequest.Method, Is.EqualTo(HttpMethod.Get));
+    }
+
+    // ─── API Key Header ────────────────────────────────────────
+
+    [Test]
+    public async Task ApiKeyHeader_SentWhenConfigured()
+    {
+        const string json = """{ "btc_tokens": [], "evm_tokens": [] }""";
+        var handler = new MockHttpHandler(HttpStatusCode.OK, json);
+        var client = CreateClient(handler, apiKey: "test-api-key-123");
+
+        await client.GetTokensAsync();
+
+        Assert.That(handler.LastRequest!.Headers.Contains("X-API-Key"), Is.True);
+        Assert.That(
+            handler.LastRequest.Headers.GetValues("X-API-Key").First(),
+            Is.EqualTo("test-api-key-123"));
+    }
+
+    [Test]
+    public async Task ApiKeyHeader_NotSentWhenNotConfigured()
+    {
+        const string json = """{ "btc_tokens": [], "evm_tokens": [] }""";
+        var handler = new MockHttpHandler(HttpStatusCode.OK, json);
+        var client = CreateClient(handler, apiKey: null);
+
+        await client.GetTokensAsync();
+
+        Assert.That(handler.LastRequest!.Headers.Contains("X-API-Key"), Is.False);
+    }
+
+    // ─── HTTP Error Handling ───────────────────────────────────
+
+    [Test]
+    public void CreateBtcToArkadeSwapAsync_ThrowsOnHttpError()
+    {
+        const string errorJson = """{ "error": "invalid_request", "message": "hash_lock is required" }""";
+        var handler = new MockHttpHandler(HttpStatusCode.BadRequest, errorJson);
+        var client = CreateClient(handler);
+
+        var request = new CreateBtcToArkadeRequest
+        {
+            ClaimPk = "02aabbcc",
+            HashLock = "",
+            RefundPk = "02ddeeff",
+            SatsReceive = 100,
+            TargetArkadeAddress = "tark1q",
+            UserId = "user-1"
+        };
+
+        var ex = Assert.ThrowsAsync<HttpRequestException>(
+            () => client.CreateBtcToArkadeSwapAsync(request));
+        Assert.That(ex!.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+    }
+
+    // ─── Status Mapping ────────────────────────────────────────
+
+    [TestCase("pending", ArkSwapStatus.Pending)]
+    [TestCase("clientfundingseen", ArkSwapStatus.Pending)]
+    [TestCase("clientfunded", ArkSwapStatus.Pending)]
+    [TestCase("serverfunded", ArkSwapStatus.Pending)]
+    [TestCase("clientredeeming", ArkSwapStatus.Pending)]
+    [TestCase("clientredeemed", ArkSwapStatus.Settled)]
+    [TestCase("serverredeemed", ArkSwapStatus.Settled)]
+    [TestCase("clientrefunded", ArkSwapStatus.Refunded)]
+    [TestCase("clientrefundedserverfunded", ArkSwapStatus.Refunded)]
+    [TestCase("clientrefundedserverrefunded", ArkSwapStatus.Refunded)]
+    [TestCase("expired", ArkSwapStatus.Failed)]
+    [TestCase("clientinvalidfunded", ArkSwapStatus.Failed)]
+    [TestCase("clientfundedtoolate", ArkSwapStatus.Failed)]
+    [TestCase("clientfundedserverrefunded", ArkSwapStatus.Failed)]
+    [TestCase("clientredeemedandclientrefunded", ArkSwapStatus.Failed)]
+    [TestCase("some_unknown_status", ArkSwapStatus.Unknown)]
+    public void MapLendaSwapStatus_MapsCorrectly(string apiStatus, ArkSwapStatus expected)
+    {
+        var result = LendaSwapProvider.MapLendaSwapStatus(apiStatus);
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    // ─── Chain / Network Mapping ───────────────────────────────
+
+    [TestCase("Arkade", SwapNetwork.Ark)]
+    [TestCase("Bitcoin", SwapNetwork.BitcoinOnchain)]
+    [TestCase("Lightning", SwapNetwork.Lightning)]
+    [TestCase("1", SwapNetwork.EvmEthereum)]
+    [TestCase("137", SwapNetwork.EvmPolygon)]
+    [TestCase("42161", SwapNetwork.EvmArbitrum)]
+    public void MapChainToNetwork_MapsKnownChains(string chain, SwapNetwork expected)
+    {
+        var result = LendaSwapProvider.MapChainToNetwork(chain);
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void MapChainToNetwork_ReturnsNullForUnknown()
+    {
+        var result = LendaSwapProvider.MapChainToNetwork("SomeUnknownChain");
+        Assert.That(result, Is.Null);
+    }
+
+    // ─── Route Mapping ─────────────────────────────────────────
+
+    [Test]
+    public void MapRouteToApiParams_BtcToArk()
+    {
+        var route = new SwapRoute(
+            SwapAsset.BtcOnchain,
+            SwapAsset.ArkBtc);
+
+        var (sourceChain, sourceToken, targetChain, targetToken) =
+            LendaSwapProvider.MapRouteToApiParams(route);
+
+        Assert.That(sourceChain, Is.EqualTo("Bitcoin"));
+        Assert.That(sourceToken, Is.EqualTo("btc"));
+        Assert.That(targetChain, Is.EqualTo("Arkade"));
+        Assert.That(targetToken, Is.EqualTo("btc"));
+    }
+
+    [Test]
+    public void MapRouteToApiParams_ArkToEvmPolygon()
+    {
+        var route = new SwapRoute(
+            SwapAsset.ArkBtc,
+            SwapAsset.Erc20(SwapNetwork.EvmPolygon, "0x3c499c"));
+
+        var (sourceChain, sourceToken, targetChain, targetToken) =
+            LendaSwapProvider.MapRouteToApiParams(route);
+
+        Assert.That(sourceChain, Is.EqualTo("Arkade"));
+        Assert.That(sourceToken, Is.EqualTo("btc"));
+        Assert.That(targetChain, Is.EqualTo("137"));
+        Assert.That(targetToken, Is.EqualTo("0x3c499c"));
+    }
+
+    // ─── Route Support ─────────────────────────────────────────
+
+    [Test]
+    public void SupportsRoute_BtcToArk_True()
+    {
+        var provider = CreateProviderForRouteTests();
+        var route = new SwapRoute(
+            SwapAsset.BtcOnchain,
+            SwapAsset.ArkBtc);
+        Assert.That(provider.SupportsRoute(route), Is.True);
+    }
+
+    [Test]
+    public void SupportsRoute_ArkToEvmPolygon_True()
+    {
+        var provider = CreateProviderForRouteTests();
+        var route = new SwapRoute(
+            SwapAsset.ArkBtc,
+            SwapAsset.Erc20(SwapNetwork.EvmPolygon, "0xusdc"));
+        Assert.That(provider.SupportsRoute(route), Is.True);
+    }
+
+    [Test]
+    public void SupportsRoute_EvmArbitrumToArk_True()
+    {
+        var provider = CreateProviderForRouteTests();
+        var route = new SwapRoute(
+            SwapAsset.Erc20(SwapNetwork.EvmArbitrum, "0xusdc"),
+            SwapAsset.ArkBtc);
+        Assert.That(provider.SupportsRoute(route), Is.True);
+    }
+
+    [Test]
+    public void SupportsRoute_LightningToArk_False()
+    {
+        var provider = CreateProviderForRouteTests();
+        var route = new SwapRoute(
+            SwapAsset.BtcLightning,
+            SwapAsset.ArkBtc);
+        Assert.That(provider.SupportsRoute(route), Is.False);
+    }
+
+    [Test]
+    public void SupportsRoute_ArkToLightning_False()
+    {
+        var provider = CreateProviderForRouteTests();
+        var route = new SwapRoute(
+            SwapAsset.ArkBtc,
+            SwapAsset.BtcLightning);
+        Assert.That(provider.SupportsRoute(route), Is.False);
+    }
+
+    // ─── CreateArkadeToEvmSwapAsync ─────────────────────────────
+
+    [Test]
+    public async Task CreateArkadeToEvmSwapAsync_DeserializesResponse()
+    {
+        const string json = """
+        {
+            "id": "swap-789",
+            "status": "pending",
+            "evm_htlc_address": "0xhtlccontract",
+            "arkade_vhtlc_address": "tark1qswap",
+            "source_amount": 200000,
+            "target_amount": 19300,
+            "protocol_fee": 500,
+            "network_fee": 200,
+            "evm_chain_id": "137",
+            "token_address": "0x3c499c"
+        }
+        """;
+
+        var handler = new MockHttpHandler(HttpStatusCode.OK, json);
+        var client = CreateClient(handler);
+
+        var request = new CreateArkadeToEvmRequest
+        {
+            HashLock = "hash123",
+            RefundPk = "02refund",
+            ClaimingAddress = "tark1qclaim",
+            TargetAddress = "0xevmaddress",
+            TokenAddress = "0x3c499c",
+            EvmChainId = "137",
+            UserId = "user-2",
+            AmountIn = 200000
+        };
+
+        var result = await client.CreateArkadeToEvmSwapAsync(request);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Id, Is.EqualTo("swap-789"));
+        Assert.That(result.Status, Is.EqualTo("pending"));
+        Assert.That(result.EvmHtlcAddress, Is.EqualTo("0xhtlccontract"));
+        Assert.That(result.EvmChainId, Is.EqualTo("137"));
+        Assert.That(result.TokenAddress, Is.EqualTo("0x3c499c"));
+
+        Assert.That(handler.LastRequest!.RequestUri!.PathAndQuery, Is.EqualTo("/swap/arkade/evm"));
+        Assert.That(handler.LastRequest.Method, Is.EqualTo(HttpMethod.Post));
+    }
+
+    // ─── CreateEvmToArkadeSwapAsync ─────────────────────────────
+
+    [Test]
+    public async Task CreateEvmToArkadeSwapAsync_DeserializesResponse()
+    {
+        const string json = """
+        {
+            "id": "swap-evm2ark",
+            "status": "pending",
+            "evm_htlc_address": "0xhtlc2",
+            "arkade_vhtlc_address": "tark1qreceive",
+            "source_amount": 20000,
+            "target_amount": 190000,
+            "protocol_fee": 300,
+            "network_fee": 100
+        }
+        """;
+
+        var handler = new MockHttpHandler(HttpStatusCode.OK, json);
+        var client = CreateClient(handler);
+
+        var request = new CreateEvmToArkadeRequest
+        {
+            HashLock = "hash456",
+            ReceiverPk = "02receiver",
+            TargetAddress = "tark1qreceive",
+            TokenAddress = "0xusdc",
+            EvmChainId = "1",
+            UserAddress = "0xuser",
+            UserId = "user-3",
+            AmountIn = 20000
+        };
+
+        var result = await client.CreateEvmToArkadeSwapAsync(request);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result.Id, Is.EqualTo("swap-evm2ark"));
+        Assert.That(result.Status, Is.EqualTo("pending"));
+
+        Assert.That(handler.LastRequest!.RequestUri!.PathAndQuery, Is.EqualTo("/swap/evm/arkade"));
+        Assert.That(handler.LastRequest.Method, Is.EqualTo(HttpMethod.Post));
+    }
+
+    // ─── Helper ────────────────────────────────────────────────
+
+    private static LendaSwapProvider CreateProviderForRouteTests()
+    {
+        // Create a minimal provider just for route testing — swap storage is mocked with NSubstitute
+        var handler = new MockHttpHandler(HttpStatusCode.OK, "{}");
+        var httpClient = new HttpClient(handler);
+        var options = Options.Create(new LendaSwapOptions { ApiUrl = BaseUrl });
+        var client = new LendaSwapClient(httpClient, options);
+        var swapStorage = NSubstitute.Substitute.For<ISwapStorage>();
+        return new LendaSwapProvider(client, swapStorage);
+    }
+}

--- a/NArk.Tests/Swaps/SwapRoutingTests.cs
+++ b/NArk.Tests/Swaps/SwapRoutingTests.cs
@@ -243,6 +243,6 @@ public class SwapRoutingTests
             contractStorage: Substitute.For<IContractStorage>(),
             safetyService: Substitute.For<ISafetyService>(),
             intentStorage: Substitute.For<IIntentStorage>(),
-            chainTimeProvider: Substitute.For<IChainTimeProvider>());
+            chainTimeProvider: Substitute.For<IBitcoinBlockchain>());
     }
 }

--- a/NArk.Tests/Swaps/SwapRoutingTests.cs
+++ b/NArk.Tests/Swaps/SwapRoutingTests.cs
@@ -128,8 +128,9 @@ public class SwapRoutingTests
     {
         _sut = BuildService(_providerA, _providerB);
 
-        // Neither test provider declares BtcOnchain<->BtcLightning support.
-        var unsupportedRoute = new SwapRoute(SwapAsset.BtcOnchain, SwapAsset.BtcLightning);
+        var unsupportedRoute = new SwapRoute(
+            SwapAsset.Erc20(SwapNetwork.EvmEthereum, "0xdead"),
+            SwapAsset.ArkBtc);
 
         var ex = Assert.Throws<InvalidOperationException>(() =>
             _sut.ResolveProvider(unsupportedRoute));
@@ -242,6 +243,6 @@ public class SwapRoutingTests
             contractStorage: Substitute.For<IContractStorage>(),
             safetyService: Substitute.For<ISafetyService>(),
             intentStorage: Substitute.For<IIntentStorage>(),
-            chainTimeProvider: Substitute.For<IBitcoinBlockchain>());
+            chainTimeProvider: Substitute.For<IChainTimeProvider>());
     }
 }


### PR DESCRIPTION
## LendaSwap provider (v0.2.34) on the multi-provider swap framework

Adds [LendaSwap](https://github.com/satoraHQ/lendaswap-sdk) as a second `ISwapProvider` alongside Boltz, extending the swap router to cover Ark↔EVM (Ethereum / Polygon / Arbitrum), Ark↔BTC-onchain, and Lightning↔EVM routes that Boltz doesn't cover.

### What's in the branch

- **HTTP client** (`NArk.Swaps/LendaSwap/Client/`): typed `LendaSwapClient` with `Quotes` / `Swaps` / `Status` partials covering the three live endpoints (`POST /api/vtxo-swap`, `GET /api/vtxo-swap/{id}`, `GET /api/vtxo-swap/estimate`).
- **Provider** (`LendaSwapProvider`): implements `ISwapProvider`, routes Ark↔EVM/BTC/LN, polls active swaps every 30s, raises `SwapStatusChangedEvent` on transitions, maps LendaSwap status strings to `ArkSwapStatus`.
- **Routing extensions**: `SwapAsset.Erc20(chain, contractAddress)` factory + `SwapNetwork.EvmEthereum`/`EvmPolygon`/`EvmArbitrum` enum values (additive — master's `BoltzSwapProvider` is unaffected).
- **DI**: `AddLendaSwapProvider(Action<LendaSwapOptions>?)` extension on `SwapServiceCollectionExtensions`.
- **Tests**: unit tests for `LendaSwapClient` (mocked HTTP) + `SwapRouting`; E2E tests with server-availability gating so they're skipped when the LendaSwap server is offline.

### Rebased onto current master (was 33 commits behind)

The branch was originally proposed before the multi-provider architecture (PR #79) landed. The foundational pieces — `SwapNetwork`/`SwapAsset`/`ISwapProvider`/the `BoltzSwapProvider` + `SwapsManagementService` refactor — were already extracted and merged. This rebase keeps **only the LendaSwap-specific commits** (8 commits) and reconciles them with master's modern API:

- `LendaSwapProvider.StartAsync` updated to the new `(CancellationToken)` signature.
- Removed dead `CreateSwapAsync` / `RefundSwapAsync` overrides (the interface drops them).
- Test mocks updated from `IChainTimeProvider` → `IBitcoinBlockchain` (the unified blockchain abstraction master adopted via #53).

### Brought up to LendaSwap SDK v0.2.34

Three upstream changes since v0.2.31 (when this branch was last touched against) are reflected:

1. **`extra_fees` (v0.2.33)** — optional per-swap surcharge in basis points (0..max_extra_fee_bps configured on the matching developer key on the LendaSwap side). Added as a nullable `int? ExtraFees` on **all 10 `Create*Request` DTOs** + as an optional `extraFees:` parameter on `LendaSwapClient.GetQuoteAsync`.
2. **`referral_code` (v0.2.34)** — wire field renamed from `reflink_code`. All request DTOs renamed `ReflinkCode` → `ReferralCode` (with the `referral_code` JSON wire name). `LendaSwapOptions.ReferralCode` is the canonical client-level default; `ReflinkCode` retained as `[Obsolete]` alias mirroring the ts-sdk's `withOrgCode` deprecation-not-removal policy.
3. **Detailed API status (v0.2.32)** — the existing status response already exposes the per-swap status string we consume; no additional client surface required for the integration.

The PR description used to cite v0.2.20 — that tag is gone from upstream history (releases were rewritten); current is v0.2.34, and the branch is now pinned to it.

### Test plan

- [x] `dotnet build` clean across `NArk.Swaps`, `NArk.Tests`, `NArk.Tests.End2End`.
- [x] **437/437 unit tests pass** locally (`dotnet test NArk.Tests`).
- [ ] CI green on the rebased commit (`1013cde`).
- [ ] E2E green when the LendaSwap test server is available (the suite gates on server availability and skips otherwise).
