### PR TITLE
fix: mark swaps Failed after 10 consecutive Boltz 404s

### DIFF
--- a/NArk.Swaps/Boltz/Client/BoltzClient.Swaps.cs
+++ b/NArk.Swaps/Boltz/Client/BoltzClient.Swaps.cs
@@ -14,9 +14,31 @@ public partial class BoltzClient
     /// </summary>
     /// <param name="swapId">The ID of the swap.</param>
     /// <returns>The status response for the swap.</returns>
+    /// <exception cref="BoltzSwapNotFoundException">
+    /// The configured Boltz instance has no record of this swap (HTTP 404 with
+    /// a "could not find swap with id" body). Distinct from generic HTTP errors
+    /// so callers can treat it as "swap unknown to this provider" rather than
+    /// a transient failure.
+    /// </exception>
     public virtual async Task<SwapStatusResponse?> GetSwapStatusAsync(string swapId, CancellationToken cancellation)
     {
-        return await _httpClient.GetFromJsonAsync<SwapStatusResponse>($"v2/swap/{swapId}", cancellation);
+        using var resp = await _httpClient.GetAsync($"v2/swap/{swapId}", cancellation);
+
+        if (resp.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            // Defensive: only treat as "swap unknown" if the body matches the
+            // shape Boltz returns for missing swaps. A 404 from a renamed
+            // route or proxy misconfiguration shouldn't trip the safety net.
+            var body = await resp.Content.ReadAsStringAsync(cancellation);
+            if (body.Contains("could not find swap", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new BoltzSwapNotFoundException(swapId, body);
+            }
+            throw new HttpRequestException(body, null, resp.StatusCode);
+        }
+
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadFromJsonAsync<SwapStatusResponse>(cancellation);
     }
 
     // Submarine Swaps

--- a/NArk.Swaps/Boltz/Client/BoltzSwapNotFoundException.cs
+++ b/NArk.Swaps/Boltz/Client/BoltzSwapNotFoundException.cs
@@ -1,0 +1,26 @@
+namespace NArk.Swaps.Boltz.Client;
+
+/// <summary>
+/// Thrown by <see cref="BoltzClient"/> when Boltz's <c>v2/swap/{id}</c> endpoint
+/// responds with HTTP 404 and a body of the form
+/// <c>{"error":"could not find swap with id: ..."}</c>. This signals the
+/// configured Boltz instance has no record of the swap — typically because the
+/// swap was created against a different Boltz endpoint that the client has
+/// since been pointed away from.
+/// </summary>
+/// <remarks>
+/// Distinct from a generic <see cref="HttpRequestException"/> so callers can
+/// reason about "swap is unknown to this provider" without conflating it with
+/// transient network or 5xx errors.
+/// </remarks>
+public class BoltzSwapNotFoundException : Exception
+{
+    /// <summary>The swap ID that was not found.</summary>
+    public string SwapId { get; }
+
+    public BoltzSwapNotFoundException(string swapId, string? boltzErrorMessage)
+        : base($"Boltz returned 404 for swap '{swapId}': {boltzErrorMessage ?? "(no body)"}")
+    {
+        SwapId = swapId;
+    }
+}

--- a/NArk.Swaps/Services/SwapsManagementService.cs
+++ b/NArk.Swaps/Services/SwapsManagementService.cs
@@ -56,6 +56,28 @@ public class SwapsManagementService : IAsyncDisposable
     private HashSet<string> _swapsIdToWatch = [];
     private readonly ConcurrentDictionary<string, string> _scriptToSwapId = [];
 
+    /// <summary>
+    /// Per-swap counter of consecutive <see cref="BoltzSwapNotFoundException"/>
+    /// responses from <c>GetSwapStatusAsync</c>. Reset to zero on any successful
+    /// status response. When a swap reaches
+    /// <see cref="UnknownToProviderThreshold"/> consecutive 404s, the safety net
+    /// in <see cref="MarkSwapAsUnknownToProvider"/> trips and the swap is
+    /// transitioned to a terminal state. Concurrent because <c>NotifySwapChanged</c>
+    /// (storage event thread) and <c>PollSwapState</c> (channel reader thread)
+    /// can both touch the map.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, int> _consecutiveUnknown = [];
+
+    /// <summary>
+    /// Number of consecutive Boltz 404s that must elapse before
+    /// <c>PollSwapState</c> gives up on a swap and transitions it to a terminal
+    /// state. At the 1-minute routine-poll cadence this is roughly a
+    /// 10-minute grace window — long enough to ride out a transient Boltz
+    /// route blip, short enough that a real "swap unknown to this provider"
+    /// surfaces inside a working day.
+    /// </summary>
+    private const int UnknownToProviderThreshold = 10;
+
     private Task? _cacheTask;
     private Task? _routinePollTask;
 
@@ -279,6 +301,9 @@ public class SwapsManagementService : IAsyncDisposable
             {
                 _logger?.LogDebug("PollSwapState: querying Boltz for {SwapId}", idToPoll);
                 var swapStatus = await _boltzClient.GetSwapStatusAsync(idToPoll, _shutdownCts.Token);
+                // A successful response (any non-throwing path past GetSwapStatusAsync)
+                // means Boltz still recognises this swap — clear the unknown counter.
+                _consecutiveUnknown.TryRemove(idToPoll, out _);
                 if (swapStatus?.Status is null)
                 {
                     _logger?.LogDebug("Swap {SwapId}: Boltz returned null status", idToPoll);
@@ -390,11 +415,86 @@ public class SwapsManagementService : IAsyncDisposable
                     _swapsIdToWatch.Remove(swapWithNewStatus.SwapId);
                 }
             }
+            catch (BoltzSwapNotFoundException)
+            {
+                // Boltz has no record of this swap. This is the canonical failure
+                // mode after a Boltz endpoint switch — old swap IDs are unknown
+                // to the new instance. Track consecutive 404s; trip the safety
+                // net only after the threshold to ride out transient blips.
+                var count = _consecutiveUnknown.AddOrUpdate(idToPoll, 1, (_, c) => c + 1);
+                _logger?.LogWarning(
+                    "Swap {SwapId}: unknown to Boltz ({Count}/{Threshold} consecutive)",
+                    idToPoll, count, UnknownToProviderThreshold);
+                if (count >= UnknownToProviderThreshold)
+                {
+                    await MarkSwapAsUnknownToProvider(idToPoll, cancellationToken);
+                }
+            }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _logger?.LogError(ex, "Swap {SwapId}: error polling state from Boltz", idToPoll);
             }
         }
