### PR TITLE
chore: drop "ark." subdomain from default mainnet Boltz URL

### DIFF
--- a/NArk.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/NArk.Core/Hosting/ServiceCollectionExtensions.cs
@@ -41,7 +41,7 @@ public record ArkNetworkConfig(
     public static readonly ArkNetworkConfig Mainnet = new(
         ArkUri: "https://arkade.computer",
         ArkadeWalletUri: "https://arkade.money",
-        BoltzUri: "https://api.ark.boltz.exchange/",
+        BoltzUri: "https://api.boltz.exchange/",
         ExplorerUri: "https://arkade.space");
 
     /// <summary>Mutinynet (signet) configuration.</summary>


### PR DESCRIPTION
## Summary

Updates \`ArkNetworkConfig.Mainnet.BoltzUri\` from \`https://api.ark.boltz.exchange/\` to \`https://api.boltz.exchange/\` so the default mainnet Boltz endpoint matches the canonical (non-ark-prefixed) host.

Diff is one line. Mutinynet (\`api.boltz.mutinynet.arkade.sh\`) and Regtest (\`localhost:9069\`) are unchanged — only mainnet carried the \`ark.*\` subdomain.

## Migration impact for live mainnet wallets

Swaps that were created against \`api.ark.boltz.exchange\` before this change ships will return \`404\` from the new endpoint. With #80 merged, those swaps transition to \`ArkSwapStatus.Failed\` after 10 consecutive 404s and stamp \`Metadata["unknownToProvider"] = "true"\`, with a \`FailReason\` pointing the user at on-chain script-path recovery after CSV expiry.

Per the earlier design discussion, we deliberately did **not** introduce per-swap URL pinning for this switch — the safety net in #80 is the agreed graceful-degradation path.

## Test plan

- [x] \`dotnet build NArk.sln\` clean
- [x] \`dotnet test NArk.Tests\` — 273/273 pass
- [ ] CI green