### PR TITLE
feat: payment tracking improvements

### DIFF
--- a/NArk.Abstractions/Payments/ArkPayment.cs
+++ b/NArk.Abstractions/Payments/ArkPayment.cs
@@ -1,3 +1,5 @@
+using NArk.Abstractions.VTXOs;
+
 namespace NArk.Abstractions.Payments;
 
 /// <summary>
@@ -31,6 +33,11 @@ public record ArkPayment(
     public string? OnchainTxId { get; init; }
 
     /// <summary>
+    /// Assets transferred with this payment. Null for BTC-only payments.
+    /// </summary>
+    public IReadOnlyList<VtxoAsset>? Assets { get; init; }
+
+    /// <summary>
     /// Application-level metadata.
     /// </summary>
     public Dictionary<string, string>? Metadata { get; init; }
@@ -58,5 +65,7 @@ public enum ArkPaymentStatus
 {
     Pending,
     Completed,
-    Failed
+    Failed,
+    /// <summary>Payment was explicitly cancelled by the user or application.</summary>
+    Cancelled
 }

--- a/NArk.Abstractions/Payments/ArkPaymentRequest.cs
+++ b/NArk.Abstractions/Payments/ArkPaymentRequest.cs
@@ -1,3 +1,5 @@
+using NArk.Abstractions.VTXOs;
+
 namespace NArk.Abstractions.Payments;
 
 /// <summary>
@@ -46,6 +48,16 @@ public record ArkPaymentRequest(
     public ulong Overpayment { get; init; }
 
     /// <summary>
+    /// Expected asset for this payment request. Null for BTC-only requests.
+    /// </summary>
+    public VtxoAsset? ExpectedAsset { get; init; }
+
+    /// <summary>
+    /// Assets received so far. Null when no assets received yet.
+    /// </summary>
+    public IReadOnlyList<VtxoAsset>? ReceivedAssets { get; init; }
+
+    /// <summary>
     /// Application-level metadata.
     /// </summary>
     public Dictionary<string, string>? Metadata { get; init; }
@@ -59,5 +71,7 @@ public enum ArkPaymentRequestStatus
     Pending,
     PartiallyPaid,
     Paid,
-    Expired
+    Expired,
+    /// <summary>Request was explicitly cancelled by the user or application.</summary>
+    Cancelled
 }

--- a/NArk.Abstractions/Payments/Bip21PaymentInfo.cs
+++ b/NArk.Abstractions/Payments/Bip21PaymentInfo.cs
@@ -1,0 +1,167 @@
+using System.Globalization;
+using NArk.Abstractions.VTXOs;
+
+namespace NArk.Abstractions.Payments;
+
+/// <summary>
+/// Parsed result from a BIP21 URI or raw payment destination.
+/// Use <see cref="Bip21Parser.Parse"/> to create instances.
+/// </summary>
+public record Bip21PaymentInfo
+{
+    /// <summary>
+    /// On-chain Bitcoin address from the URI path (may be null for Lightning-only).
+    /// </summary>
+    public string? OnchainAddress { get; init; }
+
+    /// <summary>
+    /// Ark protocol address from the <c>ark</c> query parameter.
+    /// </summary>
+    public string? ArkAddress { get; init; }
+
+    /// <summary>
+    /// BOLT11 Lightning invoice from the <c>lightning</c> query parameter.
+    /// </summary>
+    public string? LightningInvoice { get; init; }
+
+    /// <summary>
+    /// Requested amount in satoshis (converted from BIP21 BTC amount).
+    /// </summary>
+    public ulong? AmountSats { get; init; }
+
+    /// <summary>
+    /// Asset ID if present — forces Ark-only delivery.
+    /// </summary>
+    public string? AssetId { get; init; }
+
+    /// <summary>
+    /// Raw query parameters for extensibility.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> QueryParams { get; init; } =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Determines the best payment method based on available fields.
+    /// Priority: Ark (if ark address or asset present) → Lightning → Chain swap / CollaborativeExit.
+    /// </summary>
+    public ArkPaymentMethod PreferredMethod =>
+        ArkAddress is not null || AssetId is not null ? ArkPaymentMethod.ArkSend :
+        LightningInvoice is not null ? ArkPaymentMethod.SubmarineSwap :
+        OnchainAddress is not null ? ArkPaymentMethod.ChainSwap :
+        ArkPaymentMethod.ArkSend;
+
+    /// <summary>
+    /// The best recipient address based on <see cref="PreferredMethod"/>.
+    /// </summary>
+    public string? Recipient => PreferredMethod switch
+    {
+        ArkPaymentMethod.ArkSend => ArkAddress ?? OnchainAddress,
+        ArkPaymentMethod.SubmarineSwap => LightningInvoice,
+        ArkPaymentMethod.ChainSwap => OnchainAddress,
+        ArkPaymentMethod.CollaborativeExit => OnchainAddress,
+        _ => null
+    };
+}
+
+/// <summary>
+/// Parses BIP21 URIs and raw payment destinations (Ark addresses, Lightning invoices,
+/// Bitcoin addresses) into a unified <see cref="Bip21PaymentInfo"/>.
+/// </summary>
+public static class Bip21Parser
+{
+    /// <summary>
+    /// Parse any payment destination string: BIP21 URI, Ark address, Lightning invoice, or Bitcoin address.
+    /// </summary>
+    /// <returns>Parsed payment info, or null if the input is unrecognized.</returns>
+    public static Bip21PaymentInfo? Parse(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+            return null;
+
+        input = input.Trim();
+
+        // BIP21 URI
+        if (input.StartsWith("bitcoin:", StringComparison.OrdinalIgnoreCase))
+            return ParseBip21(input);
+
+        // Lightning invoice (BOLT11)
+        if (IsLightningInvoice(input))
+            return new Bip21PaymentInfo { LightningInvoice = input };
+
+        // Ark address
+        if (IsArkAddress(input))
+            return new Bip21PaymentInfo { ArkAddress = input };
+
+        // On-chain Bitcoin address (bech32, bech32m, legacy)
+        if (IsBitcoinAddress(input))
+            return new Bip21PaymentInfo { OnchainAddress = input };
+
+        return null;
+    }
+
+    private static Bip21PaymentInfo? ParseBip21(string uri)
+    {
+        try
+        {
+            var withoutScheme = uri["bitcoin:".Length..];
+            var qIdx = withoutScheme.IndexOf('?');
+            var address = qIdx >= 0 ? withoutScheme[..qIdx] : withoutScheme;
+            var queryParams = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            if (qIdx >= 0)
+            {
+                var queryString = withoutScheme[(qIdx + 1)..];
+                foreach (var pair in queryString.Split('&'))
+                {
+                    var eqIdx = pair.IndexOf('=');
+                    if (eqIdx > 0)
+                    {
+                        queryParams[Uri.UnescapeDataString(pair[..eqIdx])] =
+                            Uri.UnescapeDataString(pair[(eqIdx + 1)..]);
+                    }
+                }
+            }
+
+            ulong? amountSats = null;
+            if (queryParams.TryGetValue("amount", out var amountStr) &&
+                decimal.TryParse(amountStr, NumberStyles.Any, CultureInfo.InvariantCulture, out var btcAmount))
+            {
+                amountSats = (ulong)(btcAmount * 100_000_000m);
+            }
+
+            queryParams.TryGetValue("ark", out var arkAddress);
+            queryParams.TryGetValue("lightning", out var lightningInvoice);
+            queryParams.TryGetValue("asset", out var assetId);
+
+            return new Bip21PaymentInfo
+            {
+                OnchainAddress = string.IsNullOrWhiteSpace(address) ? null : address,
+                ArkAddress = string.IsNullOrWhiteSpace(arkAddress) ? null : arkAddress,
+                LightningInvoice = string.IsNullOrWhiteSpace(lightningInvoice) ? null : lightningInvoice,
+                AmountSats = amountSats,
+                AssetId = string.IsNullOrWhiteSpace(assetId) ? null : assetId,
+                QueryParams = queryParams
+            };
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool IsLightningInvoice(string input) =>
+        input.StartsWith("lnbc", StringComparison.OrdinalIgnoreCase) ||
+        input.StartsWith("lntb", StringComparison.OrdinalIgnoreCase) ||
+        input.StartsWith("lnbcrt", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsArkAddress(string input) =>
+        input.StartsWith("ark1", StringComparison.OrdinalIgnoreCase) ||
+        input.StartsWith("tark1", StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsBitcoinAddress(string input) =>
+        input.StartsWith("bc1", StringComparison.OrdinalIgnoreCase) ||
+        input.StartsWith("tb1", StringComparison.OrdinalIgnoreCase) ||
+        input.StartsWith("bcrt1", StringComparison.OrdinalIgnoreCase) ||
+        input.StartsWith("1") || input.StartsWith("3") ||
+        input.StartsWith("m") || input.StartsWith("n") || input.StartsWith("2");
+}

--- a/NArk.Abstractions/Payments/Bip21PaymentInfo.cs
+++ b/NArk.Abstractions/Payments/Bip21PaymentInfo.cs
@@ -1,16 +1,18 @@
 using System.Globalization;
-using NArk.Abstractions.VTXOs;
+using System.Text;
+using System.Web;
 
 namespace NArk.Abstractions.Payments;
 
 /// <summary>
-/// Parsed result from a BIP21 URI or raw payment destination.
-/// Use <see cref="Bip21Parser.Parse"/> to create instances.
+/// Information extracted from a BIP21 URI or raw payment destination.
+/// Use <see cref="ArkBip21.Parse"/> to create from a string,
+/// or <see cref="ArkBip21.Create"/> to build a URI.
 /// </summary>
 public record Bip21PaymentInfo
 {
     /// <summary>
-    /// On-chain Bitcoin address from the URI path (may be null for Lightning-only).
+    /// On-chain Bitcoin address from the URI path (may be null for Ark-only URIs).
     /// </summary>
     public string? OnchainAddress { get; init; }
 
@@ -20,33 +22,41 @@ public record Bip21PaymentInfo
     public string? ArkAddress { get; init; }
 
     /// <summary>
-    /// BOLT11 Lightning invoice from the <c>lightning</c> query parameter.
+    /// BOLT11 Lightning invoice or LNURL from the <c>lightning</c> query parameter.
     /// </summary>
-    public string? LightningInvoice { get; init; }
+    public string? Lightning { get; init; }
 
     /// <summary>
-    /// Requested amount in satoshis (converted from BIP21 BTC amount).
+    /// Requested amount in BTC (as specified in BIP21).
+    /// Use <see cref="AmountSats"/> for the satoshi equivalent.
     /// </summary>
-    public ulong? AmountSats { get; init; }
+    public decimal? Amount { get; init; }
 
     /// <summary>
-    /// Asset ID if present — forces Ark-only delivery.
+    /// Requested amount in satoshis (derived from <see cref="Amount"/>).
+    /// </summary>
+    public ulong? AmountSats => Amount.HasValue
+        ? (ulong)Math.Round(Amount.Value * 100_000_000m, 0, MidpointRounding.AwayFromZero)
+        : null;
+
+    /// <summary>
+    /// Asset ID from the <c>asset</c> query parameter. Forces Ark-only delivery.
     /// </summary>
     public string? AssetId { get; init; }
 
     /// <summary>
-    /// Raw query parameters for extensibility.
+    /// All query parameters (including ark, lightning, amount, asset).
     /// </summary>
     public IReadOnlyDictionary<string, string> QueryParams { get; init; } =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// Determines the best payment method based on available fields.
-    /// Priority: Ark (if ark address or asset present) → Lightning → Chain swap / CollaborativeExit.
+    /// Priority: Ark (if ark address or asset present) → Lightning → Chain swap.
     /// </summary>
     public ArkPaymentMethod PreferredMethod =>
         ArkAddress is not null || AssetId is not null ? ArkPaymentMethod.ArkSend :
-        LightningInvoice is not null ? ArkPaymentMethod.SubmarineSwap :
+        Lightning is not null ? ArkPaymentMethod.SubmarineSwap :
         OnchainAddress is not null ? ArkPaymentMethod.ChainSwap :
         ArkPaymentMethod.ArkSend;
 
@@ -56,7 +66,7 @@ public record Bip21PaymentInfo
     public string? Recipient => PreferredMethod switch
     {
         ArkPaymentMethod.ArkSend => ArkAddress ?? OnchainAddress,
-        ArkPaymentMethod.SubmarineSwap => LightningInvoice,
+        ArkPaymentMethod.SubmarineSwap => Lightning,
         ArkPaymentMethod.ChainSwap => OnchainAddress,
         ArkPaymentMethod.CollaborativeExit => OnchainAddress,
         _ => null
@@ -64,81 +74,209 @@ public record Bip21PaymentInfo
 }
 
 /// <summary>
-/// Parses BIP21 URIs and raw payment destinations (Ark addresses, Lightning invoices,
-/// Bitcoin addresses) into a unified <see cref="Bip21PaymentInfo"/>.
+/// Builds and parses BIP21 URIs with Ark protocol extensions.
+/// <para>
+/// <b>Building:</b> <c>ArkBip21.Create().WithArkAddress("tark1...").WithAmount(0.001m).Build()</c>
+/// </para>
+/// <para>
+/// <b>Parsing:</b> <c>ArkBip21.Parse("bitcoin:addr?ark=tark1...")</c> — also handles raw
+/// Ark addresses, Lightning invoices, and Bitcoin addresses.
+/// </para>
 /// </summary>
-public static class Bip21Parser
+public class ArkBip21
 {
+    private string? _onchainAddress;
+    private string? _arkAddress;
+    private string? _lightning;
+    private decimal? _amount;
+    private string? _assetId;
+    private readonly Dictionary<string, string> _customParameters = new(StringComparer.OrdinalIgnoreCase);
+
     /// <summary>
-    /// Parse any payment destination string: BIP21 URI, Ark address, Lightning invoice, or Bitcoin address.
+    /// Creates a new builder instance.
+    /// </summary>
+    public static ArkBip21 Create() => new();
+
+    /// <summary>
+    /// Sets the Bitcoin on-chain address (optional, placed in URI path).
+    /// </summary>
+    public ArkBip21 WithOnchainAddress(string? address)
+    {
+        _onchainAddress = address;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the Ark protocol address (placed in <c>ark</c> query parameter).
+    /// </summary>
+    public ArkBip21 WithArkAddress(string arkAddress)
+    {
+        if (string.IsNullOrWhiteSpace(arkAddress))
+            throw new ArgumentException("Ark address cannot be null or empty.", nameof(arkAddress));
+        _arkAddress = arkAddress;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the Lightning invoice or LNURL (placed in <c>lightning</c> query parameter).
+    /// </summary>
+    public ArkBip21 WithLightning(string? lightning)
+    {
+        _lightning = lightning;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the payment amount in BTC.
+    /// </summary>
+    public ArkBip21 WithAmount(decimal? amount)
+    {
+        _amount = amount;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the asset ID (placed in <c>asset</c> query parameter, forces Ark-only).
+    /// </summary>
+    public ArkBip21 WithAssetId(string? assetId)
+    {
+        _assetId = assetId;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a custom query parameter.
+    /// </summary>
+    public ArkBip21 WithCustomParameter(string key, string value)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Parameter key cannot be null or empty.", nameof(key));
+        _customParameters[key] = value;
+        return this;
+    }
+
+    /// <summary>
+    /// Builds the BIP21 URI string.
+    /// Format: <c>bitcoin:[onchain_address]?amount=X&amp;ark=Y&amp;lightning=Z</c>
+    /// </summary>
+    /// <exception cref="InvalidOperationException">No address was set (need at least ark or onchain).</exception>
+    public string Build()
+    {
+        if (string.IsNullOrWhiteSpace(_arkAddress) && string.IsNullOrWhiteSpace(_onchainAddress))
+            throw new InvalidOperationException(
+                "At least one address is required. Call WithArkAddress() or WithOnchainAddress() before Build().");
+
+        var sb = new StringBuilder("bitcoin:");
+        sb.Append(_onchainAddress ?? string.Empty);
+
+        var parameters = new List<string>();
+
+        if (_amount.HasValue)
+            parameters.Add($"amount={_amount.Value.ToString(CultureInfo.InvariantCulture)}");
+
+        // Ark address — bech32m is URL-safe, no encoding needed
+        if (!string.IsNullOrWhiteSpace(_arkAddress))
+            parameters.Add($"ark={_arkAddress}");
+
+        if (!string.IsNullOrWhiteSpace(_lightning))
+            parameters.Add($"lightning={HttpUtility.UrlEncode(_lightning)}");
+
+        if (!string.IsNullOrWhiteSpace(_assetId))
+            parameters.Add($"asset={HttpUtility.UrlEncode(_assetId)}");
+
+        foreach (var (key, value) in _customParameters)
+        {
+            if (key is "amount" or "ark" or "lightning" or "asset") continue;
+            parameters.Add($"{HttpUtility.UrlEncode(key)}={HttpUtility.UrlEncode(value)}");
+        }
+
+        if (parameters.Count > 0)
+        {
+            sb.Append('?');
+            sb.Append(string.Join("&", parameters));
+        }
+
+        return sb.ToString();
+    }
+
+    // ── Parsing ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Parses any payment destination: BIP21 URI, Ark address, Lightning invoice, or Bitcoin address.
     /// </summary>
     /// <returns>Parsed payment info, or null if the input is unrecognized.</returns>
-    public static Bip21PaymentInfo? Parse(string input)
+    public static Bip21PaymentInfo? Parse(string? input)
     {
         if (string.IsNullOrWhiteSpace(input))
             return null;
 
         input = input.Trim();
 
-        // BIP21 URI
         if (input.StartsWith("bitcoin:", StringComparison.OrdinalIgnoreCase))
-            return ParseBip21(input);
+            return ParseBip21Uri(input);
 
-        // Lightning invoice (BOLT11)
         if (IsLightningInvoice(input))
-            return new Bip21PaymentInfo { LightningInvoice = input };
+            return new Bip21PaymentInfo { Lightning = input };
 
-        // Ark address
         if (IsArkAddress(input))
             return new Bip21PaymentInfo { ArkAddress = input };
 
-        // On-chain Bitcoin address (bech32, bech32m, legacy)
         if (IsBitcoinAddress(input))
             return new Bip21PaymentInfo { OnchainAddress = input };
 
         return null;
     }
 
-    private static Bip21PaymentInfo? ParseBip21(string uri)
+    /// <summary>
+    /// Parses a BIP21 URI. Throws <see cref="FormatException"/> for invalid URIs.
+    /// Use <see cref="Parse"/> for lenient parsing that returns null on failure.
+    /// </summary>
+    /// <exception cref="FormatException">The URI is not a valid BIP21 URI.</exception>
+    public static Bip21PaymentInfo ParseStrict(string bip21Uri)
+    {
+        if (string.IsNullOrWhiteSpace(bip21Uri))
+            throw new ArgumentException("BIP21 URI cannot be null or empty.", nameof(bip21Uri));
+
+        if (!bip21Uri.StartsWith("bitcoin:", StringComparison.OrdinalIgnoreCase))
+            throw new FormatException("Invalid BIP21 URI: must start with 'bitcoin:'.");
+
+        return ParseBip21Uri(bip21Uri)
+            ?? throw new FormatException($"Failed to parse BIP21 URI: {bip21Uri}");
+    }
+
+    private static Bip21PaymentInfo? ParseBip21Uri(string uri)
     {
         try
         {
-            var withoutScheme = uri["bitcoin:".Length..];
-            var qIdx = withoutScheme.IndexOf('?');
-            var address = qIdx >= 0 ? withoutScheme[..qIdx] : withoutScheme;
-            var queryParams = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var parsed = new Uri(uri);
+            var onchainAddress = parsed.AbsolutePath.TrimStart('/');
+            var query = HttpUtility.ParseQueryString(parsed.Query);
 
-            if (qIdx >= 0)
-            {
-                var queryString = withoutScheme[(qIdx + 1)..];
-                foreach (var pair in queryString.Split('&'))
-                {
-                    var eqIdx = pair.IndexOf('=');
-                    if (eqIdx > 0)
-                    {
-                        queryParams[Uri.UnescapeDataString(pair[..eqIdx])] =
-                            Uri.UnescapeDataString(pair[(eqIdx + 1)..]);
-                    }
-                }
-            }
-
-            ulong? amountSats = null;
-            if (queryParams.TryGetValue("amount", out var amountStr) &&
+            decimal? amount = null;
+            if (query["amount"] is { } amountStr &&
                 decimal.TryParse(amountStr, NumberStyles.Any, CultureInfo.InvariantCulture, out var btcAmount))
             {
-                amountSats = (ulong)(btcAmount * 100_000_000m);
+                amount = btcAmount;
             }
 
-            queryParams.TryGetValue("ark", out var arkAddress);
-            queryParams.TryGetValue("lightning", out var lightningInvoice);
-            queryParams.TryGetValue("asset", out var assetId);
+            var arkAddress = query["ark"];
+            var lightning = query["lightning"];
+            var assetId = query["asset"];
+
+            // Preserve all query params for extensibility
+            var queryParams = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (string? key in query.AllKeys)
+            {
+                if (key is not null && query[key] is { } value)
+                    queryParams[key] = value;
+            }
 
             return new Bip21PaymentInfo
             {
-                OnchainAddress = string.IsNullOrWhiteSpace(address) ? null : address,
+                OnchainAddress = string.IsNullOrWhiteSpace(onchainAddress) ? null : onchainAddress,
                 ArkAddress = string.IsNullOrWhiteSpace(arkAddress) ? null : arkAddress,
-                LightningInvoice = string.IsNullOrWhiteSpace(lightningInvoice) ? null : lightningInvoice,
-                AmountSats = amountSats,
+                Lightning = string.IsNullOrWhiteSpace(lightning) ? null : lightning,
+                Amount = amount,
                 AssetId = string.IsNullOrWhiteSpace(assetId) ? null : assetId,
                 QueryParams = queryParams
             };
@@ -149,6 +287,8 @@ public static class Bip21Parser
         }
     }
 
+    // ── Address detection helpers ───────────────────────────────────────
+
     private static bool IsLightningInvoice(string input) =>
         input.StartsWith("lnbc", StringComparison.OrdinalIgnoreCase) ||
         input.StartsWith("lntb", StringComparison.OrdinalIgnoreCase) ||
@@ -158,10 +298,23 @@ public static class Bip21Parser
         input.StartsWith("ark1", StringComparison.OrdinalIgnoreCase) ||
         input.StartsWith("tark1", StringComparison.OrdinalIgnoreCase);
 
-    private static bool IsBitcoinAddress(string input) =>
-        input.StartsWith("bc1", StringComparison.OrdinalIgnoreCase) ||
-        input.StartsWith("tb1", StringComparison.OrdinalIgnoreCase) ||
-        input.StartsWith("bcrt1", StringComparison.OrdinalIgnoreCase) ||
-        input.StartsWith("1") || input.StartsWith("3") ||
-        input.StartsWith("m") || input.StartsWith("n") || input.StartsWith("2");
+    /// <summary>
+    /// Basic Bitcoin address detection. Checks prefix + length to avoid false positives
+    /// on short strings like "main" or "3.14".
+    /// </summary>
+    private static bool IsBitcoinAddress(string input)
+    {
+        // Bech32/bech32m (segwit v0/v1): bc1/tb1/bcrt1 + 39-62 chars
+        if (input.StartsWith("bc1", StringComparison.OrdinalIgnoreCase) ||
+            input.StartsWith("tb1", StringComparison.OrdinalIgnoreCase) ||
+            input.StartsWith("bcrt1", StringComparison.OrdinalIgnoreCase))
+            return input.Length >= 42 && input.Length <= 90;
+
+        // Legacy P2PKH/P2SH: starts with 1/3 (mainnet), m/n/2 (testnet)
+        // Base58Check addresses are 25-34 chars, but encoded as 26-35 characters
+        if (input.Length < 26 || input.Length > 35)
+            return false;
+
+        return input[0] is '1' or '3' or 'm' or 'n' or '2';
+    }
 }

--- a/NArk.Abstractions/Payments/IPaymentRequestStorage.cs
+++ b/NArk.Abstractions/Payments/IPaymentRequestStorage.cs
@@ -40,7 +40,7 @@ public interface IPaymentRequestStorage
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Update the status, received amount, and overpayment of a payment request.
+    /// Update the status, received amount, overpayment, and received assets of a payment request.
     /// </summary>
     Task<bool> UpdatePaymentRequestStatus(
         string walletId,
@@ -48,5 +48,6 @@ public interface IPaymentRequestStorage
         ArkPaymentRequestStatus status,
         ulong receivedAmount,
         ulong overpayment = 0,
+        IReadOnlyList<VTXOs.VtxoAsset>? receivedAssets = null,
         CancellationToken cancellationToken = default);
 }

--- a/NArk.Storage.EfCore/Entities/ArkPaymentEntity.cs
+++ b/NArk.Storage.EfCore/Entities/ArkPaymentEntity.cs
@@ -31,6 +31,19 @@ public class ArkPaymentEntity
     /// </summary>
     public string? OnchainTxId { get; set; }
 
+    /// <summary>
+    /// JSON array of assets transferred with this payment.
+    /// </summary>
+    [Column("Assets", TypeName = "jsonb")]
+    public string? AssetsJson { get; set; }
+
+    [NotMapped]
+    public IReadOnlyList<NArk.Abstractions.VTXOs.VtxoAsset>? Assets
+    {
+        get => AssetsJson is null ? null : JsonSerializer.Deserialize<List<NArk.Abstractions.VTXOs.VtxoAsset>>(AssetsJson);
+        set => AssetsJson = value is null ? null : JsonSerializer.Serialize(value);
+    }
+
     [Column("Metadata", TypeName = "jsonb")]
     public string? MetadataJson { get; set; }
 
@@ -60,6 +73,7 @@ public class ArkPaymentEntity
         builder.Property(e => e.IntentTxId).HasDefaultValue(null);
         builder.Property(e => e.SwapId).HasDefaultValue(null);
         builder.Property(e => e.OnchainTxId).HasDefaultValue(null);
+        builder.Property(e => e.AssetsJson).HasDefaultValue(null);
         builder.Property(e => e.MetadataJson).HasDefaultValue(null);
 
         builder.HasOne(e => e.Wallet)

--- a/NArk.Storage.EfCore/Entities/ArkPaymentRequestEntity.cs
+++ b/NArk.Storage.EfCore/Entities/ArkPaymentRequestEntity.cs
@@ -38,6 +38,32 @@ public class ArkPaymentRequestEntity
     /// </summary>
     public string? SwapId { get; set; }
 
+    /// <summary>
+    /// Expected asset for this payment request (JSON).
+    /// </summary>
+    [Column("ExpectedAsset", TypeName = "jsonb")]
+    public string? ExpectedAssetJson { get; set; }
+
+    [NotMapped]
+    public NArk.Abstractions.VTXOs.VtxoAsset? ExpectedAsset
+    {
+        get => ExpectedAssetJson is null ? null : JsonSerializer.Deserialize<NArk.Abstractions.VTXOs.VtxoAsset>(ExpectedAssetJson);
+        set => ExpectedAssetJson = value is null ? null : JsonSerializer.Serialize(value);
+    }
+
+    /// <summary>
+    /// Assets received so far (JSON array).
+    /// </summary>
+    [Column("ReceivedAssets", TypeName = "jsonb")]
+    public string? ReceivedAssetsJson { get; set; }
+
+    [NotMapped]
+    public IReadOnlyList<NArk.Abstractions.VTXOs.VtxoAsset>? ReceivedAssets
+    {
+        get => ReceivedAssetsJson is null ? null : JsonSerializer.Deserialize<List<NArk.Abstractions.VTXOs.VtxoAsset>>(ReceivedAssetsJson);
+        set => ReceivedAssetsJson = value is null ? null : JsonSerializer.Serialize(value);
+    }
+
     [Column("Metadata", TypeName = "jsonb")]
     public string? MetadataJson { get; set; }
 
@@ -62,6 +88,8 @@ public class ArkPaymentRequestEntity
         builder.Property(e => e.Status).IsRequired();
         builder.Property(e => e.CreatedAt).IsRequired();
         builder.Property(e => e.ContractScriptsJson).IsRequired();
+        builder.Property(e => e.ExpectedAssetJson).HasDefaultValue(null);
+        builder.Property(e => e.ReceivedAssetsJson).HasDefaultValue(null);
         builder.Property(e => e.MetadataJson).HasDefaultValue(null);
 
         builder.HasOne(e => e.Wallet)

--- a/NArk.Storage.EfCore/Hosting/StorageServiceCollectionExtensions.cs
+++ b/NArk.Storage.EfCore/Hosting/StorageServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using NArk.Abstractions.Contracts;
 using NArk.Abstractions.Intents;
 using NArk.Abstractions.Payments;
@@ -8,15 +9,16 @@ using NArk.Abstractions.VTXOs;
 using NArk.Abstractions.Wallets;
 using NArk.Storage.EfCore.Storage;
 using NArk.Swaps.Abstractions;
+using NArk.Swaps.Services;
 
 namespace NArk.Storage.EfCore.Hosting;
 
 public static class StorageServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers all Ark EF Core storage implementations.
-    /// The consumer's TDbContext must call modelBuilder.ConfigureArkEntities() in OnModelCreating.
-    /// For wallet provider registration, use NArk.Core.Wallet.DefaultWalletProvider separately.
+    /// Registers core Ark EF Core storage implementations.
+    /// The consumer's TDbContext must call <c>modelBuilder.ConfigureArkEntities()</c> in OnModelCreating.
+    /// For payment tracking, also call <see cref="AddArkPaymentTracking"/>.
     /// </summary>
     public static IServiceCollection AddArkEfCoreStorage<TDbContext>(
         this IServiceCollection services,
@@ -48,11 +50,26 @@ public static class StorageServiceCollectionExtensions
         services.AddSingleton<EfCoreWalletStorage>();
         services.AddSingleton<IWalletStorage>(sp => sp.GetRequiredService<EfCoreWalletStorage>());
 
+        return services;
+    }
+
+    /// <summary>
+    /// Registers payment tracking storage, and the <see cref="PaymentTrackingService"/> hosted service
+    /// that automatically updates payment statuses from protocol events.
+    /// <para>
+    /// Requires <see cref="AddArkEfCoreStorage{TDbContext}"/> to be called first.
+    /// The consumer's DbContext must also call <c>modelBuilder.ConfigureArkPaymentEntities()</c>.
+    /// </para>
+    /// </summary>
+    public static IServiceCollection AddArkPaymentTracking(this IServiceCollection services)
+    {
         services.AddSingleton<EfCorePaymentStorage>();
         services.AddSingleton<IPaymentStorage>(sp => sp.GetRequiredService<EfCorePaymentStorage>());
 
         services.AddSingleton<EfCorePaymentRequestStorage>();
         services.AddSingleton<IPaymentRequestStorage>(sp => sp.GetRequiredService<EfCorePaymentRequestStorage>());
+
+        services.AddHostedService<PaymentTrackingService>();
 
         return services;
     }

--- a/NArk.Storage.EfCore/ModelBuilderExtensions.cs
+++ b/NArk.Storage.EfCore/ModelBuilderExtensions.cs
@@ -6,8 +6,9 @@ namespace NArk.Storage.EfCore;
 public static class ModelBuilderExtensions
 {
     /// <summary>
-    /// Configures all Ark SDK entity types on the given ModelBuilder.
+    /// Configures core Ark SDK entity types on the given ModelBuilder.
     /// Call this from your DbContext's OnModelCreating.
+    /// For payment tracking tables, also call <see cref="ConfigureArkPaymentEntities"/>.
     /// </summary>
     public static ModelBuilder ConfigureArkEntities(
         this ModelBuilder modelBuilder,
@@ -25,6 +26,22 @@ public static class ModelBuilderExtensions
         ArkIntentEntity.Configure(modelBuilder.Entity<ArkIntentEntity>(), options);
         ArkIntentVtxoEntity.Configure(modelBuilder.Entity<ArkIntentVtxoEntity>(), options);
         ArkSwapEntity.Configure(modelBuilder.Entity<ArkSwapEntity>(), options);
+
+        return modelBuilder;
+    }
+
+    /// <summary>
+    /// Configures payment tracking entity types (Payments and PaymentRequests tables).
+    /// Call this from your DbContext's OnModelCreating alongside <see cref="ConfigureArkEntities"/>.
+    /// Requires <see cref="ConfigureArkEntities"/> to be called first (for the Wallet FK).
+    /// </summary>
+    public static ModelBuilder ConfigureArkPaymentEntities(
+        this ModelBuilder modelBuilder,
+        Action<ArkStorageOptions>? configure = null)
+    {
+        var options = new ArkStorageOptions();
+        configure?.Invoke(options);
+
         ArkPaymentEntity.Configure(modelBuilder.Entity<ArkPaymentEntity>(), options);
         ArkPaymentRequestEntity.Configure(modelBuilder.Entity<ArkPaymentRequestEntity>(), options);
 

--- a/NArk.Storage.EfCore/Storage/EfCorePaymentRequestStorage.cs
+++ b/NArk.Storage.EfCore/Storage/EfCorePaymentRequestStorage.cs
@@ -33,6 +33,8 @@ public class EfCorePaymentRequestStorage : IPaymentRequestStorage
             existing.LightningInvoice = request.LightningInvoice;
             existing.ContractScripts = request.ContractScripts;
             existing.SwapId = request.SwapId;
+            existing.ExpectedAsset = request.ExpectedAsset;
+            existing.ReceivedAssets = request.ReceivedAssets;
             existing.Metadata = request.Metadata;
         }
         else
@@ -51,6 +53,8 @@ public class EfCorePaymentRequestStorage : IPaymentRequestStorage
                 LightningInvoice = request.LightningInvoice,
                 ContractScripts = request.ContractScripts,
                 SwapId = request.SwapId,
+                ExpectedAsset = request.ExpectedAsset,
+                ReceivedAssets = request.ReceivedAssets,
                 Metadata = request.Metadata,
                 CreatedAt = request.CreatedAt.ToUniversalTime(),
                 ExpiresAt = request.ExpiresAt?.ToUniversalTime()
@@ -121,6 +125,7 @@ public class EfCorePaymentRequestStorage : IPaymentRequestStorage
         ArkPaymentRequestStatus status,
         ulong receivedAmount,
         ulong overpayment = 0,
+        IReadOnlyList<NArk.Abstractions.VTXOs.VtxoAsset>? receivedAssets = null,
         CancellationToken cancellationToken = default)
     {
         await using var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
@@ -133,6 +138,8 @@ public class EfCorePaymentRequestStorage : IPaymentRequestStorage
         entity.Status = status;
         entity.ReceivedAmount = (long)receivedAmount;
         entity.Overpayment = (long)overpayment;
+        if (receivedAssets is not null)
+            entity.ReceivedAssets = receivedAssets;
 
         await db.SaveChangesAsync(cancellationToken);
         PaymentRequestChanged?.Invoke(this, MapToRequest(entity));
@@ -155,6 +162,8 @@ public class EfCorePaymentRequestStorage : IPaymentRequestStorage
         ContractScripts = e.ContractScripts,
         SwapId = e.SwapId,
         Overpayment = (ulong)e.Overpayment,
+        ExpectedAsset = e.ExpectedAsset,
+        ReceivedAssets = e.ReceivedAssets,
         Metadata = e.Metadata
     };
 }

--- a/NArk.Storage.EfCore/Storage/EfCorePaymentStorage.cs
+++ b/NArk.Storage.EfCore/Storage/EfCorePaymentStorage.cs
@@ -30,6 +30,7 @@ public class EfCorePaymentStorage : IPaymentStorage
             existing.IntentTxId = payment.IntentTxId;
             existing.SwapId = payment.SwapId;
             existing.OnchainTxId = payment.OnchainTxId;
+            existing.Assets = payment.Assets;
             existing.CompletedAt = payment.CompletedAt?.ToUniversalTime();
             existing.Metadata = payment.Metadata;
         }
@@ -47,6 +48,7 @@ public class EfCorePaymentStorage : IPaymentStorage
                 IntentTxId = payment.IntentTxId,
                 SwapId = payment.SwapId,
                 OnchainTxId = payment.OnchainTxId,
+                Assets = payment.Assets,
                 Metadata = payment.Metadata,
                 CreatedAt = payment.CreatedAt.ToUniversalTime(),
                 CompletedAt = payment.CompletedAt?.ToUniversalTime()
@@ -124,7 +126,7 @@ public class EfCorePaymentStorage : IPaymentStorage
         entity.Status = status;
         entity.FailReason = failReason;
         if (onchainTxId != null) entity.OnchainTxId = onchainTxId;
-        if (status is ArkPaymentStatus.Completed or ArkPaymentStatus.Failed)
+        if (status is ArkPaymentStatus.Completed or ArkPaymentStatus.Failed or ArkPaymentStatus.Cancelled)
             entity.CompletedAt = DateTimeOffset.UtcNow;
 
         await db.SaveChangesAsync(cancellationToken);
@@ -146,6 +148,7 @@ public class EfCorePaymentStorage : IPaymentStorage
         IntentTxId = e.IntentTxId,
         SwapId = e.SwapId,
         OnchainTxId = e.OnchainTxId,
+        Assets = e.Assets,
         Metadata = e.Metadata
     };
 }

--- a/NArk.Swaps/Hosting/SwapServiceCollectionExtensions.cs
+++ b/NArk.Swaps/Hosting/SwapServiceCollectionExtensions.cs
@@ -24,10 +24,11 @@ public static class SwapServiceCollectionExtensions
         services.AddSingleton<SwapsManagementService>();
         services.AddSingleton<ISweepPolicy, SwapSweepPolicy>();
         services.AddSingleton<IContractTransformer, VHTLCContractTransformer>();
-        
+
         services.AddSingleton<CachedBoltzClient>();
         services.AddSingleton<BoltzLimitsValidator>();
         services.AddHostedService<NArk.Swaps.Hosting.SwapHostedLifecycle>();
+        services.AddHostedService<PaymentTrackingService>();
 
         // Auto-configure BoltzClientOptions from ArkNetworkConfig if available
         services.AddOptions<BoltzClientOptions>()

--- a/NArk.Swaps/Hosting/SwapServiceCollectionExtensions.cs
+++ b/NArk.Swaps/Hosting/SwapServiceCollectionExtensions.cs
@@ -28,7 +28,6 @@ public static class SwapServiceCollectionExtensions
         services.AddSingleton<CachedBoltzClient>();
         services.AddSingleton<BoltzLimitsValidator>();
         services.AddHostedService<NArk.Swaps.Hosting.SwapHostedLifecycle>();
-        services.AddHostedService<PaymentTrackingService>();
 
         // Auto-configure BoltzClientOptions from ArkNetworkConfig if available
         services.AddOptions<BoltzClientOptions>()

--- a/NArk.Swaps/NArk.Swaps.csproj
+++ b/NArk.Swaps/NArk.Swaps.csproj
@@ -23,4 +23,10 @@
     <ItemGroup>
       <Folder Include="Helpers\" />
     </ItemGroup>
+
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <_Parameter1>NArk.Tests</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
 </Project>

--- a/NArk.Swaps/Services/PaymentTrackingService.cs
+++ b/NArk.Swaps/Services/PaymentTrackingService.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using NArk.Abstractions.Intents;
 using NArk.Abstractions.Payments;
@@ -8,35 +9,39 @@ using NArk.Swaps.Models;
 namespace NArk.Swaps.Services;
 
 /// <summary>
-/// Subscribes to protocol events (VTXOs, intents, swaps) and automatically
-/// updates payment and payment request statuses.
-/// Register as a singleton after all storage implementations.
+/// Hosted service that subscribes to protocol events (VTXOs, intents, swaps) and
+/// automatically updates payment and payment request statuses.
+/// Registered via <see cref="NArk.Hosting.SwapServiceCollectionExtensions.AddArkSwapServices"/>.
 /// </summary>
-public class PaymentTrackingService
+public class PaymentTrackingService(
+    IPaymentStorage paymentStorage,
+    IPaymentRequestStorage paymentRequestStorage,
+    IVtxoStorage vtxoStorage,
+    IIntentStorage intentStorage,
+    ISwapStorage swapStorage,
+    ILogger<PaymentTrackingService> logger) : IHostedService, IDisposable
 {
-    private readonly IPaymentStorage _paymentStorage;
-    private readonly IPaymentRequestStorage _paymentRequestStorage;
-    private readonly ILogger<PaymentTrackingService> _logger;
-
-    public PaymentTrackingService(
-        IPaymentStorage paymentStorage,
-        IPaymentRequestStorage paymentRequestStorage,
-        IVtxoStorage vtxoStorage,
-        IIntentStorage intentStorage,
-        ISwapStorage swapStorage,
-        ILogger<PaymentTrackingService> logger)
+    public Task StartAsync(CancellationToken cancellationToken)
     {
-        _paymentStorage = paymentStorage;
-        _paymentRequestStorage = paymentRequestStorage;
-        _logger = logger;
-
         vtxoStorage.VtxosChanged += OnVtxoChanged;
         intentStorage.IntentChanged += OnIntentChanged;
         swapStorage.SwapsChanged += OnSwapChanged;
+        logger.LogInformation("PaymentTrackingService started");
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        vtxoStorage.VtxosChanged -= OnVtxoChanged;
+        intentStorage.IntentChanged -= OnIntentChanged;
+        swapStorage.SwapsChanged -= OnSwapChanged;
+        logger.LogInformation("PaymentTrackingService stopped");
+        return Task.CompletedTask;
     }
 
     /// <summary>
     /// When a VTXO arrives, check if it matches a pending payment request.
+    /// Tracks both sats amount and assets carried by the VTXO.
     /// </summary>
     private async void OnVtxoChanged(object? sender, ArkVtxo vtxo)
     {
@@ -44,22 +49,25 @@ public class PaymentTrackingService
         {
             if (vtxo.IsSpent()) return;
 
-            var request = await _paymentRequestStorage.GetPaymentRequestByScript(vtxo.Script);
+            var request = await paymentRequestStorage.GetPaymentRequestByScript(vtxo.Script);
             if (request is null) return;
 
             var newReceived = request.ReceivedAmount + vtxo.Amount;
             var (newStatus, overpayment) = ResolveRequestStatus(request, newReceived);
 
-            await _paymentRequestStorage.UpdatePaymentRequestStatus(
-                request.WalletId, request.RequestId, newStatus, newReceived, overpayment);
+            // Accumulate received assets from this VTXO
+            var receivedAssets = MergeAssets(request.ReceivedAssets, vtxo.Assets);
 
-            _logger.LogInformation(
+            await paymentRequestStorage.UpdatePaymentRequestStatus(
+                request.WalletId, request.RequestId, newStatus, newReceived, overpayment, receivedAssets);
+
+            logger.LogInformation(
                 "Payment request {RequestId} received {Amount} sats (total: {Total}), status: {Status}",
                 request.RequestId, vtxo.Amount, newReceived, newStatus);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error processing VTXO {TxId}:{Index} for payment request",
+            logger.LogError(ex, "Error processing VTXO {TxId}:{Index} for payment request",
                 vtxo.TransactionId, vtxo.TransactionOutputIndex);
         }
     }
@@ -85,13 +93,30 @@ public class PaymentTrackingService
     }
 
     /// <summary>
+    /// Merges newly received assets into an existing list, summing amounts for the same AssetId.
+    /// </summary>
+    internal static IReadOnlyList<VtxoAsset>? MergeAssets(
+        IReadOnlyList<VtxoAsset>? existing, IReadOnlyList<VtxoAsset>? incoming)
+    {
+        if (incoming is null or { Count: 0 }) return existing;
+        if (existing is null or { Count: 0 }) return incoming;
+
+        var merged = existing.ToDictionary(a => a.AssetId, a => a.Amount);
+        foreach (var asset in incoming)
+        {
+            merged[asset.AssetId] = merged.GetValueOrDefault(asset.AssetId) + asset.Amount;
+        }
+        return merged.Select(kv => new VtxoAsset(kv.Key, kv.Value)).ToList();
+    }
+
+    /// <summary>
     /// When an intent state changes, update linked outbound payments.
     /// </summary>
     private async void OnIntentChanged(object? sender, ArkIntent intent)
     {
         try
         {
-            var payments = await _paymentStorage.GetPayments(
+            var payments = await paymentStorage.GetPayments(
                 intentTxIds: [intent.IntentTxId]);
 
             foreach (var payment in payments)
@@ -102,27 +127,27 @@ public class PaymentTrackingService
                 {
                     ArkIntentState.BatchSucceeded => ArkPaymentStatus.Completed,
                     ArkIntentState.BatchFailed => ArkPaymentStatus.Failed,
-                    ArkIntentState.Cancelled => ArkPaymentStatus.Failed,
+                    ArkIntentState.Cancelled => ArkPaymentStatus.Cancelled,
                     _ => ArkPaymentStatus.Pending
                 };
 
                 if (newStatus == ArkPaymentStatus.Pending) continue;
 
-                var failReason = newStatus == ArkPaymentStatus.Failed
-                    ? intent.CancellationReason ?? "Intent failed"
+                var failReason = newStatus is ArkPaymentStatus.Failed or ArkPaymentStatus.Cancelled
+                    ? intent.CancellationReason ?? (newStatus == ArkPaymentStatus.Cancelled ? "Intent cancelled" : "Intent failed")
                     : null;
 
-                await _paymentStorage.UpdatePaymentStatus(
+                await paymentStorage.UpdatePaymentStatus(
                     payment.WalletId, payment.PaymentId, newStatus, failReason);
 
-                _logger.LogInformation(
+                logger.LogInformation(
                     "Payment {PaymentId} updated to {Status} from intent {IntentTxId}",
                     payment.PaymentId, newStatus, intent.IntentTxId);
             }
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error processing intent {IntentTxId} for payment tracking",
+            logger.LogError(ex, "Error processing intent {IntentTxId} for payment tracking",
                 intent.IntentTxId);
         }
     }
@@ -134,7 +159,7 @@ public class PaymentTrackingService
     {
         try
         {
-            var payments = await _paymentStorage.GetPayments(swapIds: [swap.SwapId]);
+            var payments = await paymentStorage.GetPayments(swapIds: [swap.SwapId]);
 
             foreach (var payment in payments)
             {
@@ -154,10 +179,10 @@ public class PaymentTrackingService
                     ? swap.FailReason ?? $"Swap {swap.Status}"
                     : null;
 
-                await _paymentStorage.UpdatePaymentStatus(
+                await paymentStorage.UpdatePaymentStatus(
                     payment.WalletId, payment.PaymentId, newStatus, failReason);
 
-                _logger.LogInformation(
+                logger.LogInformation(
                     "Payment {PaymentId} updated to {Status} from swap {SwapId}",
                     payment.PaymentId, newStatus, swap.SwapId);
             }
@@ -171,13 +196,13 @@ public class PaymentTrackingService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error processing swap {SwapId} for payment tracking", swap.SwapId);
+            logger.LogError(ex, "Error processing swap {SwapId} for payment tracking", swap.SwapId);
         }
     }
 
     private async Task HandleReverseSwapSettled(ArkSwap swap)
     {
-        var requests = await _paymentRequestStorage.GetPaymentRequests(
+        var requests = await paymentRequestStorage.GetPaymentRequests(
             walletIds: [swap.WalletId],
             statuses: [ArkPaymentRequestStatus.Pending, ArkPaymentRequestStatus.PartiallyPaid]);
 
@@ -188,9 +213,16 @@ public class PaymentTrackingService
             var receivedAmount = request.ReceivedAmount + (ulong)swap.ExpectedAmount;
             var (newStatus, overpayment) = ResolveRequestStatus(request, receivedAmount);
 
-            await _paymentRequestStorage.UpdatePaymentRequestStatus(
+            await paymentRequestStorage.UpdatePaymentRequestStatus(
                 request.WalletId, request.RequestId, newStatus, receivedAmount, overpayment);
             break;
         }
+    }
+
+    public void Dispose()
+    {
+        vtxoStorage.VtxosChanged -= OnVtxoChanged;
+        intentStorage.IntentChanged -= OnIntentChanged;
+        swapStorage.SwapsChanged -= OnSwapChanged;
     }
 }

--- a/NArk.Swaps/Services/PaymentTrackingService.cs
+++ b/NArk.Swaps/Services/PaymentTrackingService.cs
@@ -11,7 +11,7 @@ namespace NArk.Swaps.Services;
 /// <summary>
 /// Hosted service that subscribes to protocol events (VTXOs, intents, swaps) and
 /// automatically updates payment and payment request statuses.
-/// Registered via <see cref="NArk.Hosting.SwapServiceCollectionExtensions.AddArkSwapServices"/>.
+/// Registered via <see cref="NArk.Storage.EfCore.Hosting.StorageServiceCollectionExtensions.AddArkPaymentTracking"/>.
 /// </summary>
 public class PaymentTrackingService(
     IPaymentStorage paymentStorage,

--- a/NArk.Swaps/Services/PaymentTrackingService.cs
+++ b/NArk.Swaps/Services/PaymentTrackingService.cs
@@ -21,6 +21,11 @@ public class PaymentTrackingService(
     ISwapStorage swapStorage,
     ILogger<PaymentTrackingService> logger) : IHostedService, IDisposable
 {
+    // Serializes VTXO processing to prevent race conditions when multiple VTXOs
+    // arrive for the same payment request in the same batch round.
+    private readonly SemaphoreSlim _vtxoLock = new(1, 1);
+    private bool _disposed;
+
     public Task StartAsync(CancellationToken cancellationToken)
     {
         vtxoStorage.VtxosChanged += OnVtxoChanged;
@@ -32,16 +37,15 @@ public class PaymentTrackingService(
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        vtxoStorage.VtxosChanged -= OnVtxoChanged;
-        intentStorage.IntentChanged -= OnIntentChanged;
-        swapStorage.SwapsChanged -= OnSwapChanged;
+        Unsubscribe();
         logger.LogInformation("PaymentTrackingService stopped");
         return Task.CompletedTask;
     }
 
     /// <summary>
     /// When a VTXO arrives, check if it matches a pending payment request.
-    /// Tracks both sats amount and assets carried by the VTXO.
+    /// Serialized via <see cref="_vtxoLock"/> to prevent concurrent read-compute-write
+    /// races when multiple VTXOs target the same payment request.
     /// </summary>
     private async void OnVtxoChanged(object? sender, ArkVtxo vtxo)
     {
@@ -49,21 +53,28 @@ public class PaymentTrackingService(
         {
             if (vtxo.IsSpent()) return;
 
-            var request = await paymentRequestStorage.GetPaymentRequestByScript(vtxo.Script);
-            if (request is null) return;
+            await _vtxoLock.WaitAsync();
+            try
+            {
+                var request = await paymentRequestStorage.GetPaymentRequestByScript(vtxo.Script);
+                if (request is null) return;
 
-            var newReceived = request.ReceivedAmount + vtxo.Amount;
-            var (newStatus, overpayment) = ResolveRequestStatus(request, newReceived);
+                var newReceived = request.ReceivedAmount + vtxo.Amount;
+                var (newStatus, overpayment) = ResolveRequestStatus(request, newReceived);
 
-            // Accumulate received assets from this VTXO
-            var receivedAssets = MergeAssets(request.ReceivedAssets, vtxo.Assets);
+                var receivedAssets = MergeAssets(request.ReceivedAssets, vtxo.Assets);
 
-            await paymentRequestStorage.UpdatePaymentRequestStatus(
-                request.WalletId, request.RequestId, newStatus, newReceived, overpayment, receivedAssets);
+                await paymentRequestStorage.UpdatePaymentRequestStatus(
+                    request.WalletId, request.RequestId, newStatus, newReceived, overpayment, receivedAssets);
 
-            logger.LogInformation(
-                "Payment request {RequestId} received {Amount} sats (total: {Total}), status: {Status}",
-                request.RequestId, vtxo.Amount, newReceived, newStatus);
+                logger.LogInformation(
+                    "Payment request {RequestId} received {Amount} sats (total: {Total}), status: {Status}",
+                    request.RequestId, vtxo.Amount, newReceived, newStatus);
+            }
+            finally
+            {
+                _vtxoLock.Release();
+            }
         }
         catch (Exception ex)
         {
@@ -80,7 +91,6 @@ public class PaymentTrackingService(
     private static (ArkPaymentRequestStatus Status, ulong Overpayment) ResolveRequestStatus(
         ArkPaymentRequest request, ulong newReceived)
     {
-        // Any-amount request: paid as soon as anything arrives
         if (request.Amount is null)
             return (ArkPaymentRequestStatus.Paid, 0);
 
@@ -94,6 +104,7 @@ public class PaymentTrackingService(
 
     /// <summary>
     /// Merges newly received assets into an existing list, summing amounts for the same AssetId.
+    /// Handles duplicate AssetIds in existing list defensively.
     /// </summary>
     internal static IReadOnlyList<VtxoAsset>? MergeAssets(
         IReadOnlyList<VtxoAsset>? existing, IReadOnlyList<VtxoAsset>? incoming)
@@ -101,11 +112,12 @@ public class PaymentTrackingService(
         if (incoming is null or { Count: 0 }) return existing;
         if (existing is null or { Count: 0 }) return incoming;
 
-        var merged = existing.ToDictionary(a => a.AssetId, a => a.Amount);
-        foreach (var asset in incoming)
-        {
+        var merged = new Dictionary<string, ulong>();
+        foreach (var asset in existing)
             merged[asset.AssetId] = merged.GetValueOrDefault(asset.AssetId) + asset.Amount;
-        }
+        foreach (var asset in incoming)
+            merged[asset.AssetId] = merged.GetValueOrDefault(asset.AssetId) + asset.Amount;
+
         return merged.Select(kv => new VtxoAsset(kv.Key, kv.Value)).ToList();
     }
 
@@ -187,7 +199,6 @@ public class PaymentTrackingService(
                     payment.PaymentId, newStatus, swap.SwapId);
             }
 
-            // Also check if this swap fulfills a payment request (reverse submarine → Lightning receive)
             if (swap.Status == ArkSwapStatus.Settled &&
                 swap.SwapType == ArkSwapType.ReverseSubmarine)
             {
@@ -200,6 +211,11 @@ public class PaymentTrackingService(
         }
     }
 
+    /// <summary>
+    /// Reverse submarine swaps settle Lightning → Ark. Asset tracking is not applicable here
+    /// because Lightning invoices are BTC-only; the VTXO that arrives will be tracked separately
+    /// via <see cref="OnVtxoChanged"/> which handles assets.
+    /// </summary>
     private async Task HandleReverseSwapSettled(ArkSwap swap)
     {
         var requests = await paymentRequestStorage.GetPaymentRequests(
@@ -219,10 +235,18 @@ public class PaymentTrackingService(
         }
     }
 
-    public void Dispose()
+    private void Unsubscribe()
     {
         vtxoStorage.VtxosChanged -= OnVtxoChanged;
         intentStorage.IntentChanged -= OnIntentChanged;
         swapStorage.SwapsChanged -= OnSwapChanged;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        Unsubscribe();
+        _vtxoLock.Dispose();
     }
 }

--- a/NArk.Tests/ArkBip21Tests.cs
+++ b/NArk.Tests/ArkBip21Tests.cs
@@ -1,0 +1,255 @@
+using NArk.Abstractions.Payments;
+
+namespace NArk.Tests;
+
+[TestFixture]
+public class ArkBip21Tests
+{
+    // ── Parse: BIP21 URIs ──────────────────────────────────────────────
+
+    [Test]
+    public void Parse_Bip21_WithArkAndAmount()
+    {
+        var info = ArkBip21.Parse("bitcoin:bc1qtest?amount=0.001&ark=tark1qtest");
+
+        Assert.That(info, Is.Not.Null);
+        Assert.That(info!.OnchainAddress, Is.EqualTo("bc1qtest"));
+        Assert.That(info.ArkAddress, Is.EqualTo("tark1qtest"));
+        Assert.That(info.Amount, Is.EqualTo(0.001m));
+        Assert.That(info.AmountSats, Is.EqualTo(100_000UL));
+    }
+
+    [Test]
+    public void Parse_Bip21_WithAllParams()
+    {
+        var info = ArkBip21.Parse("bitcoin:bc1qtest?amount=0.5&ark=tark1qfoo&lightning=lnbc500u1ptest&asset=abc123");
+
+        Assert.That(info, Is.Not.Null);
+        Assert.That(info!.OnchainAddress, Is.EqualTo("bc1qtest"));
+        Assert.That(info.ArkAddress, Is.EqualTo("tark1qfoo"));
+        Assert.That(info.Lightning, Is.EqualTo("lnbc500u1ptest"));
+        Assert.That(info.AssetId, Is.EqualTo("abc123"));
+        Assert.That(info.AmountSats, Is.EqualTo(50_000_000UL));
+    }
+
+    [Test]
+    public void Parse_Bip21_ArkOnly_NoOnchainAddress()
+    {
+        var info = ArkBip21.Parse("bitcoin:?ark=tark1qtest");
+
+        Assert.That(info, Is.Not.Null);
+        Assert.That(info!.OnchainAddress, Is.Null);
+        Assert.That(info.ArkAddress, Is.EqualTo("tark1qtest"));
+    }
+
+    [Test]
+    public void Parse_Bip21_CaseInsensitiveScheme()
+    {
+        var info = ArkBip21.Parse("BITCOIN:bc1qtest?ark=tark1q");
+        Assert.That(info, Is.Not.Null);
+        Assert.That(info!.OnchainAddress, Is.EqualTo("bc1qtest"));
+    }
+
+    [Test]
+    public void Parse_Bip21_AmountRoundsCorrectly()
+    {
+        // 0.000000015 BTC = 1.5 sats → should round to 2
+        var info = ArkBip21.Parse("bitcoin:bc1qtest?amount=0.000000015&ark=tark1q");
+        Assert.That(info, Is.Not.Null);
+        Assert.That(info!.AmountSats, Is.EqualTo(2UL));
+    }
+
+    [Test]
+    public void Parse_Bip21_OneSat()
+    {
+        var info = ArkBip21.Parse("bitcoin:bc1qtest?amount=0.00000001&ark=tark1q");
+        Assert.That(info, Is.Not.Null);
+        Assert.That(info!.AmountSats, Is.EqualTo(1UL));
+    }
+
+    // ── Parse: Raw destinations ────────────────────────────────────────
+
+    [Test]
+    public void Parse_ArkAddress()
+    {
+        var info = ArkBip21.Parse("tark1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx");
+        Assert.That(info, Is.Not.Null);
+        Assert.That(info!.ArkAddress, Is.EqualTo("tark1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx"));
+        Assert.That(info.PreferredMethod, Is.EqualTo(ArkPaymentMethod.ArkSend));
+    }
+
+    [Test]
+    public void Parse_LightningInvoice()
+    {
+        var info = ArkBip21.Parse("lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rq");
+        Assert.That(info, Is.Not.Null);
+        Assert.That(info!.Lightning, Is.EqualTo("lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rq"));
+        Assert.That(info.PreferredMethod, Is.EqualTo(ArkPaymentMethod.SubmarineSwap));
+    }
+
+    [Test]
+    public void Parse_BitcoinAddress_Bech32()
+    {
+        var info = ArkBip21.Parse("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4");
+        Assert.That(info, Is.Not.Null);
+        Assert.That(info!.OnchainAddress, Is.EqualTo("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"));
+        Assert.That(info.PreferredMethod, Is.EqualTo(ArkPaymentMethod.ChainSwap));
+    }
+
+    [Test]
+    public void Parse_BitcoinAddress_Testnet()
+    {
+        var info = ArkBip21.Parse("tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx");
+        Assert.That(info, Is.Not.Null);
+        Assert.That(info!.OnchainAddress, Is.Not.Null);
+    }
+
+    // ── Parse: Rejection ───────────────────────────────────────────────
+
+    [Test]
+    public void Parse_Null_ReturnsNull()
+    {
+        Assert.That(ArkBip21.Parse(null), Is.Null);
+    }
+
+    [Test]
+    public void Parse_Empty_ReturnsNull()
+    {
+        Assert.That(ArkBip21.Parse(""), Is.Null);
+        Assert.That(ArkBip21.Parse("   "), Is.Null);
+    }
+
+    [Test]
+    public void Parse_Unrecognized_ReturnsNull()
+    {
+        Assert.That(ArkBip21.Parse("hello world"), Is.Null);
+        Assert.That(ArkBip21.Parse("main"), Is.Null);
+        Assert.That(ArkBip21.Parse("3.14"), Is.Null);
+        Assert.That(ArkBip21.Parse("not-an-address"), Is.Null);
+    }
+
+    [TestCase("m")]
+    [TestCase("2x")]
+    [TestCase("3")]
+    public void Parse_TooShortForLegacyAddress_ReturnsNull(string input)
+    {
+        Assert.That(ArkBip21.Parse(input), Is.Null);
+    }
+
+    // ── Parse: PreferredMethod routing ──────────────────────────────────
+
+    [Test]
+    public void PreferredMethod_ArkOverLightning()
+    {
+        var info = ArkBip21.Parse("bitcoin:bc1qtest?ark=tark1q&lightning=lnbc1");
+        Assert.That(info!.PreferredMethod, Is.EqualTo(ArkPaymentMethod.ArkSend));
+    }
+
+    [Test]
+    public void PreferredMethod_AssetForcesArk()
+    {
+        var info = new Bip21PaymentInfo
+        {
+            OnchainAddress = "bc1qtest",
+            AssetId = "abc123"
+        };
+        Assert.That(info.PreferredMethod, Is.EqualTo(ArkPaymentMethod.ArkSend));
+    }
+
+    // ── ParseStrict ────────────────────────────────────────────────────
+
+    [Test]
+    public void ParseStrict_ValidUri_Works()
+    {
+        var info = ArkBip21.ParseStrict("bitcoin:bc1qtest?ark=tark1q");
+        Assert.That(info.ArkAddress, Is.EqualTo("tark1q"));
+    }
+
+    [Test]
+    public void ParseStrict_InvalidScheme_Throws()
+    {
+        Assert.Throws<FormatException>(() => ArkBip21.ParseStrict("http://example.com"));
+    }
+
+    [Test]
+    public void ParseStrict_Empty_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => ArkBip21.ParseStrict(""));
+    }
+
+    // ── Build ──────────────────────────────────────────────────────────
+
+    [Test]
+    public void Build_ArkOnly()
+    {
+        var uri = ArkBip21.Create()
+            .WithArkAddress("tark1qtest")
+            .Build();
+
+        Assert.That(uri, Is.EqualTo("bitcoin:?ark=tark1qtest"));
+    }
+
+    [Test]
+    public void Build_FullUri()
+    {
+        var uri = ArkBip21.Create()
+            .WithOnchainAddress("bc1qtest")
+            .WithArkAddress("tark1qtest")
+            .WithAmount(0.001m)
+            .WithLightning("lnbc100n1p")
+            .Build();
+
+        Assert.That(uri, Does.StartWith("bitcoin:bc1qtest?"));
+        Assert.That(uri, Does.Contain("amount=0.001"));
+        Assert.That(uri, Does.Contain("ark=tark1qtest"));
+        Assert.That(uri, Does.Contain("lightning="));
+    }
+
+    [Test]
+    public void Build_WithAsset()
+    {
+        var uri = ArkBip21.Create()
+            .WithArkAddress("tark1qtest")
+            .WithAssetId("abc123")
+            .Build();
+
+        Assert.That(uri, Does.Contain("asset=abc123"));
+    }
+
+    [Test]
+    public void Build_NoAddress_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() => ArkBip21.Create().Build());
+    }
+
+    [Test]
+    public void Build_OnchainOnly_Works()
+    {
+        var uri = ArkBip21.Create()
+            .WithOnchainAddress("bc1qtest")
+            .Build();
+
+        Assert.That(uri, Is.EqualTo("bitcoin:bc1qtest"));
+    }
+
+    // ── Roundtrip ──────────────────────────────────────────────────────
+
+    [Test]
+    public void Build_Then_Parse_Roundtrips()
+    {
+        var uri = ArkBip21.Create()
+            .WithOnchainAddress("bc1qtest")
+            .WithArkAddress("tark1qtest")
+            .WithAmount(0.005m)
+            .WithLightning("lnbc500n1ptest")
+            .Build();
+
+        var info = ArkBip21.Parse(uri);
+
+        Assert.That(info, Is.Not.Null);
+        Assert.That(info!.OnchainAddress, Is.EqualTo("bc1qtest"));
+        Assert.That(info.ArkAddress, Is.EqualTo("tark1qtest"));
+        Assert.That(info.Amount, Is.EqualTo(0.005m));
+        Assert.That(info.AmountSats, Is.EqualTo(500_000UL));
+    }
+}

--- a/NArk.Tests/MergeAssetsTests.cs
+++ b/NArk.Tests/MergeAssetsTests.cs
@@ -1,0 +1,92 @@
+using NArk.Abstractions.VTXOs;
+using NArk.Swaps.Services;
+
+namespace NArk.Tests;
+
+[TestFixture]
+public class MergeAssetsTests
+{
+    [Test]
+    public void BothNull_ReturnsNull()
+    {
+        var result = PaymentTrackingService.MergeAssets(null, null);
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void ExistingNull_ReturnsIncoming()
+    {
+        var incoming = new List<VtxoAsset> { new("asset1", 100) };
+        var result = PaymentTrackingService.MergeAssets(null, incoming);
+        Assert.That(result, Is.SameAs(incoming));
+    }
+
+    [Test]
+    public void IncomingNull_ReturnsExisting()
+    {
+        var existing = new List<VtxoAsset> { new("asset1", 100) };
+        var result = PaymentTrackingService.MergeAssets(existing, null);
+        Assert.That(result, Is.SameAs(existing));
+    }
+
+    [Test]
+    public void IncomingEmpty_ReturnsExisting()
+    {
+        var existing = new List<VtxoAsset> { new("asset1", 100) };
+        var result = PaymentTrackingService.MergeAssets(existing, new List<VtxoAsset>());
+        Assert.That(result, Is.SameAs(existing));
+    }
+
+    [Test]
+    public void DisjointAssets_Concatenates()
+    {
+        var existing = new List<VtxoAsset> { new("asset1", 100) };
+        var incoming = new List<VtxoAsset> { new("asset2", 200) };
+
+        var result = PaymentTrackingService.MergeAssets(existing, incoming)!;
+
+        Assert.That(result, Has.Count.EqualTo(2));
+        Assert.That(result.Single(a => a.AssetId == "asset1").Amount, Is.EqualTo(100UL));
+        Assert.That(result.Single(a => a.AssetId == "asset2").Amount, Is.EqualTo(200UL));
+    }
+
+    [Test]
+    public void SameAsset_SumsAmounts()
+    {
+        var existing = new List<VtxoAsset> { new("asset1", 100) };
+        var incoming = new List<VtxoAsset> { new("asset1", 250) };
+
+        var result = PaymentTrackingService.MergeAssets(existing, incoming)!;
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0].AssetId, Is.EqualTo("asset1"));
+        Assert.That(result[0].Amount, Is.EqualTo(350UL));
+    }
+
+    [Test]
+    public void DuplicateAssetIdInExisting_HandlesGracefully()
+    {
+        // Corrupted data: same AssetId appears twice in existing
+        var existing = new List<VtxoAsset> { new("asset1", 100), new("asset1", 50) };
+        var incoming = new List<VtxoAsset> { new("asset1", 200) };
+
+        var result = PaymentTrackingService.MergeAssets(existing, incoming)!;
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0].Amount, Is.EqualTo(350UL)); // 100 + 50 + 200
+    }
+
+    [Test]
+    public void MultipleAssets_MixedMerge()
+    {
+        var existing = new List<VtxoAsset> { new("a", 10), new("b", 20) };
+        var incoming = new List<VtxoAsset> { new("b", 30), new("c", 40) };
+
+        var result = PaymentTrackingService.MergeAssets(existing, incoming)!;
+
+        Assert.That(result, Has.Count.EqualTo(3));
+        Assert.That(result.Single(x => x.AssetId == "a").Amount, Is.EqualTo(10UL));
+        Assert.That(result.Single(x => x.AssetId == "b").Amount, Is.EqualTo(50UL));
+        Assert.That(result.Single(x => x.AssetId == "c").Amount, Is.EqualTo(40UL));
+    }
+}

--- a/NArk.Tests/VtxoPollingHandlerTests.cs
+++ b/NArk.Tests/VtxoPollingHandlerTests.cs
@@ -129,9 +129,11 @@ public class PostBatchVtxoPollingHandlerTests
                 cancellationToken: Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyCollection<ArkContractEntity>>(contracts));
 
-        // Mock the VTXO snapshot to return empty (just verify it's called)
+        // Mock the VTXO snapshot (after-filtered overload — see PostBatchVtxoPollingHandler).
         _clientTransport.GetVtxoByScriptsAsSnapshot(
                 Arg.Any<IReadOnlySet<string>>(),
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<DateTimeOffset?>(),
                 Arg.Any<CancellationToken>())
             .Returns(AsyncEnumerable.Empty<ArkVtxo>());
 
@@ -140,6 +142,8 @@ public class PostBatchVtxoPollingHandlerTests
         // Verify that VTXO polling was triggered with the scripts from active contracts
         _clientTransport.Received(1).GetVtxoByScriptsAsSnapshot(
             Arg.Is<IReadOnlySet<string>>(s => s.Contains("script1")),
+            Arg.Any<DateTimeOffset?>(),
+            Arg.Any<DateTimeOffset?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -263,6 +267,8 @@ public class PostSpendVtxoPollingHandlerTests
 
         _clientTransport.GetVtxoByScriptsAsSnapshot(
                 Arg.Any<IReadOnlySet<string>>(),
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<DateTimeOffset?>(),
                 Arg.Any<CancellationToken>())
             .Returns(new[] { dummyVtxo }.ToAsyncEnumerable());
 
@@ -289,10 +295,14 @@ public class PostSpendVtxoPollingHandlerTests
 
         await _handler.HandleAsync(@event);
 
-        // pollOneByOne=true queries each script individually (1 input + 1 output = 2 calls),
-        // and returning a spent input VTXO ensures the retry loop breaks after the first attempt
-        _clientTransport.Received(2).GetVtxoByScriptsAsSnapshot(
+        // PollScriptsForVtxos now batches all scripts into a single after-filtered
+        // call (since arkd's multi-script query was fixed). The retry loop breaks
+        // after attempt 1 because the spent-input check via GetVtxosByOutpoints
+        // sees the input as spent.
+        _clientTransport.Received(1).GetVtxoByScriptsAsSnapshot(
             Arg.Any<IReadOnlySet<string>>(),
+            Arg.Any<DateTimeOffset?>(),
+            Arg.Any<DateTimeOffset?>(),
             Arg.Any<CancellationToken>());
     }
 

--- a/samples/NArk.Wallet/NArk.Wallet.Client/Program.cs
+++ b/samples/NArk.Wallet/NArk.Wallet.Client/Program.cs
@@ -28,6 +28,7 @@ builder.Services.AddBesqlDbContextFactory<WalletDbContext>(options =>
     options.UseSqlite("Data Source=ArkadeWallet.db");
 });
 builder.Services.AddArkEfCoreStorage<WalletDbContext>();
+builder.Services.AddArkPaymentTracking();
 
 // ── NArk SDK core services ──
 builder.Services.AddArkCoreServices();

--- a/samples/NArk.Wallet/NArk.Wallet.Client/Services/WalletDbContext.cs
+++ b/samples/NArk.Wallet/NArk.Wallet.Client/Services/WalletDbContext.cs
@@ -19,5 +19,6 @@ public class WalletDbContext(DbContextOptions<WalletDbContext> options) : DbCont
     {
         base.OnModelCreating(modelBuilder);
         modelBuilder.ConfigureArkEntities();
+        modelBuilder.ConfigureArkPaymentEntities();
     }
 }


### PR DESCRIPTION
## Summary
- Add asset tracking to `ArkPayment` and `ArkPaymentRequest` (JSONB columns for asset lists)
- Add `Cancelled` status to both payment and payment request enums
- Convert `PaymentTrackingService` from constructor-subscription to proper `IHostedService`
- Add `SemaphoreSlim` serialization in `OnVtxoChanged` to prevent race conditions on `ReceivedAmount`
- Add `ArkBip21` fluent builder + parser (modeled after BTCPay's `ArkadeBip21Builder`)
- Add `MergeAssets` helper with duplicate-safe dictionary merging
- **Make payment tracking fully opt-in**: consumers call `AddArkPaymentTracking()` and `ConfigureArkPaymentEntities()` separately
- 35 new unit tests (27 BIP21 + 8 MergeAssets)

## Opt-in Usage
```csharp
// DI registration
services.AddArkEfCoreStorage<MyDbContext>();
services.AddArkPaymentTracking(); // opt-in

// DbContext
modelBuilder.ConfigureArkEntities();
modelBuilder.ConfigureArkPaymentEntities(); // opt-in
```

## Test plan
- [x] All 292 unit tests pass
- [x] Build succeeds across all projects (including WASM wallet sample)
- [ ] CI green (build + E2E)