### PR TITLE
fix: prevent shared wallet address collisions on reimport

### DIFF
--- a/NArk.Storage.EfCore/Storage/EfCoreWalletStorage.cs
+++ b/NArk.Storage.EfCore/Storage/EfCoreWalletStorage.cs
@@ -56,7 +56,7 @@ public class EfCoreWalletStorage : IWalletStorage
         if (existing != null)
         {
             existing.Wallet = wallet.Secret;
-            existing.LastUsedIndex = wallet.LastUsedIndex;
+            existing.LastUsedIndex = Math.Max(existing.LastUsedIndex, wallet.LastUsedIndex);
             if (!string.IsNullOrEmpty(wallet.AccountDescriptor))
                 existing.AccountDescriptor ??= wallet.AccountDescriptor;
         }
@@ -120,7 +120,7 @@ public class EfCoreWalletStorage : IWalletStorage
             existing.WalletDestination = wallet.Destination;
             existing.WalletType = wallet.WalletType;
             existing.AccountDescriptor = wallet.AccountDescriptor;
-            existing.LastUsedIndex = wallet.LastUsedIndex;
+            existing.LastUsedIndex = Math.Max(existing.LastUsedIndex, wallet.LastUsedIndex);
             inserted = false;
         }
         else


### PR DESCRIPTION
## Summary

When the same mnemonic is imported into a second BTCPay Server store (using the arkade plugin), `UpsertWallet` and `SaveWallet` overwrote `LastUsedIndex` with 0 (fresh import), resetting the derivation counter. This caused the next `DeriveContract` call to re-derive addresses that were already in use, resulting in a `duplicate key` violation on BTCPay's `AddressInvoices` table and crashing the plugin.

 ## Fix

`Math.Max(existing.LastUsedIndex, wallet.LastUsedIndex)` in both methods ensures  the index never goes backwards.