+    }
+
+    /// <summary>
+    /// Transitions a swap to <see cref="ArkSwapStatus.Failed"/> once Boltz has
+    /// consistently reported it unknown for <see cref="UnknownToProviderThreshold"/>
+    /// consecutive polls. Called from <see cref="PollSwapState"/>'s
+    /// <see cref="BoltzSwapNotFoundException"/> handler — at this point the
+    /// swap is presumed permanently lost to the configured Boltz instance,
+    /// typically because the operator pointed the SDK at a different Boltz
+    /// endpoint than the one the swap was created on. After this transition
+    /// the user must recover funds on-chain via the contract's script-path
+    /// after CSV expiry; cooperative refund is no longer available because
+    /// the original Boltz instance is unreachable.
+    /// </summary>
+    private async Task MarkSwapAsUnknownToProvider(string swapId, CancellationToken cancellationToken)
+    {
+        await using var @lock = await _safetyService.LockKeyAsync($"swap::{swapId}", cancellationToken);
+
+        var swap = (await _swapsStorage.GetSwaps(swapIds: [swapId], cancellationToken: cancellationToken))
+            .FirstOrDefault();
+        if (swap is null)
+        {
+            _logger?.LogDebug("MarkSwapAsUnknownToProvider: swap {SwapId} no longer in storage", swapId);
+            _consecutiveUnknown.TryRemove(swapId, out _);
+            return;
+        }
+
+        // Idempotency: another caller (or a previous trip of this safety net)
+        // may have already moved it terminal — nothing to do.
+        if (!swap.Status.IsActive())
+        {
+            _consecutiveUnknown.TryRemove(swapId, out _);
+            _swapsIdToWatch.Remove(swapId);
+            return;
+        }
+
+        var newMetadata = swap.Metadata is null
+            ? new Dictionary<string, string>()
+            : new Dictionary<string, string>(swap.Metadata);
+        newMetadata["unknownToProvider"] = "true";
+
+        var newSwap = swap with
+        {
+            Status = ArkSwapStatus.Failed,
+            FailReason = "Boltz no longer recognises this swap. " +
+                         "Recover funds on-chain via the contract's script-path after CSV expiry.",
+            UpdatedAt = DateTimeOffset.UtcNow,
+            Metadata = newMetadata,
+        };
+
+        await _swapsStorage.SaveSwap(swap.WalletId, newSwap, cancellationToken: cancellationToken);
+
+        _logger?.LogWarning(
+            "Swap {SwapId}: marked Failed after {Threshold} consecutive Boltz 404s — swap is unknown to the configured Boltz instance",
+            swapId, UnknownToProviderThreshold);
+
+        // Stop polling and clear the counter. NotifySwapChanged handles
+        // _scriptToSwapId eviction via the SaveSwap event we just emitted.
+        _swapsIdToWatch.Remove(swapId);
+        _consecutiveUnknown.TryRemove(swapId, out _);
     }
 
     private async Task RequestRefundCooperatively(ArkSwap swap, CancellationToken cancellationToken = default)

