### PR TITLE
test: add EfCoreWalletStorage tests for LastUsedIndex regression

### DIFF
--- a/NArk.Storage.EfCore/Storage/EfCoreWalletStorage.cs
+++ b/NArk.Storage.EfCore/Storage/EfCoreWalletStorage.cs
@@ -56,7 +56,7 @@ public class EfCoreWalletStorage : IWalletStorage
         if (existing != null)
         {
             existing.Wallet = wallet.Secret;
-            existing.LastUsedIndex = wallet.LastUsedIndex;
+            existing.LastUsedIndex = Math.Max(existing.LastUsedIndex, wallet.LastUsedIndex);
             if (!string.IsNullOrEmpty(wallet.AccountDescriptor))
                 existing.AccountDescriptor ??= wallet.AccountDescriptor;
         }
@@ -120,7 +120,7 @@ public class EfCoreWalletStorage : IWalletStorage
             existing.WalletDestination = wallet.Destination;
             existing.WalletType = wallet.WalletType;
             existing.AccountDescriptor = wallet.AccountDescriptor;
-            existing.LastUsedIndex = wallet.LastUsedIndex;
+            existing.LastUsedIndex = Math.Max(existing.LastUsedIndex, wallet.LastUsedIndex);
             inserted = false;
         }
         else

--- a/NArk.Tests/EfCoreWalletStorageTests.cs
+++ b/NArk.Tests/EfCoreWalletStorageTests.cs
@@ -1,0 +1,108 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NArk.Abstractions.Wallets;
+using NArk.Storage.EfCore;
+using NArk.Storage.EfCore.Storage;
+
+namespace NArk.Tests;
+
+[TestFixture]
+public class EfCoreWalletStorageTests
+{
+    private SqliteConnection _connection = null!;
+    private DbContextOptions<TestArkDbContext> _dbOptions;
+    private EfCoreWalletStorage _storage = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<TestArkDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        using var ctx = new TestArkDbContext(_dbOptions);
+        ctx.Database.EnsureCreated();
+
+        _storage = new EfCoreWalletStorage(new TestArkDbContextFactory(_dbOptions));
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _connection.Dispose();
+    }
+
+    [Test]
+    public async Task SaveWallet_DoesNotResetLastUsedIndex_WhenExistingIndexIsHigher()
+    {
+        var wallet = MakeWallet("w1", lastUsedIndex: 10);
+        await _storage.SaveWallet(wallet);
+
+        // Re-import same wallet with lower index (simulates shared mnemonic reimport)
+        var reimported = wallet with { LastUsedIndex = 0 };
+        await _storage.SaveWallet(reimported);
+
+        var loaded = await _storage.GetWalletById("w1");
+        Assert.That(loaded!.LastUsedIndex, Is.EqualTo(10));
+    }
+
+    [Test]
+    public async Task SaveWallet_AdvancesLastUsedIndex_WhenNewIndexIsHigher()
+    {
+        var wallet = MakeWallet("w1", lastUsedIndex: 5);
+        await _storage.SaveWallet(wallet);
+
+        var updated = wallet with { LastUsedIndex = 12 };
+        await _storage.SaveWallet(updated);
+
+        var loaded = await _storage.GetWalletById("w1");
+        Assert.That(loaded!.LastUsedIndex, Is.EqualTo(12));
+    }
+
+    [Test]
+    public async Task UpsertWallet_DoesNotResetLastUsedIndex_WhenExistingIndexIsHigher()
+    {
+        var wallet = MakeWallet("w1", lastUsedIndex: 10);
+        await _storage.UpsertWallet(wallet);
+
+        var reimported = wallet with { LastUsedIndex = 0 };
+        await _storage.UpsertWallet(reimported);
+
+        var loaded = await _storage.GetWalletById("w1");
+        Assert.That(loaded!.LastUsedIndex, Is.EqualTo(10));
+    }
+
+    [Test]
+    public async Task UpsertWallet_AdvancesLastUsedIndex_WhenNewIndexIsHigher()
+    {
+        var wallet = MakeWallet("w1", lastUsedIndex: 5);
+        await _storage.UpsertWallet(wallet);
+
+        var updated = wallet with { LastUsedIndex = 12 };
+        await _storage.UpsertWallet(updated);
+
+        var loaded = await _storage.GetWalletById("w1");
+        Assert.That(loaded!.LastUsedIndex, Is.EqualTo(12));
+    }
+
+    private static ArkWalletInfo MakeWallet(string id, int lastUsedIndex = 0) =>
+        new(id, "secret-" + id, null, WalletType.HD, null, lastUsedIndex);
+
+    /// <summary>
+    /// Minimal DbContext that registers the Ark entity model for testing.
+    /// </summary>
+    private class TestArkDbContext(DbContextOptions<TestArkDbContext> options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.ConfigureArkEntities();
+    }
+
+    private class TestArkDbContextFactory(DbContextOptions<TestArkDbContext> options) : IArkDbContextFactory
+    {
+        public Task<DbContext> CreateDbContextAsync(CancellationToken ct = default)
+            => Task.FromResult<DbContext>(new TestArkDbContext(options));
+    }
+}

--- a/NArk.Tests/NArk.Tests.csproj
+++ b/NArk.Tests/NArk.Tests.csproj
@@ -22,6 +22,7 @@
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
         <PackageReference Include="System.Linq.Async" Version="7.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.16" />
     </ItemGroup>
 
     <ItemGroup>
@@ -31,6 +32,7 @@
     <ItemGroup>
       <ProjectReference Include="..\NArk.Core\NArk.Core.csproj" />
       <ProjectReference Include="..\NArk.Swaps\NArk.Swaps.csproj" />
+      <ProjectReference Include="..\NArk.Storage.EfCore\NArk.Storage.EfCore.csproj" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- Adds unit tests for the `Math.Max` fix in `EfCoreWalletStorage` to prevent `LastUsedIndex` from regressing when a wallet is re-saved with a lower index (e.g. shared mnemonic reimport)
- Covers both `SaveWallet` and `UpsertWallet` paths, testing both the guard (lower index doesn't overwrite) and normal advancement (higher index does)
- Uses SQLite in-memory for fast, isolated EfCore integration tests

## Test plan
- [x] All 4 new tests pass locally
- [x] Verified tests fail without the `Math.Max` fix
- [x] Full test suite (243 tests) passes