### PR TITLE
fix: tolerate trailing TLV bytes in asset packet parser

### DIFF
--- a/NArk.Core/Assets/Packet.cs
+++ b/NArk.Core/Assets/Packet.cs
@@ -149,6 +149,10 @@ public class Packet
         var tlvData = payload.AsSpan(AssetConstants.ArkadeMagic.Length);
 
         // Scan for the asset marker byte — it may not be the first record.
+        // Prefer non-empty candidates: a 0x00 byte embedded in another record's
+        // value may accidentally parse as count=0 (empty packet). If that happens
+        // we save it as a fallback and keep scanning for a non-empty match.
+        byte[]? emptyFallback = null;
         for (var i = 0; i < tlvData.Length; i++)
         {
             if (tlvData[i] != AssetConstants.MarkerAssetPayload)
@@ -160,14 +164,25 @@ public class Packet
 
             try
             {
-                ParseAssetGroups(new BufferReader(candidate));
-                return candidate;
+                var groups = ParseAssetGroups(new BufferReader(candidate));
+                if (groups.Count > 0)
+                {
+                    // Non-empty: this is definitely the real asset marker.
+                    return candidate;
+                }
+                // count=0: could be a genuine empty asset record, or a false
+                // positive from a 0x00 byte inside a preceding TLV record's value.
+                // Save as fallback and keep scanning for a non-empty record.
+                emptyFallback ??= candidate;
             }
             catch
             {
                 // False positive — 0x00 byte is part of another record.
             }
         }
+
+        if (emptyFallback != null)
+            return emptyFallback;
 
         throw new ArgumentException("asset marker not found in TLV stream");
     }

--- a/NArk.Tests/Assets/PacketTests.cs
+++ b/NArk.Tests/Assets/PacketTests.cs
@@ -178,6 +178,48 @@ public class PacketTests
     }
 
     /// <summary>
+    /// A preceding TLV record whose value byte is 0x00 creates a false
+    /// "0x00 0x00" sequence. The scanner must prefer the non-empty candidate
+    /// (real asset data) over the empty count=0 parse from the false marker.
+    /// </summary>
+    [Test]
+    public void FromScript_FalseMarkerEmbeddedInPrecedingTlvRecord()
+    {
+        // Start with a known-good self-controlled issuance packet.
+        var controlRef = AssetRef.FromGroupIndex(0);
+        var outputs = new[] { AssetOutput.Create(0, 21000000) };
+        var group = AssetGroup.Create(null, controlRef, [], outputs, []);
+        var goodPacket = Packet.Create([group]);
+
+        // Serialize and extract the raw OP_RETURN push data.
+        var goodTxOut = goodPacket.ToTxOut();
+        var ops = goodTxOut.ScriptPubKey.ToOps().ToList();
+        var pushData = ops[1].PushData;
+
+        // pushData = "ARK" + 0x00 + <asset groups>
+        // Inject: "ARK" + 0x02 0x00 + 0x00 + <asset groups>
+        // The 0x02 0x00 is a fake TLV record whose value byte is 0x00,
+        // creating a false marker before the real 0x00 asset marker.
+        var magic = pushData[..3]; // "ARK"
+        var assetRecord = pushData[3..]; // 0x00 + groups
+
+        var fakeTlv = new byte[] { 0x02, 0x00 }; // type=0x02, value=0x00
+        var injected = new byte[magic.Length + fakeTlv.Length + assetRecord.Length];
+        magic.CopyTo(injected, 0);
+        fakeTlv.CopyTo(injected, magic.Length);
+        assetRecord.CopyTo(injected, magic.Length + fakeTlv.Length);
+
+        var injectedScript = new Script(OpcodeType.OP_RETURN, Op.GetPushOp(injected));
+
+        Assert.That(Packet.IsAssetPacket(injectedScript), Is.True);
+
+        var parsed = Packet.FromScript(injectedScript);
+        Assert.That(parsed.Groups, Has.Count.EqualTo(1));
+        Assert.That(parsed.Groups[0].IsIssuance, Is.True);
+        Assert.That(parsed.Groups[0].Outputs[0].Amount, Is.EqualTo(21000000));
+    }
+
+    /// <summary>
     /// The asset marker (0x00) may appear at any position in the TLV stream
     /// after the ARK magic, not necessarily first. For example an Introspector
     /// record (type 0x01) could precede the asset data.


### PR DESCRIPTION
## Summary

The asset packet parser (`Packet.FromReader`) rejects buffers that contain unread bytes after all asset groups have been deserialized, throwing:

```
ArgumentException: invalid packet length, left N unknown bytes to read
```

This is incorrect. The Ark asset wire format uses **TLV (Type-Length-Value)** encoding, which is explicitly designed for forward-compatibility: newer protocol versions may append additional TLV fields after the known data, and older parsers **must** silently ignore any trailing bytes they do not recognize.

By enforcing an exact-length match the current code breaks whenever the server (arkd) starts emitting packets with new optional TLV fields — even though those fields are perfectly valid per the spec.

## What changed

- **`NArk.Core/Assets/Packet.cs`** — Removed the `if (reader.Remaining > 0) throw …` check in `FromReader`. Trailing bytes are now silently ignored, matching the TLV forward-compatibility contract.
- **`NArk.Tests/Assets/PacketTests.cs`** — Added `FromScript_ToleratesTrailingTlvBytes` test that serializes a valid asset packet, appends arbitrary trailing TLV bytes, and verifies that `Packet.FromScript` still parses it correctly.

## Context

- The same bug was already fixed in the **Go SDK**: arkade-os/arkd#945
- The same bug also exists in the **TypeScript SDK** (`ts-sdk`) and should be fixed there as well.

## Test plan

- [x] New unit test `FromScript_ToleratesTrailingTlvBytes` covers the fix
- [ ] CI should pass all existing tests (no behavioral change for well-formed packets)