--- a/NArk.Tests/BoltzClientNotFoundTests.cs
+++ b/NArk.Tests/BoltzClientNotFoundTests.cs
@@ -1,0 +1,95 @@
+using System.Net;
+using Microsoft.Extensions.Options;
+using NArk.Swaps.Boltz.Client;
+using NArk.Swaps.Boltz.Models;
+
+namespace NArk.Tests;
+
+/// <summary>
+/// Verifies <see cref="BoltzClient.GetSwapStatusAsync"/> distinguishes
+/// "swap unknown to this Boltz instance" (404 + matching body) from generic
+/// HTTP failures. The distinction matters because
+/// <c>SwapsManagementService.PollSwapState</c> uses <see cref="BoltzSwapNotFoundException"/>
+/// to drive a per-swap consecutive-unknown counter, and we must not trip the
+/// counter on transient route or proxy 404s.
+/// </summary>
+[TestFixture]
+public class BoltzClientNotFoundTests
+{
+    private static BoltzClient CreateClient(HttpResponseMessage response)
+    {
+        var handler = new StubHandler(response);
+        var http = new HttpClient(handler);
+        var options = Options.Create(new BoltzClientOptions
+        {
+            BoltzUrl = "https://example.test/",
+            WebsocketUrl = "wss://example.test/",
+        });
+        return new BoltzClient(http, options);
+    }
+
+    [Test]
+    public void Throws_BoltzSwapNotFoundException_On_404_With_CouldNotFindSwap_Body()
+    {
+        var resp = new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent("{\"error\":\"could not find swap with id: zKC8PCx8dddd6Xna\"}"),
+        };
+        var client = CreateClient(resp);
+
+        var ex = Assert.ThrowsAsync<BoltzSwapNotFoundException>(
+            () => client.GetSwapStatusAsync("zKC8PCx8dddd6Xna", CancellationToken.None));
+        Assert.That(ex!.SwapId, Is.EqualTo("zKC8PCx8dddd6Xna"));
+    }
+
+    [Test]
+    public void Throws_HttpRequestException_On_404_With_NonMatching_Body()
+    {
+        // A 404 from a renamed route or misconfigured proxy must NOT trip the
+        // safety net — it propagates as a generic HTTP error so the existing
+        // catch-all path logs and continues without tripping the counter.
+        var resp = new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent("<html><body>404 Not Found</body></html>"),
+        };
+        var client = CreateClient(resp);
+
+        Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetSwapStatusAsync("anyId", CancellationToken.None));
+    }
+
+    [Test]
+    public async Task Returns_Status_On_Success()
+    {
+        var resp = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("{\"status\":\"swap.created\"}"),
+        };
+        var client = CreateClient(resp);
+
+        var status = await client.GetSwapStatusAsync("anyId", CancellationToken.None);
+        Assert.That(status, Is.Not.Null);
+        Assert.That(status!.Status, Is.EqualTo("swap.created"));
+    }
+
+    [Test]
+    public void Throws_HttpRequestException_On_5xx()
+    {
+        // 5xx is transient — handled by the generic catch-all in PollSwapState,
+        // not by the not-found safety net.
+        var resp = new HttpResponseMessage(HttpStatusCode.BadGateway)
+        {
+            Content = new StringContent(""),
+        };
+        var client = CreateClient(resp);
+
+        Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetSwapStatusAsync("anyId", CancellationToken.None));
+    }
+
+    private sealed class StubHandler(HttpResponseMessage response) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(response);
+    }
+}


