### PR TITLE
feat: HD wallet gap-limit recovery via modular discovery providers

### DIFF
--- a/NArk.Abstractions/Recovery/IContractDiscoveryProvider.cs
+++ b/NArk.Abstractions/Recovery/IContractDiscoveryProvider.cs
@@ -1,0 +1,71 @@
+using NArk.Abstractions.Contracts;
+using NArk.Abstractions.Wallets;
+using NBitcoin.Scripting;
+
+namespace NArk.Abstractions.Recovery;
+
+/// <summary>
+/// Probes a single derivation index of an HD wallet to determine whether any
+/// contract derivable from that index has ever been used. Each implementation
+/// answers from a different source of truth (arkd indexer, on-chain UTXO set,
+/// boltz swap history, etc.) and they are aggregated by
+/// <c>HdWalletRecoveryService</c> using a logical OR — if any provider sees
+/// usage at an index, the index counts as used and the gap counter resets.
+/// </summary>
+/// <remarks>
+/// Providers are stateless and may be queried concurrently for different
+/// indices. They MUST NOT mutate <see cref="IWalletStorage"/> or
+/// <see cref="IContractStorage"/> directly; instead, return any contracts they
+/// reconstructed via <see cref="DiscoveryResult.Contracts"/>, and the
+/// orchestrator persists them once recovery completes.
+/// </remarks>
+public interface IContractDiscoveryProvider
+{
+    /// <summary>
+    /// Short identifier used in log lines and the recovery report
+    /// (e.g. <c>"indexer"</c>, <c>"boarding"</c>, <c>"boltz"</c>).
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Probe whether any contract derivable from <paramref name="userDescriptor"/>
+    /// at <paramref name="index"/> has ever been used.
+    /// </summary>
+    /// <param name="wallet">The HD wallet being recovered.</param>
+    /// <param name="userDescriptor">
+    /// The output descriptor at the given index — concrete (no remaining
+    /// <c>/*</c>), already derived from <c>wallet.AccountDescriptor</c>.
+    /// </param>
+    /// <param name="index">The derivation index being probed.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// A <see cref="DiscoveryResult"/> describing whether the index was used and,
+    /// if so, the reconstructed contracts to persist.
+    /// </returns>
+    Task<DiscoveryResult> DiscoverAsync(
+        ArkWalletInfo wallet,
+        OutputDescriptor userDescriptor,
+        int index,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Result of querying a single <see cref="IContractDiscoveryProvider"/> for one index.
+/// </summary>
+/// <param name="Used">
+/// <c>true</c> if the provider found evidence the descriptor at this index has
+/// been used (a VTXO, an on-chain boarding UTXO, a boltz swap, etc.).
+/// </param>
+/// <param name="Contracts">
+/// Contracts the provider reconstructed and would like the orchestrator to
+/// persist. May be empty even when <paramref name="Used"/> is true if the
+/// provider only knows "this was used" but not enough to materialize a
+/// contract on its own.
+/// </param>
+public record DiscoveryResult(
+    bool Used,
+    IReadOnlyList<ArkContract> Contracts)
+{
+    /// <summary>Convenience: provider saw nothing at this index.</summary>
+    public static DiscoveryResult NotFound { get; } = new(false, []);
+}

--- a/NArk.Abstractions/Recovery/IContractDiscoveryProvider.cs
+++ b/NArk.Abstractions/Recovery/IContractDiscoveryProvider.cs
@@ -13,11 +13,29 @@ namespace NArk.Abstractions.Recovery;
 /// usage at an index, the index counts as used and the gap counter resets.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Providers are stateless and may be queried concurrently for different
-/// indices. They MUST NOT mutate <see cref="IWalletStorage"/> or
-/// <see cref="IContractStorage"/> directly; instead, return any contracts they
-/// reconstructed via <see cref="DiscoveryResult.Contracts"/>, and the
-/// orchestrator persists them once recovery completes.
+/// indices (and concurrently with each other for the same index).
+/// </para>
+/// <para>
+/// As a rule, providers SHOULD return reconstructed contracts via
+/// <see cref="DiscoveryResult.Contracts"/> and let the orchestrator persist
+/// them once recovery completes — this keeps the orchestrator the single
+/// writer and lets it dedupe across providers.
+/// </para>
+/// <para>
+/// The deliberate exception is when a provider already has a richer import
+/// path of its own that produces metadata the orchestrator cannot reconstruct.
+/// <c>BoltzSwapDiscoveryProvider</c> is the canonical example: it delegates to
+/// <c>SwapsManagementService.RestoreSwaps</c>, which writes both the contract
+/// (with <c>Source=swap:&lt;id&gt;</c> metadata) and the corresponding
+/// <c>SwapData</c> row in one transaction. Returning those contracts back
+/// through the orchestrator would either lose the swap-id linkage or require
+/// duplicating the same write. Such providers should set
+/// <see cref="DiscoveryResult.Used"/> to <c>true</c> and leave
+/// <see cref="DiscoveryResult.Contracts"/> empty so the orchestrator does not
+/// re-import what they already persisted.
+/// </para>
 /// </remarks>
 public interface IContractDiscoveryProvider
 {

--- a/NArk.Abstractions/Recovery/RecoveryOptions.cs
+++ b/NArk.Abstractions/Recovery/RecoveryOptions.cs
@@ -6,15 +6,17 @@ namespace NArk.Abstractions.Recovery;
 /// <param name="GapLimit">
 /// Number of consecutive unused derivation indices that signals the end of
 /// usage and stops the scan. BIP44 recommends 20; tune higher for wallets
-/// known to have generated many addresses ahead of use.
+/// known to have generated many addresses ahead of use. MUST be &gt; 0.
 /// </param>
 /// <param name="MaxIndex">
 /// Hard upper bound on the highest index probed. Acts as a safety stop in
-/// case the gap is never reached on a pathological provider.
+/// case the gap is never reached on a pathological provider. MUST be
+/// ≥ <paramref name="StartIndex"/>.
 /// </param>
 /// <param name="StartIndex">
 /// First derivation index to probe. Default 0 (full scan from the start);
 /// callers can resume a partial scan by passing the highest known index.
+/// MUST be ≥ 0.
 /// </param>
 public record RecoveryOptions(
     int GapLimit = 20,
@@ -23,6 +25,22 @@ public record RecoveryOptions(
 {
     /// <summary>Default options (gap=20, max=10000, start=0).</summary>
     public static RecoveryOptions Default { get; } = new();
+
+    /// <summary>
+    /// Validates the options and throws <see cref="ArgumentOutOfRangeException"/>
+    /// if any field is nonsensical. Called by <c>HdWalletRecoveryService.ScanAsync</c>
+    /// at the start of every scan.
+    /// </summary>
+    public void Validate()
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(GapLimit, nameof(GapLimit));
+        ArgumentOutOfRangeException.ThrowIfNegative(StartIndex, nameof(StartIndex));
+        ArgumentOutOfRangeException.ThrowIfNegative(MaxIndex, nameof(MaxIndex));
+        if (StartIndex > MaxIndex)
+            throw new ArgumentOutOfRangeException(
+                nameof(StartIndex),
+                $"StartIndex ({StartIndex}) cannot exceed MaxIndex ({MaxIndex}).");
+    }
 }
 
 /// <summary>

--- a/NArk.Abstractions/Recovery/RecoveryOptions.cs
+++ b/NArk.Abstractions/Recovery/RecoveryOptions.cs
@@ -1,0 +1,56 @@
+namespace NArk.Abstractions.Recovery;
+
+/// <summary>
+/// Configuration for an HD wallet recovery scan.
+/// </summary>
+/// <param name="GapLimit">
+/// Number of consecutive unused derivation indices that signals the end of
+/// usage and stops the scan. BIP44 recommends 20; tune higher for wallets
+/// known to have generated many addresses ahead of use.
+/// </param>
+/// <param name="MaxIndex">
+/// Hard upper bound on the highest index probed. Acts as a safety stop in
+/// case the gap is never reached on a pathological provider.
+/// </param>
+/// <param name="StartIndex">
+/// First derivation index to probe. Default 0 (full scan from the start);
+/// callers can resume a partial scan by passing the highest known index.
+/// </param>
+public record RecoveryOptions(
+    int GapLimit = 20,
+    int MaxIndex = 10_000,
+    int StartIndex = 0)
+{
+    /// <summary>Default options (gap=20, max=10000, start=0).</summary>
+    public static RecoveryOptions Default { get; } = new();
+}
+
+/// <summary>
+/// Summary of an HD wallet recovery scan.
+/// </summary>
+/// <param name="HighestUsedIndex">
+/// Highest derivation index that any provider reported as used; <c>-1</c> if
+/// no usage was detected at all.
+/// </param>
+/// <param name="ScannedCount">Total number of indices probed.</param>
+/// <param name="DiscoveredContracts">
+/// Contracts that were reconstructed and persisted during the scan.
+/// </param>
+/// <param name="ProviderHits">
+/// Per-provider counts of indices each one reported as used. Useful for
+/// logging and tests.
+/// </param>
+public record RecoveryReport(
+    int HighestUsedIndex,
+    int ScannedCount,
+    IReadOnlyList<DiscoveredContract> DiscoveredContracts,
+    IReadOnlyDictionary<string, int> ProviderHits);
+
+/// <summary>
+/// A single contract that recovery reconstructed, with the index it came from
+/// and the provider that detected it.
+/// </summary>
+public record DiscoveredContract(
+    int Index,
+    string ProviderName,
+    NArk.Abstractions.Contracts.ArkContract Contract);

--- a/NArk.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/NArk.Core/Hosting/ServiceCollectionExtensions.cs
@@ -2,10 +2,12 @@ using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using NArk.Abstractions.Fees;
 using NArk.Abstractions.Wallets;
+using NArk.Abstractions.Recovery;
 using NArk.Core.CoinSelector;
 using NArk.Core.Events;
 using NArk.Core.Fees;
 using NArk.Core.Models.Options;
+using NArk.Core.Recovery;
 using NArk.Core.Services;
 using NArk.Core.Sweeper;
 using NArk.Abstractions.Services;
@@ -95,6 +97,20 @@ public static class ServiceCollectionExtensions
 
         // VTXO polling - automatically poll for updates after batch success and spend transactions
         services.AddVtxoPolling();
+
+        // HD-wallet recovery: gap-limit scan for prior contract usage on import.
+        services.AddSingleton<HdWalletRecoveryService>();
+        services.AddSingleton<IContractDiscoveryProvider, IndexerVtxoDiscoveryProvider>();
+        // BoardingUtxoDiscoveryProvider activates only when an IBoardingUtxoProvider has
+        // been registered (typically by the plugin via NBXplorer/Esplora). When absent the
+        // provider is a no-op so HD recovery still works without on-chain probing.
+        services.AddSingleton<IContractDiscoveryProvider>(sp =>
+            sp.GetService<IBoardingUtxoProvider>() is { } utxoProvider
+                ? new BoardingUtxoDiscoveryProvider(
+                    utxoProvider,
+                    sp.GetRequiredService<IClientTransport>(),
+                    sp.GetService<ILogger<BoardingUtxoDiscoveryProvider>>())
+                : NullContractDiscoveryProvider.Instance);
 
         return services;
     }

--- a/NArk.Core/Recovery/BoardingUtxoDiscoveryProvider.cs
+++ b/NArk.Core/Recovery/BoardingUtxoDiscoveryProvider.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Logging;
+using NArk.Abstractions.Recovery;
+using NArk.Abstractions.Services;
+using NArk.Abstractions.Wallets;
+using NArk.Core.Contracts;
+using NArk.Core.Transport;
+using NBitcoin.Scripting;
+
+namespace NArk.Core.Recovery;
+
+/// <summary>
+/// Discovery provider that asks the on-chain side (NBXplorer / Esplora,
+/// abstracted by <see cref="IBoardingUtxoProvider"/>) whether the
+/// <see cref="ArkBoardingContract"/> derived from a given HD index ever
+/// received a UTXO. Boarding contracts are one-shot funding entry points
+/// onto the Ark — a historical hit at any index is unambiguous evidence
+/// of usage.
+/// </summary>
+/// <remarks>
+/// <see cref="IBoardingUtxoProvider"/> is optional in the SDK (the plugin
+/// provides one via NBXplorer). When no implementation is registered this
+/// provider is also not registered, so HD recovery still works without
+/// on-chain probing — just without boarding-address detection.
+/// </remarks>
+public class BoardingUtxoDiscoveryProvider(
+    IBoardingUtxoProvider utxoProvider,
+    IClientTransport clientTransport,
+    ILogger<BoardingUtxoDiscoveryProvider>? logger = null) : IContractDiscoveryProvider
+{
+    /// <inheritdoc />
+    public string Name => "boarding";
+
+    /// <inheritdoc />
+    public async Task<DiscoveryResult> DiscoverAsync(
+        ArkWalletInfo wallet,
+        OutputDescriptor userDescriptor,
+        int index,
+        CancellationToken cancellationToken = default)
+    {
+        var serverInfo = await clientTransport.GetServerInfoAsync(cancellationToken);
+        var contract = new ArkBoardingContract(serverInfo.SignerKey, serverInfo.BoardingExit, userDescriptor);
+        var address = contract.GetOnchainAddress(serverInfo.Network).ToString();
+
+        var utxos = await utxoProvider.GetUtxosAsync(address, cancellationToken);
+        if (utxos.Count == 0) return DiscoveryResult.NotFound;
+
+        logger?.LogDebug(
+            "BoardingUtxoDiscoveryProvider: hit at index {Index} on address {Address} ({Count} UTXO(s))",
+            index, address, utxos.Count);
+        return new DiscoveryResult(true, [contract]);
+    }
+}

--- a/NArk.Core/Recovery/BoardingUtxoDiscoveryProvider.cs
+++ b/NArk.Core/Recovery/BoardingUtxoDiscoveryProvider.cs
@@ -27,6 +27,12 @@ public class BoardingUtxoDiscoveryProvider(
     IClientTransport clientTransport,
     ILogger<BoardingUtxoDiscoveryProvider>? logger = null) : IContractDiscoveryProvider
 {
+    // See IndexerVtxoDiscoveryProvider for rationale: ArkServerInfo is invariant
+    // for a recovery scan, fetch once and reuse for every probe.
+    private readonly Lazy<Task<ArkServerInfo>> _serverInfo = new(
+        () => clientTransport.GetServerInfoAsync(),
+        LazyThreadSafetyMode.ExecutionAndPublication);
+
     /// <inheritdoc />
     public string Name => "boarding";
 
@@ -37,7 +43,7 @@ public class BoardingUtxoDiscoveryProvider(
         int index,
         CancellationToken cancellationToken = default)
     {
-        var serverInfo = await clientTransport.GetServerInfoAsync(cancellationToken);
+        var serverInfo = await _serverInfo.Value.WaitAsync(cancellationToken);
         var contract = new ArkBoardingContract(serverInfo.SignerKey, serverInfo.BoardingExit, userDescriptor);
         var address = contract.GetOnchainAddress(serverInfo.Network).ToString();
 

--- a/NArk.Core/Recovery/HdWalletRecoveryService.cs
+++ b/NArk.Core/Recovery/HdWalletRecoveryService.cs
@@ -3,6 +3,7 @@ using NArk.Abstractions.Contracts;
 using NArk.Abstractions.Recovery;
 using NArk.Abstractions.Wallets;
 using NArk.Core.Transport;
+using NArk.Core.Wallet;
 using NBitcoin;
 using NBitcoin.Scripting;
 
@@ -45,6 +46,7 @@ public class HdWalletRecoveryService(
         CancellationToken cancellationToken = default)
     {
         options ??= RecoveryOptions.Default;
+        options.Validate();
 
         var wallet = await walletStorage.GetWalletById(walletId, cancellationToken)
             ?? throw new InvalidOperationException($"Wallet '{walletId}' not found.");
@@ -82,29 +84,25 @@ public class HdWalletRecoveryService(
             cancellationToken.ThrowIfCancellationRequested();
             scanned++;
 
-            var descriptor = DeriveAtIndex(wallet.AccountDescriptor, index, network);
+            // Reuse the canonical derivation method so this stays in lockstep with
+            // the runtime path (HierarchicalDeterministicAddressProvider.GetNextSigningDescriptor) —
+            // any divergence here would silently make recovery look at the wrong scripts.
+            var descriptor = HierarchicalDeterministicAddressProvider.GetDescriptorFromIndex(
+                network, wallet.AccountDescriptor, index);
+
+            // Probe every provider in parallel — they hit different backends
+            // (gRPC to arkd, HTTP to Boltz, HTTP to Esplora etc.) and the
+            // interface contract requires them to be safe under concurrent use.
+            var probes = providersList
+                .Select(p => ProbeAsync(p, wallet, descriptor, index, cancellationToken))
+                .ToArray();
+            var probeResults = await Task.WhenAll(probes);
 
             var indexUsed = false;
-            foreach (var provider in providersList)
+            for (var i = 0; i < probeResults.Length; i++)
             {
-                DiscoveryResult result;
-                try
-                {
-                    result = await provider.DiscoverAsync(wallet, descriptor, index, cancellationToken);
-                }
-                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-                {
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    logger?.LogWarning(ex,
-                        "Recovery: provider {Provider} threw at index {Index}; treating as not-found",
-                        provider.Name, index);
-                    continue;
-                }
-
-                if (!result.Used) continue;
+                var (provider, result) = (providersList[i], probeResults[i]);
+                if (result is null || !result.Used) continue;
 
                 indexUsed = true;
                 providerHits[provider.Name]++;
@@ -164,16 +162,28 @@ public class HdWalletRecoveryService(
         return report;
     }
 
-    private static OutputDescriptor DeriveAtIndex(string accountDescriptor, int index, Network network)
+    private async Task<DiscoveryResult?> ProbeAsync(
+        IContractDiscoveryProvider provider,
+        ArkWalletInfo wallet,
+        OutputDescriptor descriptor,
+        int index,
+        CancellationToken cancellationToken)
     {
-        // Mirror HierarchicalDeterministicAddressProvider.GetDescriptorFromIndex:
-        // the AccountDescriptor stores the wildcard form `tr([origin]xpub/*)`,
-        // and the concrete descriptor at index N is the wildcard with `/*`
-        // replaced by `/N`. We also tolerate /0/* legacy form by replacing /0/* first.
-        var resolved = accountDescriptor.Contains("/0/*")
-            ? accountDescriptor.Replace("/0/*", $"/0/{index}")
-            : accountDescriptor.Replace("/*", $"/{index}");
-        return OutputDescriptor.Parse(resolved, network);
+        try
+        {
+            return await provider.DiscoverAsync(wallet, descriptor, index, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogWarning(ex,
+                "Recovery: provider {Provider} threw at index {Index}; treating as not-found",
+                provider.Name, index);
+            return null;
+        }
     }
 
     private async Task PersistDiscoveriesAsync(
@@ -192,6 +202,11 @@ public class HdWalletRecoveryService(
             var script = entry.Contract.GetScriptPubKey().ToHex();
             if (!seenScripts.Add(script)) continue;
 
+            // Persist as Active even if the contract has already been fully spent;
+            // VTXO polling will reconcile the activity state on the next sync tick
+            // (sweepers / one-time-use transformers will deactivate it). Marking
+            // as Active here ensures the script enters the subscription set so
+            // any late-arriving VTXOs aren't missed during recovery.
             var entity = entry.Contract.ToEntity(
                 wallet.Id,
                 serverKey,

--- a/NArk.Core/Recovery/HdWalletRecoveryService.cs
+++ b/NArk.Core/Recovery/HdWalletRecoveryService.cs
@@ -1,0 +1,218 @@
+using Microsoft.Extensions.Logging;
+using NArk.Abstractions.Contracts;
+using NArk.Abstractions.Recovery;
+using NArk.Abstractions.Wallets;
+using NArk.Core.Transport;
+using NBitcoin;
+using NBitcoin.Scripting;
+
+namespace NArk.Core.Recovery;
+
+/// <summary>
+/// Iteratively probes derivation indices of an HD wallet to recover contracts
+/// that were used before the wallet was imported into local storage. Each
+/// index is probed by every registered <see cref="IContractDiscoveryProvider"/>
+/// (arkd indexer, on-chain boarding, boltz, …) and the union of results
+/// determines whether the index counts as used.
+/// </summary>
+/// <remarks>
+/// The scan stops once <see cref="RecoveryOptions.GapLimit"/> consecutive
+/// unused indices are seen, or once <see cref="RecoveryOptions.MaxIndex"/> is
+/// reached. Discovered contracts are persisted via <see cref="IContractStorage"/>
+/// and <c>wallet.LastUsedIndex</c> is bumped to <c>HighestUsedIndex + 1</c> so
+/// future derivations don't collide with recovered scripts.
+/// </remarks>
+public class HdWalletRecoveryService(
+    IEnumerable<IContractDiscoveryProvider> providers,
+    IWalletStorage walletStorage,
+    IContractStorage contractStorage,
+    IClientTransport clientTransport,
+    ILogger<HdWalletRecoveryService>? logger = null)
+{
+    /// <summary>
+    /// Scan an HD wallet's derivation indices for prior usage.
+    /// </summary>
+    /// <param name="walletId">The wallet to recover. MUST be a HD wallet.</param>
+    /// <param name="options">Scan configuration. Defaults to <see cref="RecoveryOptions.Default"/>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A <see cref="RecoveryReport"/> describing what was found.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// If the wallet is not HD, has no AccountDescriptor, or is unknown.
+    /// </exception>
+    public async Task<RecoveryReport> ScanAsync(
+        string walletId,
+        RecoveryOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        options ??= RecoveryOptions.Default;
+
+        var wallet = await walletStorage.GetWalletById(walletId, cancellationToken)
+            ?? throw new InvalidOperationException($"Wallet '{walletId}' not found.");
+        if (wallet.WalletType != WalletType.HD)
+            throw new InvalidOperationException(
+                $"Recovery only supports HD wallets; '{walletId}' is {wallet.WalletType}.");
+        if (string.IsNullOrEmpty(wallet.AccountDescriptor))
+            throw new InvalidOperationException($"Wallet '{walletId}' has no AccountDescriptor.");
+
+        var serverInfo = await clientTransport.GetServerInfoAsync(cancellationToken);
+        var network = serverInfo.Network;
+        // Drop any no-op placeholders (e.g. NullContractDiscoveryProvider that the
+        // DI graph injects when an optional source like IBoardingUtxoProvider is missing).
+        var providersList = providers
+            .Where(p => p is not NullContractDiscoveryProvider)
+            .ToList();
+        if (providersList.Count == 0)
+        {
+            logger?.LogWarning("HdWalletRecoveryService: no IContractDiscoveryProvider registered — scan will be a no-op");
+        }
+
+        logger?.LogInformation(
+            "Recovery scan starting for wallet {WalletId} with gap={Gap}, maxIndex={Max}, providers=[{Providers}]",
+            walletId, options.GapLimit, options.MaxIndex,
+            string.Join(", ", providersList.Select(p => p.Name)));
+
+        var discoveredContracts = new List<DiscoveredContract>();
+        var providerHits = providersList.ToDictionary(p => p.Name, _ => 0);
+        var highestUsed = -1;
+        var consecutiveMisses = 0;
+        var scanned = 0;
+
+        for (var index = options.StartIndex; index <= options.MaxIndex; index++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            scanned++;
+
+            var descriptor = DeriveAtIndex(wallet.AccountDescriptor, index, network);
+
+            var indexUsed = false;
+            foreach (var provider in providersList)
+            {
+                DiscoveryResult result;
+                try
+                {
+                    result = await provider.DiscoverAsync(wallet, descriptor, index, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogWarning(ex,
+                        "Recovery: provider {Provider} threw at index {Index}; treating as not-found",
+                        provider.Name, index);
+                    continue;
+                }
+
+                if (!result.Used) continue;
+
+                indexUsed = true;
+                providerHits[provider.Name]++;
+                foreach (var contract in result.Contracts)
+                {
+                    discoveredContracts.Add(new DiscoveredContract(index, provider.Name, contract));
+                }
+            }
+
+            if (indexUsed)
+            {
+                highestUsed = index;
+                consecutiveMisses = 0;
+                logger?.LogInformation(
+                    "Recovery: index {Index} used (running highest={Highest}, contracts so far={Count})",
+                    index, highestUsed, discoveredContracts.Count);
+            }
+            else
+            {
+                consecutiveMisses++;
+                if (consecutiveMisses >= options.GapLimit)
+                {
+                    logger?.LogInformation(
+                        "Recovery: hit gap limit of {Gap} after index {Index}; stopping scan",
+                        options.GapLimit, index);
+                    break;
+                }
+            }
+        }
+
+        // Persist discovered contracts. We do this after the scan so we can
+        // dedupe by script (one provider may reconstruct a contract another
+        // provider already touched, e.g. boltz reconstructing a VHTLC whose
+        // settled VTXO the indexer also reported).
+        await PersistDiscoveriesAsync(wallet, discoveredContracts, serverInfo.SignerKey, cancellationToken);
+
+        if (highestUsed >= 0)
+        {
+            var newLastUsed = Math.Max(highestUsed + 1, wallet.LastUsedIndex);
+            if (newLastUsed != wallet.LastUsedIndex)
+            {
+                logger?.LogInformation(
+                    "Recovery: bumping wallet {WalletId} LastUsedIndex {Old} -> {New}",
+                    walletId, wallet.LastUsedIndex, newLastUsed);
+                await walletStorage.UpdateLastUsedIndex(walletId, newLastUsed, cancellationToken);
+            }
+        }
+
+        var report = new RecoveryReport(
+            highestUsed,
+            scanned,
+            discoveredContracts,
+            providerHits);
+        logger?.LogInformation(
+            "Recovery scan finished for wallet {WalletId}: scanned={Scanned}, highestUsed={Highest}, discovered={Count}",
+            walletId, scanned, highestUsed, discoveredContracts.Count);
+        return report;
+    }
+
+    private static OutputDescriptor DeriveAtIndex(string accountDescriptor, int index, Network network)
+    {
+        // Mirror HierarchicalDeterministicAddressProvider.GetDescriptorFromIndex:
+        // the AccountDescriptor stores the wildcard form `tr([origin]xpub/*)`,
+        // and the concrete descriptor at index N is the wildcard with `/*`
+        // replaced by `/N`. We also tolerate /0/* legacy form by replacing /0/* first.
+        var resolved = accountDescriptor.Contains("/0/*")
+            ? accountDescriptor.Replace("/0/*", $"/0/{index}")
+            : accountDescriptor.Replace("/*", $"/{index}");
+        return OutputDescriptor.Parse(resolved, network);
+    }
+
+    private async Task PersistDiscoveriesAsync(
+        ArkWalletInfo wallet,
+        IReadOnlyList<DiscoveredContract> discovered,
+        OutputDescriptor serverKey,
+        CancellationToken cancellationToken)
+    {
+        if (discovered.Count == 0) return;
+
+        // Dedupe by script — different providers may reconstruct the same
+        // contract; persist whichever we saw first.
+        var seenScripts = new HashSet<string>();
+        foreach (var entry in discovered)
+        {
+            var script = entry.Contract.GetScriptPubKey().ToHex();
+            if (!seenScripts.Add(script)) continue;
+
+            var entity = entry.Contract.ToEntity(
+                wallet.Id,
+                serverKey,
+                activityState: ContractActivityState.Active) with
+            {
+                Metadata = new Dictionary<string, string>
+                {
+                    ["Source"] = $"recovery:{entry.ProviderName}",
+                    ["RecoveryIndex"] = entry.Index.ToString(),
+                },
+            };
+            try
+            {
+                await contractStorage.SaveContract(entity, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex,
+                    "Recovery: failed to persist contract at index {Index} from {Provider}",
+                    entry.Index, entry.ProviderName);
+            }
+        }
+    }
+}

--- a/NArk.Core/Recovery/IndexerVtxoDiscoveryProvider.cs
+++ b/NArk.Core/Recovery/IndexerVtxoDiscoveryProvider.cs
@@ -1,0 +1,47 @@
+using Microsoft.Extensions.Logging;
+using NArk.Abstractions.Contracts;
+using NArk.Abstractions.Recovery;
+using NArk.Abstractions.Wallets;
+using NArk.Core.Contracts;
+using NArk.Core.Transport;
+using NBitcoin.Scripting;
+
+namespace NArk.Core.Recovery;
+
+/// <summary>
+/// Discovery provider that asks arkd's indexer whether the
+/// <see cref="ArkPaymentContract"/> derived from a given HD index has any
+/// VTXO recorded against it (spent or unspent). A single VTXO at any state
+/// is sufficient evidence the index was used.
+/// </summary>
+public class IndexerVtxoDiscoveryProvider(
+    IClientTransport clientTransport,
+    ILogger<IndexerVtxoDiscoveryProvider>? logger = null) : IContractDiscoveryProvider
+{
+    /// <inheritdoc />
+    public string Name => "indexer";
+
+    /// <inheritdoc />
+    public async Task<DiscoveryResult> DiscoverAsync(
+        ArkWalletInfo wallet,
+        OutputDescriptor userDescriptor,
+        int index,
+        CancellationToken cancellationToken = default)
+    {
+        var serverInfo = await clientTransport.GetServerInfoAsync(cancellationToken);
+        var contract = new ArkPaymentContract(serverInfo.SignerKey, serverInfo.UnilateralExit, userDescriptor);
+        var script = contract.GetScriptPubKey().ToHex();
+
+        await foreach (var _ in clientTransport.GetVtxoByScriptsAsSnapshot(
+                           new HashSet<string> { script }, cancellationToken))
+        {
+            // Any VTXO is enough — return immediately to avoid streaming the whole script's history.
+            logger?.LogDebug(
+                "IndexerVtxoDiscoveryProvider: hit at index {Index} on script {Script}",
+                index, script);
+            return new DiscoveryResult(true, [contract]);
+        }
+
+        return DiscoveryResult.NotFound;
+    }
+}

--- a/NArk.Core/Recovery/IndexerVtxoDiscoveryProvider.cs
+++ b/NArk.Core/Recovery/IndexerVtxoDiscoveryProvider.cs
@@ -18,6 +18,14 @@ public class IndexerVtxoDiscoveryProvider(
     IClientTransport clientTransport,
     ILogger<IndexerVtxoDiscoveryProvider>? logger = null) : IContractDiscoveryProvider
 {
+    // ArkServerInfo is invariant for the wallet-recovery use case (signer key,
+    // exit delays, network — all server-side config that doesn't change between
+    // probes). Cache the fetch on first use and reuse for every subsequent
+    // index — saves N round-trips per scan when a wallet has dozens of indices.
+    private readonly Lazy<Task<ArkServerInfo>> _serverInfo = new(
+        () => clientTransport.GetServerInfoAsync(),
+        LazyThreadSafetyMode.ExecutionAndPublication);
+
     /// <inheritdoc />
     public string Name => "indexer";
 
@@ -28,7 +36,7 @@ public class IndexerVtxoDiscoveryProvider(
         int index,
         CancellationToken cancellationToken = default)
     {
-        var serverInfo = await clientTransport.GetServerInfoAsync(cancellationToken);
+        var serverInfo = await _serverInfo.Value.WaitAsync(cancellationToken);
         var contract = new ArkPaymentContract(serverInfo.SignerKey, serverInfo.UnilateralExit, userDescriptor);
         var script = contract.GetScriptPubKey().ToHex();
 

--- a/NArk.Core/Recovery/NullContractDiscoveryProvider.cs
+++ b/NArk.Core/Recovery/NullContractDiscoveryProvider.cs
@@ -1,0 +1,27 @@
+using NArk.Abstractions.Recovery;
+using NArk.Abstractions.Wallets;
+using NBitcoin.Scripting;
+
+namespace NArk.Core.Recovery;
+
+/// <summary>
+/// No-op discovery provider used as a placeholder when an optional dependency
+/// (e.g. <c>IBoardingUtxoProvider</c>) isn't registered. Always returns
+/// <see cref="DiscoveryResult.NotFound"/> so it's invisible to the gap-limit
+/// orchestrator while still satisfying DI.
+/// </summary>
+internal sealed class NullContractDiscoveryProvider : IContractDiscoveryProvider
+{
+    public static readonly NullContractDiscoveryProvider Instance = new();
+
+    private NullContractDiscoveryProvider() { }
+
+    public string Name => "null";
+
+    public Task<DiscoveryResult> DiscoverAsync(
+        ArkWalletInfo wallet,
+        OutputDescriptor userDescriptor,
+        int index,
+        CancellationToken cancellationToken = default)
+        => Task.FromResult(DiscoveryResult.NotFound);
+}

--- a/NArk.Core/Wallet/HierarchicalDeterministicAddressProvider.cs
+++ b/NArk.Core/Wallet/HierarchicalDeterministicAddressProvider.cs
@@ -55,7 +55,14 @@ public class HierarchicalDeterministicAddressProvider(
         return descriptor;
     }
 
-    private static OutputDescriptor GetDescriptorFromIndex(Network network, string descriptor, int index)
+    /// <summary>
+    /// Resolves the wildcard <paramref name="descriptor"/> at the given <paramref name="index"/>.
+    /// This is the canonical derivation entry point — both the runtime
+    /// <see cref="GetNextSigningDescriptor"/> path and any external recovery
+    /// scanners (e.g. <c>HdWalletRecoveryService</c>) MUST go through here so
+    /// they always agree on which script corresponds to a given HD index.
+    /// </summary>
+    internal static OutputDescriptor GetDescriptorFromIndex(Network network, string descriptor, int index)
     {
         return OutputDescriptor.Parse(descriptor.Replace("/*", $"/{index}"), network);
     }

--- a/NArk.Swaps/Hosting/SwapServiceCollectionExtensions.cs
+++ b/NArk.Swaps/Hosting/SwapServiceCollectionExtensions.cs
@@ -1,10 +1,12 @@
 using Microsoft.Extensions.DependencyInjection;
+using NArk.Abstractions.Recovery;
 using NArk.Core.Sweeper;
 using NArk.Core.Transformers;
 using NArk.Swaps.Boltz;
 using NArk.Swaps.Boltz.Client;
 using NArk.Swaps.Boltz.Models;
 using NArk.Swaps.Policies;
+using NArk.Swaps.Recovery;
 using NArk.Swaps.Services;
 using NArk.Swaps.Transformers;
 
@@ -24,6 +26,7 @@ public static class SwapServiceCollectionExtensions
         services.AddSingleton<SwapsManagementService>();
         services.AddSingleton<ISweepPolicy, SwapSweepPolicy>();
         services.AddSingleton<IContractTransformer, VHTLCContractTransformer>();
+        services.AddSingleton<IContractDiscoveryProvider, BoltzSwapDiscoveryProvider>();
         
         services.AddSingleton<CachedBoltzClient>();
         services.AddSingleton<BoltzLimitsValidator>();

--- a/NArk.Swaps/Recovery/BoltzSwapDiscoveryProvider.cs
+++ b/NArk.Swaps/Recovery/BoltzSwapDiscoveryProvider.cs
@@ -1,0 +1,61 @@
+using Microsoft.Extensions.Logging;
+using NArk.Abstractions.Recovery;
+using NArk.Abstractions.Wallets;
+using NArk.Swaps.Services;
+using NBitcoin.Scripting;
+
+namespace NArk.Swaps.Recovery;
+
+/// <summary>
+/// Discovery provider that asks Boltz whether the user pubkey at the given
+/// HD derivation index ever participated in a swap as sender or receiver.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This provider piggybacks on <see cref="SwapsManagementService.RestoreSwaps"/>
+/// — calling it for a single descriptor causes Boltz's <c>/v2/swap/restore</c>
+/// to be queried for the descriptor's pubkey. If the call returns any swaps
+/// they are reconstructed, persisted as <c>VHTLCContract</c>s, and recorded
+/// in <c>ISwapStorage</c> with their original swap-id metadata.
+/// </para>
+/// <para>
+/// We deliberately do NOT return the reconstructed contracts back to the
+/// recovery orchestrator: <see cref="SwapsManagementService.RestoreSwaps"/>
+/// already imported them with rich <c>Source=swap:&lt;id&gt;</c> metadata, and
+/// reusing that path keeps the swap-side bookkeeping correct. The orchestrator
+/// only learns that boltz saw usage at this index, which is sufficient for
+/// gap-limit accounting.
+/// </para>
+/// <para>
+/// Performance: at most one HTTP call per scanned index. For the typical
+/// gap-of-20 scan that is bounded at ~25 calls — fine for a one-time recovery
+/// operation.
+/// </para>
+/// </remarks>
+public class BoltzSwapDiscoveryProvider(
+    SwapsManagementService swapsManagementService,
+    ILogger<BoltzSwapDiscoveryProvider>? logger = null) : IContractDiscoveryProvider
+{
+    /// <inheritdoc />
+    public string Name => "boltz";
+
+    /// <inheritdoc />
+    public async Task<DiscoveryResult> DiscoverAsync(
+        ArkWalletInfo wallet,
+        OutputDescriptor userDescriptor,
+        int index,
+        CancellationToken cancellationToken = default)
+    {
+        var restored = await swapsManagementService.RestoreSwaps(
+            wallet.Id, [userDescriptor], cancellationToken);
+
+        if (restored.Count == 0) return DiscoveryResult.NotFound;
+
+        logger?.LogDebug(
+            "BoltzSwapDiscoveryProvider: hit at index {Index} — restored {Count} swap(s)",
+            index, restored.Count);
+        // RestoreSwaps already imported the VHTLC contracts via IContractService.
+        // Return Used=true with no extra contracts to avoid double-imports.
+        return new DiscoveryResult(true, []);
+    }
+}

--- a/NArk.Tests/Recovery/HdWalletRecoveryServiceTests.cs
+++ b/NArk.Tests/Recovery/HdWalletRecoveryServiceTests.cs
@@ -1,0 +1,297 @@
+using NArk.Abstractions.Contracts;
+using NArk.Abstractions.Extensions;
+using NArk.Abstractions.Recovery;
+using NArk.Abstractions.Wallets;
+using NArk.Core;
+using NArk.Core.Contracts;
+using NArk.Core.Recovery;
+using NArk.Core.Scripts;
+using NArk.Core.Transport;
+using NBitcoin;
+using NBitcoin.Scripting;
+using NBitcoin.Secp256k1;
+using NSubstitute;
+
+namespace NArk.Tests.Recovery;
+
+[TestFixture]
+public class HdWalletRecoveryServiceTests
+{
+    private const string Mnemonic =
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    private const string AccountDescriptorTemplate =
+        "tr([73c5da0a/86'/1'/0']tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd/*)";
+
+    private static readonly OutputDescriptor TestServerKey =
+        KeyExtensions.ParseOutputDescriptor(
+            "03aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88",
+            Network.RegTest);
+
+    private static readonly ArkServerInfo TestServerInfo = new(
+        Dust: Money.Satoshis(330),
+        SignerKey: TestServerKey,
+        DeprecatedSigners: new Dictionary<ECXOnlyPubKey, long>(),
+        Network: Network.RegTest,
+        UnilateralExit: new Sequence(144),
+        BoardingExit: new Sequence(144),
+        ForfeitAddress: BitcoinAddress.Create("bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080", Network.RegTest),
+        ForfeitPubKey: TestServerKey.Extract().XOnlyPubKey,
+        CheckpointTapScript: new UnilateralPathArkTapScript(
+            new Sequence(144),
+            new NofNMultisigTapScript(Array.Empty<ECXOnlyPubKey>())),
+        FeeTerms: new ArkOperatorFeeTerms("0", "0", "0", "0", "0"));
+
+    private IWalletStorage _walletStorage = null!;
+    private IContractStorage _contractStorage = null!;
+    private IClientTransport _transport = null!;
+    private List<ArkContractEntity> _persistedContracts = null!;
+    private int _lastUsedIndexAfter = -1;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _walletStorage = Substitute.For<IWalletStorage>();
+        _contractStorage = Substitute.For<IContractStorage>();
+        _transport = Substitute.For<IClientTransport>();
+        _persistedContracts = new List<ArkContractEntity>();
+        _lastUsedIndexAfter = -1;
+
+        _transport.GetServerInfoAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(TestServerInfo));
+
+        _contractStorage.SaveContract(Arg.Any<ArkContractEntity>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                _persistedContracts.Add(callInfo.Arg<ArkContractEntity>());
+                return Task.CompletedTask;
+            });
+
+        _walletStorage.UpdateLastUsedIndex(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                _lastUsedIndexAfter = callInfo.ArgAt<int>(1);
+                return Task.CompletedTask;
+            });
+    }
+
+    [Test]
+    public async Task Scan_NoUsage_StopsAtGap_NoContractsSaved()
+    {
+        SetupWallet();
+        var provider = new StubProvider("indexer", _ => false);
+        var sut = NewService([provider]);
+
+        var report = await sut.ScanAsync("w1", new RecoveryOptions(GapLimit: 5));
+
+        Assert.That(report.HighestUsedIndex, Is.EqualTo(-1));
+        Assert.That(report.ScannedCount, Is.EqualTo(5));
+        Assert.That(report.DiscoveredContracts, Is.Empty);
+        Assert.That(_persistedContracts, Is.Empty);
+        Assert.That(_lastUsedIndexAfter, Is.EqualTo(-1));
+    }
+
+    [Test]
+    public async Task Scan_UsageAtIndexZero_ThenGap_StopsAtGap()
+    {
+        SetupWallet();
+        var provider = new StubProvider("indexer", i => i == 0);
+        var sut = NewService([provider]);
+
+        var report = await sut.ScanAsync("w1", new RecoveryOptions(GapLimit: 5));
+
+        Assert.That(report.HighestUsedIndex, Is.EqualTo(0));
+        Assert.That(report.ScannedCount, Is.EqualTo(6)); // index 0 + 5 misses
+        Assert.That(report.DiscoveredContracts, Has.Count.EqualTo(1));
+        Assert.That(_persistedContracts, Has.Count.EqualTo(1));
+        Assert.That(_lastUsedIndexAfter, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Scan_InterleavedUsage_FindsHighestAndAllContracts()
+    {
+        SetupWallet();
+        var hits = new HashSet<int> { 0, 3, 7 };
+        var provider = new StubProvider("indexer", hits.Contains);
+        var sut = NewService([provider]);
+
+        var report = await sut.ScanAsync("w1", new RecoveryOptions(GapLimit: 4));
+
+        Assert.That(report.HighestUsedIndex, Is.EqualTo(7));
+        Assert.That(report.DiscoveredContracts.Select(d => d.Index),
+            Is.EquivalentTo(hits));
+        Assert.That(_persistedContracts, Has.Count.EqualTo(3));
+        Assert.That(_lastUsedIndexAfter, Is.EqualTo(8));
+    }
+
+    [Test]
+    public async Task Scan_TwoProviders_OrSemantics()
+    {
+        SetupWallet();
+        var indexer = new StubProvider("indexer", i => i == 2);
+        var boltz = new StubProvider("boltz", i => i == 5, returnContracts: false);
+        var sut = NewService([indexer, boltz]);
+
+        var report = await sut.ScanAsync("w1", new RecoveryOptions(GapLimit: 4));
+
+        Assert.That(report.HighestUsedIndex, Is.EqualTo(5));
+        Assert.That(report.ProviderHits["indexer"], Is.EqualTo(1));
+        Assert.That(report.ProviderHits["boltz"], Is.EqualTo(1));
+        // Only "indexer" returned contracts; "boltz" returned (used:true, contracts:[])
+        Assert.That(report.DiscoveredContracts, Has.Count.EqualTo(1));
+        Assert.That(_persistedContracts, Has.Count.EqualTo(1));
+        Assert.That(_lastUsedIndexAfter, Is.EqualTo(6));
+    }
+
+    [Test]
+    public async Task Scan_ProviderThrows_TreatedAsNotFound()
+    {
+        SetupWallet();
+        var throwingProvider = new StubProvider("flaky", _ => throw new InvalidOperationException("boom"));
+        var goodProvider = new StubProvider("indexer", i => i == 1);
+        var sut = NewService([throwingProvider, goodProvider]);
+
+        var report = await sut.ScanAsync("w1", new RecoveryOptions(GapLimit: 3));
+
+        Assert.That(report.HighestUsedIndex, Is.EqualTo(1));
+        Assert.That(report.ProviderHits["flaky"], Is.EqualTo(0));
+        Assert.That(report.ProviderHits["indexer"], Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Scan_DuplicateContractsAcrossProviders_DedupedByScript()
+    {
+        SetupWallet();
+        // Both providers return a contract that produces the same script for index 0
+        var p1 = new StubProvider("indexer", i => i == 0);
+        var p2 = new StubProvider("boarding", i => i == 0);
+        var sut = NewService([p1, p2]);
+
+        var report = await sut.ScanAsync("w1", new RecoveryOptions(GapLimit: 2));
+
+        Assert.That(report.HighestUsedIndex, Is.EqualTo(0));
+        // Both providers returned a contract, but the orchestrator dedups on script
+        Assert.That(_persistedContracts, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public async Task Scan_StartIndex_BeginsThere()
+    {
+        SetupWallet();
+        var provider = new StubProvider("indexer", _ => false);
+        var sut = NewService([provider]);
+
+        var report = await sut.ScanAsync("w1", new RecoveryOptions(GapLimit: 3, StartIndex: 50));
+
+        Assert.That(report.ScannedCount, Is.EqualTo(3));
+        // The provider should have been queried with indices 50, 51, 52 — verified via call count.
+        Assert.That(provider.IndicesProbed, Is.EquivalentTo(new[] { 50, 51, 52 }));
+    }
+
+    [Test]
+    public async Task Scan_MaxIndex_StopsThereEvenWithoutGap()
+    {
+        SetupWallet();
+        var provider = new StubProvider("indexer", _ => true); // every index is a hit, never gaps
+        var sut = NewService([provider]);
+
+        var report = await sut.ScanAsync("w1", new RecoveryOptions(GapLimit: 100, MaxIndex: 4));
+
+        Assert.That(report.ScannedCount, Is.EqualTo(5)); // indices 0..4
+        Assert.That(report.HighestUsedIndex, Is.EqualTo(4));
+    }
+
+    [Test]
+    public void Scan_SingleKeyWallet_Throws()
+    {
+        var wallet = new ArkWalletInfo("w1", "secret", null, WalletType.SingleKey, null, 0);
+        _walletStorage.GetWalletById("w1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ArkWalletInfo?>(wallet));
+
+        var sut = NewService([new StubProvider("indexer", _ => true)]);
+
+        Assert.ThrowsAsync<InvalidOperationException>(() => sut.ScanAsync("w1"));
+    }
+
+    [Test]
+    public void Scan_UnknownWallet_Throws()
+    {
+        _walletStorage.GetWalletById("missing", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ArkWalletInfo?>(null));
+
+        var sut = NewService([new StubProvider("indexer", _ => true)]);
+
+        Assert.ThrowsAsync<InvalidOperationException>(() => sut.ScanAsync("missing"));
+    }
+
+    [Test]
+    public async Task Scan_NullProvidersFiltered()
+    {
+        SetupWallet();
+        var sut = NewService([NullContractDiscoveryProvider.Instance]);
+
+        var report = await sut.ScanAsync("w1", new RecoveryOptions(GapLimit: 3));
+
+        Assert.That(report.ProviderHits, Does.Not.ContainKey("null"));
+        Assert.That(report.ScannedCount, Is.EqualTo(3));
+    }
+
+    [Test]
+    public async Task Scan_DoesNotLowerLastUsedIndex()
+    {
+        SetupWallet(lastUsedIndex: 50);
+        var provider = new StubProvider("indexer", i => i == 5);
+        var sut = NewService([provider]);
+
+        await sut.ScanAsync("w1", new RecoveryOptions(GapLimit: 3));
+
+        // Wallet already had LastUsedIndex=50; we must never lower it.
+        // The orchestrator should NOT call UpdateLastUsedIndex when its
+        // computed value is below the stored one.
+        Assert.That(_lastUsedIndexAfter, Is.EqualTo(-1));
+    }
+
+    private void SetupWallet(int lastUsedIndex = 0)
+    {
+        var wallet = new ArkWalletInfo("w1", Mnemonic, null, WalletType.HD, AccountDescriptorTemplate, lastUsedIndex);
+        _walletStorage.GetWalletById("w1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ArkWalletInfo?>(wallet));
+    }
+
+    private HdWalletRecoveryService NewService(IEnumerable<IContractDiscoveryProvider> providers)
+        => new(providers, _walletStorage, _contractStorage, _transport);
+
+    /// <summary>
+    /// Test-side discovery provider: a hit predicate decides whether any given
+    /// index counts as used. When <paramref name="returnContracts"/> is true
+    /// (default) it returns a single ArkPaymentContract built from the
+    /// derived descriptor — gives the orchestrator something to persist.
+    /// </summary>
+    private sealed class StubProvider(
+        string name,
+        Func<int, bool> hits,
+        bool returnContracts = true) : IContractDiscoveryProvider
+    {
+        public List<int> IndicesProbed { get; } = [];
+        public string Name => name;
+
+        public Task<DiscoveryResult> DiscoverAsync(
+            ArkWalletInfo wallet,
+            OutputDescriptor userDescriptor,
+            int index,
+            CancellationToken cancellationToken = default)
+        {
+            IndicesProbed.Add(index);
+            if (!hits(index))
+                return Task.FromResult(DiscoveryResult.NotFound);
+
+            if (!returnContracts)
+                return Task.FromResult(new DiscoveryResult(true, []));
+
+            var contract = new ArkPaymentContract(
+                TestServerInfo.SignerKey,
+                TestServerInfo.UnilateralExit,
+                userDescriptor);
+            return Task.FromResult(new DiscoveryResult(true, [contract]));
+        }
+    }
+}

--- a/NArk.Tests/VtxoPollingHandlerTests.cs
+++ b/NArk.Tests/VtxoPollingHandlerTests.cs
@@ -129,9 +129,11 @@ public class PostBatchVtxoPollingHandlerTests
                 cancellationToken: Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyCollection<ArkContractEntity>>(contracts));
 
-        // Mock the VTXO snapshot to return empty (just verify it's called)
+        // Mock the VTXO snapshot (after-filtered overload — see PostBatchVtxoPollingHandler).
         _clientTransport.GetVtxoByScriptsAsSnapshot(
                 Arg.Any<IReadOnlySet<string>>(),
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<DateTimeOffset?>(),
                 Arg.Any<CancellationToken>())
             .Returns(AsyncEnumerable.Empty<ArkVtxo>());
 
@@ -140,6 +142,8 @@ public class PostBatchVtxoPollingHandlerTests
         // Verify that VTXO polling was triggered with the scripts from active contracts
         _clientTransport.Received(1).GetVtxoByScriptsAsSnapshot(
             Arg.Is<IReadOnlySet<string>>(s => s.Contains("script1")),
+            Arg.Any<DateTimeOffset?>(),
+            Arg.Any<DateTimeOffset?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -263,6 +267,8 @@ public class PostSpendVtxoPollingHandlerTests
 
         _clientTransport.GetVtxoByScriptsAsSnapshot(
                 Arg.Any<IReadOnlySet<string>>(),
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<DateTimeOffset?>(),
                 Arg.Any<CancellationToken>())
             .Returns(new[] { dummyVtxo }.ToAsyncEnumerable());
 
@@ -289,10 +295,14 @@ public class PostSpendVtxoPollingHandlerTests
 
         await _handler.HandleAsync(@event);
 
-        // pollOneByOne=true queries each script individually (1 input + 1 output = 2 calls),
-        // and returning a spent input VTXO ensures the retry loop breaks after the first attempt
-        _clientTransport.Received(2).GetVtxoByScriptsAsSnapshot(
+        // PollScriptsForVtxos now batches all scripts into a single after-filtered
+        // call (since arkd's multi-script query was fixed). The retry loop breaks
+        // after attempt 1 because the spent-input check via GetVtxosByOutpoints
+        // sees the input as spent.
+        _clientTransport.Received(1).GetVtxoByScriptsAsSnapshot(
             Arg.Any<IReadOnlySet<string>>(),
+            Arg.Any<DateTimeOffset?>(),
+            Arg.Any<DateTimeOffset?>(),
             Arg.Any<CancellationToken>());
     }
 

--- a/README.md
+++ b/README.md
@@ -431,6 +431,29 @@ var contract = await contractService.DeriveContract(
 // The contract's script can be converted to an ArkAddress for display
 ```
 
+## HD Wallet Recovery
+
+When importing an HD wallet from its mnemonic, the SDK has no record of contracts the previous instance derived. `HdWalletRecoveryService` rebuilds that state by sweeping derivation indices via gap-limit and asking each registered `IContractDiscoveryProvider` whether it ever saw activity at that index.
+
+The default providers ship with the SDK:
+
+- `IndexerVtxoDiscoveryProvider` (`AddArkCoreServices`) — asks arkd's indexer for VTXOs at the index's payment script.
+- `BoardingUtxoDiscoveryProvider` (`AddArkCoreServices`, opt-in via registering an `IBoardingUtxoProvider`) — asks NBXplorer/Esplora for historical UTXOs at the index's boarding address.
+- `BoltzSwapDiscoveryProvider` (`AddArkSwapServices`) — asks Boltz `/v2/swap/restore` whether the index's user pubkey ever participated in a swap.
+
+```csharp
+var recovery = serviceProvider.GetRequiredService<HdWalletRecoveryService>();
+
+var report = await recovery.ScanAsync(walletId);
+// or with options:
+var deepReport = await recovery.ScanAsync(walletId, new RecoveryOptions(GapLimit: 50));
+
+Console.WriteLine($"Highest used index: {report.HighestUsedIndex}");
+Console.WriteLine($"Discovered {report.DiscoveredContracts.Count} contract(s)");
+```
+
+Custom discovery sources are added by implementing `IContractDiscoveryProvider` and registering it in DI; the orchestrator picks them up automatically. See [docs/articles/recovery.md](docs/articles/recovery.md) for the full API and tuning guidance.
+
 ## EF Core Storage
 
 `NArk.Storage.EfCore` provides ready-made storage implementations. It is **provider-agnostic** — no dependency on Npgsql or any specific database driver.

--- a/docs/articles/recovery.md
+++ b/docs/articles/recovery.md
@@ -1,0 +1,87 @@
+# HD Wallet Recovery
+
+When a user re-imports an HD wallet from its mnemonic, the SDK has no local record of the contracts that were derived under the previous instance — the script-pubkeys, swap VHTLCs, boarding addresses, etc. The **HD recovery scanner** rebuilds that state by sweeping derivation indices and asking external sources whether each one was ever used.
+
+## How it works
+
+1. The wallet is identified as HD (single-key wallets are rejected; they have no notion of indexing).
+2. Starting from `StartIndex` (default 0), the scanner derives the concrete `OutputDescriptor` at each index from the wallet's `AccountDescriptor`.
+3. Every registered `IContractDiscoveryProvider` is asked whether *its* source of truth has any record of that descriptor's pubkey. The default providers ship with the SDK:
+
+   | Provider | Source | Detects |
+   |---|---|---|
+   | `IndexerVtxoDiscoveryProvider` | arkd indexer | Any VTXO ever recorded against the index's `ArkPaymentContract` |
+   | `BoardingUtxoDiscoveryProvider` | NBXplorer / Esplora (whichever `IBoardingUtxoProvider` is registered) | Any historical UTXO at the index's `ArkBoardingContract` on-chain address |
+   | `BoltzSwapDiscoveryProvider` | Boltz `/v2/swap/restore` | Any swap (submarine or reverse) involving the index's user pubkey |
+
+4. If **any** provider reports usage, the index counts as used: the gap counter resets, the scanner records every contract the providers reconstructed, and continues to the next index.
+5. The scan stops once `GapLimit` consecutive unused indices are seen, or once `MaxIndex` is reached.
+6. Discovered contracts are persisted via `IContractStorage` (deduped by script in case multiple providers reconstructed the same one) and `wallet.LastUsedIndex` is bumped to `HighestUsedIndex + 1` so subsequent derivations don't collide with recovered scripts.
+
+## Setup
+
+`AddArkCoreServices` registers `HdWalletRecoveryService`, the indexer provider, and a conditional boarding provider (active only when an `IBoardingUtxoProvider` is also registered). `AddArkSwapServices` adds the Boltz provider. So the recovery surface is ready as long as the application opted into core + swaps:
+
+```csharp
+services.AddArkCoreServices();
+services.AddArkSwapServices();
+services.AddSingleton<IBoardingUtxoProvider, NBXplorerBoardingUtxoProvider>(); // or Esplora
+```
+
+## Usage
+
+```csharp
+var recovery = serviceProvider.GetRequiredService<HdWalletRecoveryService>();
+
+// Default scan: gap=20, max=10000
+var report = await recovery.ScanAsync(walletId);
+
+Console.WriteLine($"Highest used index: {report.HighestUsedIndex}");
+Console.WriteLine($"Scanned: {report.ScannedCount}");
+foreach (var (provider, hits) in report.ProviderHits)
+    Console.WriteLine($"  {provider}: {hits} hit(s)");
+
+// Tune the scan for wallets known to have generated many addresses ahead of use:
+var deepReport = await recovery.ScanAsync(walletId, new RecoveryOptions(GapLimit: 50));
+
+// Resume a partial scan from a known index:
+var resumed = await recovery.ScanAsync(walletId, new RecoveryOptions(StartIndex: 200, GapLimit: 20));
+```
+
+## Adding custom providers
+
+To probe an additional source (a custom indexer, a different swap counterparty, an external escrow service, etc.), implement `IContractDiscoveryProvider` and register it in DI. The orchestrator picks all registered providers up automatically:
+
+```csharp
+public class MyCustomDiscoveryProvider : IContractDiscoveryProvider
+{
+    public string Name => "my-custom";
+
+    public async Task<DiscoveryResult> DiscoverAsync(
+        ArkWalletInfo wallet,
+        OutputDescriptor userDescriptor,
+        int index,
+        CancellationToken ct)
+    {
+        // Derive whatever script/pubkey shape your source expects, then probe.
+        var pubKeyHex = OutputDescriptorHelpers.Extract(userDescriptor).PubKey!.ToHex();
+        var hits = await _myService.LookupAsync(pubKeyHex, ct);
+        if (hits.Count == 0) return DiscoveryResult.NotFound;
+
+        // If you can reconstruct an ArkContract from the hits, return it so the
+        // orchestrator persists it with recovery-source metadata.
+        return new DiscoveryResult(true, [/* reconstructed contracts */]);
+    }
+}
+
+services.AddSingleton<IContractDiscoveryProvider, MyCustomDiscoveryProvider>();
+```
+
+Providers are queried sequentially per index; aggregate results use OR semantics — any hit counts. They MUST NOT mutate `IWalletStorage` or `IContractStorage` directly: return contracts via `DiscoveryResult.Contracts` and the orchestrator will persist them with `Source=recovery:<provider-name>` metadata. The exception is `BoltzSwapDiscoveryProvider`, which delegates to the existing `SwapsManagementService.RestoreSwaps` — that path imports VHTLC contracts itself with the canonical `Source=swap:<id>` metadata and the swap record, so the provider returns an empty contract list to avoid double-imports.
+
+## Tuning notes
+
+- **Gap limit**: BIP44 recommends 20. Increase if you know the wallet pre-generated many addresses without using them; decrease for a faster scan when you're confident usage is dense.
+- **MaxIndex**: hard upper bound. The default of 10,000 is generous; a paranoid scan can go to `int.MaxValue`, but every index is at minimum one indexer round-trip.
+- **Performance**: indexer + boarding probes are local-network-cheap (gRPC/HTTP one round-trip each). Boltz probes are one HTTP call to `/v2/swap/restore` per index — for a typical gap-of-20 scan that's ~25 calls, taking a few seconds in total.
+- **Idempotency**: scans are safe to re-run. The orchestrator dedupes by script and never lowers `wallet.LastUsedIndex`.

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -12,5 +12,7 @@
   href: swaps.md
 - name: Storage
   href: storage.md
+- name: Recovery
+  href: recovery.md
 - name: Development
   href: development.md

--- a/samples/NArk.Wallet/NArk.Wallet.Client/Pages/Home.razor
+++ b/samples/NArk.Wallet/NArk.Wallet.Client/Pages/Home.razor
@@ -8,10 +8,28 @@
     @if (State.ActiveWalletId is null)
     {
         <p class="balance-label">Welcome to Arkade</p>
-        <p style="font-size:18px;font-weight:500;margin-bottom:20px;">Create a wallet to get started</p>
-        <button class="btn btn-primary" @onclick="CreateWallet" disabled="@_creating">
+        <p style="font-size:18px;font-weight:500;margin-bottom:20px;">Create or restore a wallet to get started</p>
+        <button class="btn btn-primary" @onclick="CreateWallet" disabled="@_creating || _restoring">
             @(_creating ? "Creating..." : "Create Wallet")
         </button>
+
+        <details style="margin-top:24px;text-align:left;max-width:420px;margin-left:auto;margin-right:auto;">
+            <summary style="cursor:pointer;font-size:14px;color:#64748b;">Restore from mnemonic / nsec</summary>
+            <textarea class="form-control" rows="3" placeholder="12 or 24 word mnemonic, or nsec1..."
+                      style="margin-top:12px;width:100%;font-family:monospace;font-size:13px;"
+                      @bind="_restoreSecret" disabled="@(_creating || _restoring)"></textarea>
+            <button class="btn btn-secondary" style="margin-top:8px;width:100%;"
+                    @onclick="RestoreWallet" disabled="@(_creating || _restoring || string.IsNullOrWhiteSpace(_restoreSecret))">
+                @(_restoring ? "Scanning derivation indices…" : "Restore Wallet")
+            </button>
+            @if (_restoreReport is not null)
+            {
+                <p style="margin-top:8px;font-size:13px;color:#16a34a;">
+                    Recovered @_restoreReport.DiscoveredContracts.Count contract(s) up to index @_restoreReport.HighestUsedIndex.
+                </p>
+            }
+        </details>
+
         @if (_error is not null)
         {
             <p style="color:#ef4444;margin-top:12px;font-size:14px;">@_error</p>
@@ -132,7 +150,10 @@
     private int _activeSlide;
     private int _slideCount = 3;
     private bool _creating;
+    private bool _restoring;
     private string? _error;
+    private string _restoreSecret = string.Empty;
+    private NArk.Abstractions.Recovery.RecoveryReport? _restoreReport;
 
     protected override async Task OnInitializedAsync()
     {
@@ -175,6 +196,34 @@
             _error = $"Failed to create wallet: {ex.Message}";
         }
         finally { _creating = false; }
+    }
+
+    private async Task RestoreWallet()
+    {
+        _restoring = true;
+        _error = null;
+        _restoreReport = null;
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+            var wallet = await Ark.CreateWallet(_restoreSecret.Trim());
+            State.SetActiveWallet(wallet.Id);
+
+            // Sweep derivation indices through every registered IContractDiscoveryProvider
+            // (arkd indexer, on-chain boarding, Boltz) to rebuild prior contract state.
+            // Only HD wallets are scanned; nsec wallets just return without effect.
+            if (wallet.WalletType == NArk.Abstractions.Wallets.WalletType.HD)
+            {
+                _restoreReport = await Ark.RestoreWallet(wallet.Id, cancellationToken: cts.Token);
+            }
+
+            await LoadWallet();
+        }
+        catch (Exception ex)
+        {
+            _error = $"Failed to restore wallet: {ex.Message}";
+        }
+        finally { _restoring = false; }
     }
 
     private async Task ScrollTo(int index)

--- a/samples/NArk.Wallet/NArk.Wallet.Client/Services/ArkWalletService.cs
+++ b/samples/NArk.Wallet/NArk.Wallet.Client/Services/ArkWalletService.cs
@@ -3,9 +3,11 @@ using NArk.Abstractions;
 using NArk.Abstractions.Assets;
 using NArk.Abstractions.Contracts;
 using NArk.Abstractions.Intents;
+using NArk.Abstractions.Recovery;
 using NArk.Abstractions.VTXOs;
 using NArk.Abstractions.Wallets;
 using NArk.Core;
+using NArk.Core.Recovery;
 using NArk.Core.Services;
 using NArk.Core.Transport;
 using NArk.Core.Wallet;
@@ -36,6 +38,7 @@ public class ArkWalletService(
     IContractService contractService,
     SwapsManagementService swapsManagementService,
     BoltzLimitsValidator boltzLimitsValidator,
+    HdWalletRecoveryService recoveryService,
     ArkNetworkConfig networkConfig)
 {
     // ── Wallets ──
@@ -51,6 +54,22 @@ public class ArkWalletService(
         await walletStorage.SaveWallet(wallet);
         return wallet;
     }
+
+    /// <summary>
+    /// Run an HD-wallet gap-limit recovery scan for a freshly imported wallet.
+    /// Discovers contracts that were used by a previous instance of the same
+    /// mnemonic — VTXOs (arkd indexer), boarding UTXOs (on-chain), and Boltz
+    /// swaps — and persists them in local storage so balances and history
+    /// reflect the wallet's prior activity.
+    /// </summary>
+    /// <remarks>
+    /// Only meaningful for HD wallets; SingleKey wallets have no derivation index
+    /// and the scanner will throw. Safe to re-run; subsequent calls are
+    /// idempotent (deduped by script, never lowers <c>LastUsedIndex</c>).
+    /// </remarks>
+    public Task<RecoveryReport> RestoreWallet(string walletId, RecoveryOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => recoveryService.ScanAsync(walletId, options, cancellationToken);
 
     public async Task DeleteWallet(string walletId)
         => await walletStorage.DeleteWallet(walletId);


### PR DESCRIPTION
## Summary

Re-importing an HD wallet from its mnemonic used to leave the local SDK with no record of the contracts the previous instance derived. This PR adds a gap-limit scanner that rebuilds that state by sweeping derivation indices and asking each registered `IContractDiscoveryProvider` whether it ever saw activity at that index — OR semantics across all sources.

## Why modular providers

The user had three different sources of truth in mind:

- **arkd indexer** — has the wallet's payment contracts ever held a VTXO?
- **on-chain (NBXplorer/Esplora)** — has any historical UTXO landed at the boarding address?
- **boltz** — has the index's user pubkey participated in a submarine/reverse swap?

Each runs over a different protocol. Making this pluggable means a custom integration can drop in a `MyEscrowDiscoveryProvider` without touching the orchestrator. The interface is small (`Task<DiscoveryResult> DiscoverAsync(wallet, descriptor, index, ct)`) and provider results are unioned.

## Surfaces

- `NArk.Abstractions.Recovery` — `IContractDiscoveryProvider`, `DiscoveryResult`, `RecoveryOptions`, `RecoveryReport`
- `NArk.Core.Recovery` — `HdWalletRecoveryService` orchestrator, `IndexerVtxoDiscoveryProvider`, `BoardingUtxoDiscoveryProvider` (conditional on `IBoardingUtxoProvider` being registered)
- `NArk.Swaps.Recovery` — `BoltzSwapDiscoveryProvider` (delegates to existing `SwapsManagementService.RestoreSwaps` so VHTLC + swap rows get the canonical `Source=swap:<id>` metadata)
- DI: registered automatically by `AddArkCoreServices` + `AddArkSwapServices`

## Behaviour

- Discovered contracts are persisted with `Source=recovery:<provider>` + `RecoveryIndex=<n>` metadata.
- Dedup by script — multiple providers reconstructing the same contract → only one persisted.
- `wallet.LastUsedIndex` is bumped to `HighestUsedIndex + 1` but never lowered.
- Idempotent — safe to re-run.
- `SingleKey` wallets throw (no derivation index).

## Tests

12 new test cases in `NArk.Tests/Recovery/HdWalletRecoveryServiceTests.cs` cover:
- No usage / usage at 0 / interleaved usage
- OR semantics across two providers
- Throwing provider treated as not-found
- Per-script dedupe
- `StartIndex` / `MaxIndex` honoured
- `SingleKey` and unknown-wallet rejection
- Null-provider filtering
- Never-lower-`LastUsedIndex` invariant

Also fixes two pre-existing stale tests in `VtxoPollingHandlerTests` that were left broken on master by the v2.1.5 `GetVtxoByScriptsAsSnapshot` signature change and the `b014d1f` one-by-one polling removal.

`dotnet test NArk.Tests` → 269/269 pass.

## Docs + sample wallet

- README "HD Wallet Recovery" section
- New `docs/articles/recovery.md` with usage, custom-provider how-to, and tuning notes — registered in `toc.yml`
- Sample wallet (`samples/NArk.Wallet`) gets a "Restore from mnemonic / nsec" panel on the home page that runs the scanner and shows the discovered-contract count

DocFX build green (1 pre-existing unrelated warning on `index.md`).

## Test plan
- [ ] `dotnet test NArk.Tests` is green (269/269)
- [ ] `dotnet build NArk.sln` is green including the sample wallet
- [ ] DocFX build is green
- [ ] Smoke-test the sample wallet: paste a known-active mnemonic into the restore panel and confirm contracts get listed and balances appear