### PR DESCRIPTION
## Summary

Bounds a real failure mode that surfaces when the configured Boltz endpoint changes (e.g. operator switches `BoltzClientOptions.BoltzUrl`): in-flight swaps created against the old instance start returning HTTP 404, but the existing catch-all in `PollSwapState` just logs and continues — the swap stays \`Pending\` forever and the cooperative refund path is inaccessible because the original Boltz instance is unreachable.

This adds a small, bounded safety net:

1. `BoltzClient.GetSwapStatusAsync` now distinguishes the "swap unknown" 404 (matching body \`could not find swap with id: ...\`) from generic 404s (renamed routes, proxy misconfig). The former throws a typed `BoltzSwapNotFoundException`; the latter still propagates as `HttpRequestException`.
2. `SwapsManagementService.PollSwapState` keeps a per-swap consecutive-unknown counter, reset on any successful response. After **10 consecutive 404s** (~10 minutes at the 1-min routine-poll cadence) the swap is transitioned to \`ArkSwapStatus.Failed\` with \`FailReason\` explaining the on-chain script-path recovery and \`Metadata["unknownToProvider"] = "true"\` so dashboards can render a different hint.
3. The swap is removed from `_swapsIdToWatch` and the counter cleared so polling stops; \`NotifySwapChanged\` handles \`_scriptToSwapId\` eviction via the existing storage event flow.

**This does not recover funds** — the user must spend the contract via its script-path after CSV expiry. The PR bounds the log noise and surfaces something actionable in the dashboard rather than letting swaps silently zombie.

## Why these specific choices

- **Body-shape check on 404**: a future Boltz route rename returning 404 from a missing endpoint would otherwise false-positive trip the safety net. The \`could not find swap\` substring is what the live API returns today.
- **Threshold = 10**: at the 1-min poll cadence this is ~10 minutes — long enough to ride out a transient Boltz blip, short enough that operators see something within a working day. Configurable as a `private const` if we want to tune it.
- **Reuse `Failed` rather than a new enum value**: avoids cascading changes through every consumer that switches on `ArkSwapStatus`. The metadata flag is a forward-compatible signal for UIs that want to differentiate.
- **Idempotent**: \`MarkSwapAsUnknownToProvider\` no-ops if the swap is already terminal.

## Test plan

- [x] 273 unit tests pass (4 new in `BoltzClientNotFoundTests.cs` covering: matching-body 404 → `BoltzSwapNotFoundException`; non-matching-body 404 → `HttpRequestException`; 200 happy path; 5xx → `HttpRequestException`)
- [x] Build clean across `NArk.Swaps` + `NArk.Tests`
- [ ] CI green