### PR TITLE
feat(logging): tag swap + batch log entries with WalletId scope

### DIFF
--- a/NArk.Core/Recovery/HdWalletRecoveryService.cs
+++ b/NArk.Core/Recovery/HdWalletRecoveryService.cs
@@ -45,6 +45,7 @@ public class HdWalletRecoveryService(
         RecoveryOptions? options = null,
         CancellationToken cancellationToken = default)
     {
+        using var _walletScope = logger?.BeginScope(("WalletId", walletId));
         options ??= RecoveryOptions.Default;
         options.Validate();
 

--- a/NArk.Core/Services/AssetManager.cs
+++ b/NArk.Core/Services/AssetManager.cs
@@ -34,6 +34,7 @@ public class AssetManager(
     public async Task<IssuanceResult> IssueAsync(string walletId, IssuanceParams parameters,
         CancellationToken cancellationToken = default)
     {
+        using var _walletScope = logger?.BeginScope(("WalletId", walletId));
         logger?.LogDebug("Issuing {Amount} new asset units for wallet {WalletId}", parameters.Amount, walletId);
 
         var serverInfo = await transport.GetServerInfoAsync(cancellationToken);
@@ -120,6 +121,7 @@ public class AssetManager(
     public async Task<string> ReissueAsync(string walletId, ReissuanceParams parameters,
         CancellationToken cancellationToken = default)
     {
+        using var _walletScope = logger?.BeginScope(("WalletId", walletId));
         logger?.LogDebug("Reissuing {Amount} units using control asset {AssetId} for wallet {WalletId}",
             parameters.Amount, parameters.AssetId, walletId);
 
@@ -195,6 +197,7 @@ public class AssetManager(
     public async Task<string> BurnAsync(string walletId, BurnParams parameters,
         CancellationToken cancellationToken = default)
     {
+        using var _walletScope = logger?.BeginScope(("WalletId", walletId));
         logger?.LogDebug("Burning {Amount} units of asset {AssetId} for wallet {WalletId}",
             parameters.Amount, parameters.AssetId, walletId);
 

--- a/NArk.Core/Services/BatchManagementService.cs
+++ b/NArk.Core/Services/BatchManagementService.cs
@@ -219,34 +219,40 @@ public class BatchManagementService(
             if (!_activeIntents.TryGetValue(intentId, out var intent))
                 continue;
 
-            try
+            // Tag every log emitted during this intent's batch event handling
+            // with the owning wallet so per-wallet diagnostic-log capture
+            // (in BTCPay plugin) can route them.
+            using (logger?.BeginScope(("WalletId", intent.WalletId)))
             {
-                var isComplete = await session.ProcessEventAsync(eventResponse, cancellationToken);
-                if (isComplete)
+                try
                 {
+                    var isComplete = await session.ProcessEventAsync(eventResponse, cancellationToken);
+                    if (isComplete)
+                    {
+                        CleanupBatchSession(intentId, batchId);
+                    }
+
+                    switch (eventResponse)
+                    {
+                        case BatchFailedEvent batchFailed when batchFailed.Id == intent.BatchId:
+                            await HandleBatchFailedAsync(intent, batchFailed, cancellationToken);
+                            CleanupBatchSession(intentId, batchId);
+                            _activeIntents.TryRemove(intentId, out _);
+                            _ = UpdateTopicsAsync(removeTopics: GetTopicsForIntent(intent));
+                            break;
+
+                        case BatchFinalizedEvent batchFinalized when batchFinalized.Id == intent.BatchId:
+                            await HandleBatchFinalizedAsync(intent, batchFinalized, cancellationToken);
+                            CleanupBatchSession(intentId, batchId);
+                            _activeIntents.TryRemove(intentId, out _);
+                            break;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    await HandleBatchExceptionAsync(intent, ex, cancellationToken);
                     CleanupBatchSession(intentId, batchId);
                 }
-
-                switch (eventResponse)
-                {
-                    case BatchFailedEvent batchFailed when batchFailed.Id == intent.BatchId:
-                        await HandleBatchFailedAsync(intent, batchFailed, cancellationToken);
-                        CleanupBatchSession(intentId, batchId);
-                        _activeIntents.TryRemove(intentId, out _);
-                        _ = UpdateTopicsAsync(removeTopics: GetTopicsForIntent(intent));
-                        break;
-
-                    case BatchFinalizedEvent batchFinalized when batchFinalized.Id == intent.BatchId:
-                        await HandleBatchFinalizedAsync(intent, batchFinalized, cancellationToken);
-                        CleanupBatchSession(intentId, batchId);
-                        _activeIntents.TryRemove(intentId, out _);
-                        break;
-                }
-            }
-            catch (Exception ex)
-            {
-                await HandleBatchExceptionAsync(intent, ex, cancellationToken);
-                CleanupBatchSession(intentId, batchId);
             }
         }
     }
@@ -440,13 +446,16 @@ public class BatchManagementService(
             if (!_activeIntents.TryGetValue(intentId, out var intent) || _activeBatchSessions.ContainsKey(intentId))
                 continue;
 
-            try
+            using (logger?.BeginScope(("WalletId", intent.WalletId)))
             {
-                await SetupBatchSessionAsync(intentId, intent, serverInfo, batchEvent, CancellationToken.None);
-            }
-            catch (Exception ex)
-            {
-                logger?.LogWarning(0, ex, "Failed to handle batch started event for intent {IntentId}", intentId);
+                try
+                {
+                    await SetupBatchSessionAsync(intentId, intent, serverInfo, batchEvent, CancellationToken.None);
+                }
+                catch (Exception ex)
+                {
+                    logger?.LogWarning(0, ex, "Failed to handle batch started event for intent {IntentId}", intentId);
+                }
             }
         }
     }

--- a/NArk.Core/Services/DelegationMonitorService.cs
+++ b/NArk.Core/Services/DelegationMonitorService.cs
@@ -82,6 +82,7 @@ public class DelegationMonitorService(
                 return;
 
             var walletId = contract.WalletIdentifier;
+            using var _walletScope = logger?.BeginScope(("WalletId", walletId));
             var serverInfo = await clientTransport.GetServerInfoAsync();
             var parsed = ArkContractParser.Parse(contract.Type, contract.AdditionalData, serverInfo.Network);
             if (parsed is null)

--- a/NArk.Core/Services/IntentGenerationService.cs
+++ b/NArk.Core/Services/IntentGenerationService.cs
@@ -85,6 +85,7 @@ public class IntentGenerationService(
         foreach (var walletContracts in contracts)
         {
             var walletId = walletContracts.Key;
+            using var _walletScope = logger?.BeginScope(("WalletId", walletId));
 
             // Check for BatchInProgress intents. A batch resolves in seconds, so if an intent
             // has been stuck in BatchInProgress for over 5 minutes, it's orphaned — cancel it
@@ -566,6 +567,7 @@ public class IntentGenerationService(
 
     public async Task<string> GenerateManualIntent(string walletId, ArkIntentSpec spec, CancellationToken cancellationToken = default)
     {
+        using var _walletScope = logger?.BeginScope(("WalletId", walletId));
         logger?.LogDebug("Generating manual intent for wallet {WalletId}", walletId);
         var intentTxId = await GenerateIntentFromSpec(walletId, spec, cancellationToken)
             ?? throw new InvalidOperationException("Intent generation returned null unexpectedly");

--- a/NArk.Core/Services/OnchainService.cs
+++ b/NArk.Core/Services/OnchainService.cs
@@ -14,6 +14,7 @@ public class OnchainService(IClientTransport clientTransport, IContractService c
     public async Task<string> InitiateCollaborativeExit(string walletId, ArkTxOut output,
         CancellationToken cancellationToken = default)
     {
+        using var _walletScope = logger?.BeginScope(("WalletId", walletId));
         logger?.LogDebug("Initiating collaborative exit for wallet {WalletId} with output value {Value}", walletId, output.Value);
         var serverInfo = await clientTransport.GetServerInfoAsync(cancellationToken);
 
@@ -74,6 +75,10 @@ public class OnchainService(IClientTransport clientTransport, IContractService c
 
     public async Task<string> InitiateCollaborativeExit(ArkCoin[] inputs, ArkTxOut[] outputs, CancellationToken cancellationToken = default)
     {
+        // walletId is uniform by construction (validated below); open the
+        // scope before the validations so any rejection log carries it.
+        var walletId = inputs.Length > 0 ? inputs[0].WalletIdentifier : null;
+        using var _walletScope = walletId is not null ? logger?.BeginScope(("WalletId", walletId)) : null;
         logger?.LogDebug("Initiating collaborative exit with {InputCount} inputs and {OutputCount} outputs", inputs.Length, outputs.Length);
         if (outputs.All(o => o.Type == ArkTxOutType.Vtxo))
         {

--- a/NArk.Core/Services/SpendingService.cs
+++ b/NArk.Core/Services/SpendingService.cs
@@ -62,6 +62,7 @@ public class SpendingService(
     public async Task<uint256> Spend(string walletId, ArkCoin[] inputs, ArkTxOut[] outputs,
         CancellationToken cancellationToken = default)
     {
+        using var _walletScope = logger?.BeginScope(("WalletId", walletId));
         logger?.LogDebug("Spending {InputCount} inputs with {OutputCount} outputs for wallet {WalletId}", inputs.Length,
             outputs.Length, walletId);
         try
@@ -143,6 +144,7 @@ public class SpendingService(
     public async Task<IReadOnlySet<ArkCoin>> GetAvailableCoins(string walletId,
         CancellationToken cancellationToken = default)
     {
+        using var _walletScope = logger?.BeginScope(("WalletId", walletId));
         logger?.LogDebug("Getting available coins for wallet {WalletId}", walletId);
 
 
@@ -191,6 +193,7 @@ public class SpendingService(
 
     public async Task<uint256> Spend(string walletId, ArkTxOut[] outputs, CancellationToken cancellationToken = default)
     {
+        using var _walletScope = logger?.BeginScope(("WalletId", walletId));
         logger?.LogDebug("Spending with automatic coin selection for wallet {WalletId} with {OutputCount} outputs",
             walletId, outputs.Length);
         var serverInfo = await transport.GetServerInfoAsync(cancellationToken);

--- a/NArk.Core/Services/SweeperService.cs
+++ b/NArk.Core/Services/SweeperService.cs
@@ -194,6 +194,12 @@ public class SweeperService(
 
         foreach (var coin in coinsToSweep)
         {
+            // Tag every log line emitted during this coin's sweep with the
+            // owning wallet so per-wallet diagnostic-log capture can route
+            // them. The set may span multiple wallets; the scope is per
+            // iteration, not per call.
+            using var _walletScope = logger?.BeginScope(("WalletId", coin.WalletIdentifier));
+
             if (lockedOutpoints.Contains(coin.Outpoint))
             {
                 logger?.LogDebug("Sweep skipped for outpoint {Outpoint}: locked by pending intent", coin.Outpoint);

--- a/NArk.Swaps/Services/SwapsManagementService.cs
+++ b/NArk.Swaps/Services/SwapsManagementService.cs
@@ -338,104 +338,113 @@ public class SwapsManagementService : IAsyncDisposable
                     _logger?.LogWarning("Swap {SwapId}: not found in storage", idToPoll);
                     continue;
                 }
-                _scriptToSwapId[swap.ContractScript] = swap.SwapId;
 
-                // Terminal states: nothing to do
-                if (swap.Status is ArkSwapStatus.Refunded or ArkSwapStatus.Settled) continue;
-
-                // Refresh VTXO state for the swap's contract script directly against arkd.
-                // We cannot rely solely on the indexer subscription stream here: arkd does
-                // not retroactively replay events, so if a VTXO lands between the moment
-                // we subscribe and the moment we start reading the stream (or if a stream
-                // reconnect drops a message), it never reaches OnVtxosChanged and the
-                // swap stalls until a manual sync. Polling the single contract script per
-                // status-check is cheap and closes that gap.
-                if (!string.IsNullOrEmpty(swap.ContractScript))
+                // Tag every log emitted from here on with the owning wallet
+                // so per-wallet diagnostic-log capture (in BTCPay plugin)
+                // can route them to the right file. `continue` inside this
+                // using block still targets the foreach — the using's
+                // finally disposes the scope before the iteration exits.
+                using (_logger?.BeginScope(("WalletId", swap.WalletId)))
                 {
-                    var freshCount = 0;
-                    try
+                    _scriptToSwapId[swap.ContractScript] = swap.SwapId;
+
+                    // Terminal states: nothing to do
+                    if (swap.Status is ArkSwapStatus.Refunded or ArkSwapStatus.Settled) continue;
+
+                    // Refresh VTXO state for the swap's contract script directly against arkd.
+                    // We cannot rely solely on the indexer subscription stream here: arkd does
+                    // not retroactively replay events, so if a VTXO lands between the moment
+                    // we subscribe and the moment we start reading the stream (or if a stream
+                    // reconnect drops a message), it never reaches OnVtxosChanged and the
+                    // swap stalls until a manual sync. Polling the single contract script per
+                    // status-check is cheap and closes that gap.
+                    if (!string.IsNullOrEmpty(swap.ContractScript))
                     {
-                        await foreach (var freshVtxo in _clientTransport.GetVtxoByScriptsAsSnapshot(
-                                           new HashSet<string> { swap.ContractScript }, cancellationToken))
+                        var freshCount = 0;
+                        try
                         {
-                            freshCount++;
-                            await _vtxoStorage.UpsertVtxo(freshVtxo, cancellationToken);
+                            await foreach (var freshVtxo in _clientTransport.GetVtxoByScriptsAsSnapshot(
+                                               new HashSet<string> { swap.ContractScript }, cancellationToken))
+                            {
+                                freshCount++;
+                                await _vtxoStorage.UpsertVtxo(freshVtxo, cancellationToken);
+                            }
+                            _logger?.LogInformation(
+                                "Swap {SwapId}: refreshed contract script — arkd returned {Count} VTXO(s)",
+                                idToPoll, freshCount);
                         }
-                        _logger?.LogInformation(
-                            "Swap {SwapId}: refreshed contract script — arkd returned {Count} VTXO(s)",
-                            idToPoll, freshCount);
+                        catch (Exception ex) when (ex is not OperationCanceledException)
+                        {
+                            _logger?.LogWarning(ex, "Swap {SwapId}: failed to refresh VTXOs for contract script during status poll", idToPoll);
+                        }
                     }
-                    catch (Exception ex) when (ex is not OperationCanceledException)
+
+                    // If not refunded and status is refundable, start a coop refund
+                    if (swap.SwapType is ArkSwapType.Submarine && swap.Status is not ArkSwapStatus.Refunded &&
+                        IsRefundableStatus(swapStatus.Status))
                     {
-                        _logger?.LogWarning(ex, "Swap {SwapId}: failed to refresh VTXOs for contract script during status poll", idToPoll);
+                        _logger?.LogInformation("Swap {SwapId}: Boltz status '{BoltzStatus}' is refundable, initiating cooperative refund",
+                            idToPoll, swapStatus.Status);
+                        var newSwap =
+                            swap with { Status = ArkSwapStatus.Failed, UpdatedAt = DateTimeOffset.Now };
+                        await RequestRefundCooperatively(newSwap, cancellationToken);
+                        // Don't map status to Failed below — if refund succeeded, status is already
+                        // Refunded in storage; if it returned early (e.g. VTXOs not yet available
+                        // due to batch round race), keep the swap Pending so routine polls retry.
+                        continue;
                     }
-                }
 
-                // If not refunded and status is refundable, start a coop refund
-                if (swap.SwapType is ArkSwapType.Submarine && swap.Status is not ArkSwapStatus.Refunded &&
-                    IsRefundableStatus(swapStatus.Status))
-                {
-                    _logger?.LogInformation("Swap {SwapId}: Boltz status '{BoltzStatus}' is refundable, initiating cooperative refund",
-                        idToPoll, swapStatus.Status);
-                    var newSwap =
-                        swap with { Status = ArkSwapStatus.Failed, UpdatedAt = DateTimeOffset.Now };
-                    await RequestRefundCooperatively(newSwap, cancellationToken);
-                    // Don't map status to Failed below — if refund succeeded, status is already
-                    // Refunded in storage; if it returned early (e.g. VTXOs not yet available
-                    // due to batch round race), keep the swap Pending so routine polls retry.
-                    continue;
-                }
+                    // For ARK→BTC chain swaps: try to claim BTC when server has locked
+                    if (swap.SwapType is ArkSwapType.ChainArkToBtc &&
+                        IsChainSwapClaimableStatus(swapStatus.Status))
+                    {
+                        await TryClaimBtcForChainSwap(swap, cancellationToken);
+                    }
 
-                // For ARK→BTC chain swaps: try to claim BTC when server has locked
-                if (swap.SwapType is ArkSwapType.ChainArkToBtc &&
-                    IsChainSwapClaimableStatus(swapStatus.Status))
-                {
-                    await TryClaimBtcForChainSwap(swap, cancellationToken);
-                }
+                    // For BTC→ARK chain swaps: provide cooperative cross-signature so Boltz
+                    // can claim our BTC lockup via key-path (more efficient than script-path).
+                    // This is non-critical — Boltz can eventually claim via script-path with preimage.
+                    if (swap.SwapType is ArkSwapType.ChainBtcToArk &&
+                        swapStatus.Status is "transaction.claim.pending")
+                    {
+                        await TrySignBoltzBtcClaim(swap, cancellationToken);
+                    }
 
-                // For BTC→ARK chain swaps: provide cooperative cross-signature so Boltz
-                // can claim our BTC lockup via key-path (more efficient than script-path).
-                // This is non-critical — Boltz can eventually claim via script-path with preimage.
-                if (swap.SwapType is ArkSwapType.ChainBtcToArk &&
-                    swapStatus.Status is "transaction.claim.pending")
-                {
-                    await TrySignBoltzBtcClaim(swap, cancellationToken);
-                }
+                    // Re-read swap — claim handlers may have updated status to terminal
+                    var updatedSwaps = await _swapsStorage.GetSwaps(swapIds: [idToPoll], cancellationToken: cancellationToken);
+                    swap = updatedSwaps.FirstOrDefault() ?? swap;
+                    if (swap.Status is ArkSwapStatus.Settled or ArkSwapStatus.Refunded) continue;
 
-                // Re-read swap — claim handlers may have updated status to terminal
-                var updatedSwaps = await _swapsStorage.GetSwaps(swapIds: [idToPoll], cancellationToken: cancellationToken);
-                swap = updatedSwaps.FirstOrDefault() ?? swap;
-                if (swap.Status is ArkSwapStatus.Settled or ArkSwapStatus.Refunded) continue;
+                    var newStatus = Map(swapStatus.Status);
 
-                var newStatus = Map(swapStatus.Status);
+                    if (swap.Status == newStatus)
+                    {
+                        _logger?.LogDebug(
+                            "Swap {SwapId}: mapped Boltz '{BoltzStatus}' -> {Status}, unchanged",
+                            idToPoll, swapStatus.Status, newStatus);
+                        continue;
+                    }
 
-                if (swap.Status == newStatus)
-                {
-                    _logger?.LogDebug(
-                        "Swap {SwapId}: mapped Boltz '{BoltzStatus}' -> {Status}, unchanged",
-                        idToPoll, swapStatus.Status, newStatus);
-                    continue;
-                }
+                    _logger?.LogInformation("Swap {SwapId}: status changed {OldStatus} -> {NewStatus} (Boltz: '{BoltzStatus}')",
+                        idToPoll, swap.Status, newStatus, swapStatus.Status);
 
-                _logger?.LogInformation("Swap {SwapId}: status changed {OldStatus} -> {NewStatus} (Boltz: '{BoltzStatus}')",
-                    idToPoll, swap.Status, newStatus, swapStatus.Status);
+                    var swapWithNewStatus =
+                        swap with { Status = newStatus, UpdatedAt = DateTimeOffset.Now };
 
-                var swapWithNewStatus =
-                    swap with { Status = newStatus, UpdatedAt = DateTimeOffset.Now };
+                    await _swapsStorage.SaveSwap(swap.WalletId,
+                        swapWithNewStatus, cancellationToken: cancellationToken);
 
-                await _swapsStorage.SaveSwap(swap.WalletId,
-                    swapWithNewStatus, cancellationToken: cancellationToken);
-
-                if (swapWithNewStatus.Status is ArkSwapStatus.Settled or ArkSwapStatus.Refunded)
-                {
-                    _logger?.LogInformation("Swap {SwapId}: terminal state {Status}, removing from watch list",
-                        idToPoll, swapWithNewStatus.Status);
-                    _scriptToSwapId.Remove(swapWithNewStatus.ContractScript, out _);
-                    _swapsIdToWatch.Remove(swapWithNewStatus.SwapId);
-                    // Drop the subscription on the persistent websocket so we
-                    // don't keep receiving updates for a swap we no longer
-                    // care about. Best-effort — failure is non-fatal.
-                    await UnsubscribeOnWebsocketAsync([swapWithNewStatus.SwapId], cancellationToken);
+                    if (swapWithNewStatus.Status is ArkSwapStatus.Settled or ArkSwapStatus.Refunded)
+                    {
+                        _logger?.LogInformation("Swap {SwapId}: terminal state {Status}, removing from watch list",
+                            idToPoll, swapWithNewStatus.Status);
+                        _scriptToSwapId.Remove(swapWithNewStatus.ContractScript, out _);
+                        _swapsIdToWatch.Remove(swapWithNewStatus.SwapId);
+                        // Drop the subscription on the persistent websocket so we
+                        // don't keep receiving updates for a swap we no longer
+                        // care about. Best-effort — failure is non-fatal.
+                        await UnsubscribeOnWebsocketAsync([swapWithNewStatus.SwapId], cancellationToken);
+                    }
                 }
             }
             catch (BoltzSwapNotFoundException)
@@ -854,6 +863,7 @@ public class SwapsManagementService : IAsyncDisposable
     public async Task<string> InitiateSubmarineSwap(string walletId, BOLT11PaymentRequest invoice, bool autoPay = true,
         CancellationToken cancellationToken = default)
     {
+        using var _walletScope = _logger?.BeginScope(("WalletId", walletId));
         _logger?.LogInformation("Initiating submarine swap for wallet {WalletId}, autoPay={AutoPay}", walletId, autoPay);
         var serverInfo = await _clientTransport.GetServerInfoAsync(cancellationToken);
 
@@ -914,6 +924,7 @@ public class SwapsManagementService : IAsyncDisposable
     public async Task<uint256> PayExistingSubmarineSwap(string walletId, string swapId,
         CancellationToken cancellationToken = default)
     {
+        using var _walletScope = _logger?.BeginScope(("WalletId", walletId));
         var swaps = await _swapsStorage.GetSwaps(walletIds: [walletId], swapIds: [swapId],
             cancellationToken: cancellationToken);
         var swap = swaps.FirstOrDefault()
@@ -941,6 +952,7 @@ public class SwapsManagementService : IAsyncDisposable
     public async Task<string> InitiateReverseSwap(string walletId, CreateInvoiceParams invoiceParams,
         CancellationToken cancellationToken = default)
     {
+        using var _walletScope = _logger?.BeginScope(("WalletId", walletId));
         _logger?.LogInformation("Initiating reverse swap for wallet {WalletId}, amount={Amount}",
             walletId, invoiceParams.Amount);
         var addressProvider = await _walletProvider.GetAddressProviderAsync(walletId, cancellationToken);
@@ -986,6 +998,7 @@ public class SwapsManagementService : IAsyncDisposable
         long amountSats,
         CancellationToken cancellationToken = default)
     {
+        using var _walletScope = _logger?.BeginScope(("WalletId", walletId));
         _logger?.LogInformation("Initiating BTC→ARK chain swap for wallet {WalletId}, amount={Amount}",
             walletId, amountSats);
 
@@ -1048,6 +1061,7 @@ public class SwapsManagementService : IAsyncDisposable
         BitcoinAddress btcDestination,
         CancellationToken cancellationToken = default)
     {
+        using var _walletScope = _logger?.BeginScope(("WalletId", walletId));
         _logger?.LogInformation("Initiating ARK→BTC chain swap for wallet {WalletId}, amount={Amount}, dest={Dest}",
             walletId, amountSats, btcDestination);
 
@@ -1322,6 +1336,7 @@ public class SwapsManagementService : IAsyncDisposable
         OutputDescriptor[] descriptors,
         CancellationToken cancellationToken = default)
     {
+        using var _walletScope = _logger?.BeginScope(("WalletId", walletId));
         if (descriptors.Length == 0)
             return [];
 


### PR DESCRIPTION
## Summary

Adds `using (logger.BeginScope(("WalletId", id)))` at every per-wallet entry point in the SDK so downstream sinks (e.g. the BTCPay plugin's per-wallet diagnostic log added in [ArkLabsHQ/btcpay-arkade#46](https://github.com/ArkLabsHQ/btcpay-arkade/pull/46)) can route every transitively-emitted log line to the right wallet — including ones whose message template doesn't already carry `{WalletId}`.

## Why

Without scopes, capture is best-effort: a custom `ILoggerProvider` can only see `WalletId` if the call site happens to include it as a structured arg. Many services log heavily but with `{SwapId}` / `{IntentId}` / `{Outpoint}` only — so per-wallet capture missed them.

Adding a scope is cheap (one allocation per iteration / call) and propagates through async via `AsyncLocal`, so any sub-method called from the scoped region inherits it without further changes.

## What's scoped

**`NArk.Swaps/Services/SwapsManagementService.cs`**
- `PollSwapState` foreach iteration body (after the swap is loaded) — transitively covers `TryClaimBtcForChainSwap`, `TrySignBoltzBtcClaim`, `RequestRefundCooperatively`
- Public initiate / pay / restore methods: `InitiateSubmarineSwap`, `PayExistingSubmarineSwap`, `InitiateReverseSwap`, `InitiateBtcToArkChainSwap`, `InitiateArkToBtcChainSwap`, `RestoreSwaps`

**`NArk.Core/Services/BatchManagementService.cs`**
- `RouteToBatchSessionsAsync` per-intent loop — transitively covers `HandleBatchFailedAsync`, `HandleBatchFinalizedAsync`, `HandleBatchExceptionAsync`
- `HandleBatchStartedForAllIntentsAsync` per-intent loop — transitively covers `SetupBatchSessionAsync`

**`NArk.Core/Services/OnchainService.cs`**
- `InitiateCollaborativeExit(string walletId, …)` and the `(ArkCoin[] inputs, …)` overload (the latter derives the wallet from `inputs[0].WalletIdentifier` and opens the scope before validations so rejection logs carry it too)

**`NArk.Core/Services/IntentGenerationService.cs`**
- `GenerateManualIntent(string walletId, …)`
- The periodic per-wallet loop in the generation cycle (`foreach (var walletContracts in contracts)`) — `using var` at the top of each iteration disposes between wallets

**`NArk.Core/Services/SpendingService.cs`**
- `Spend(string walletId, ArkCoin[], …)`, `Spend(string walletId, ArkTxOut[], …)`, and `GetAvailableCoins(string walletId, …)`

**`NArk.Core/Services/AssetManager.cs`**
- `IssueAsync(string walletId, …)`, `ReissueAsync(string walletId, …)`, `BurnAsync(string walletId, …)`

**`NArk.Core/Recovery/HdWalletRecoveryService.cs`**
- `ScanAsync(string walletId, …)`

**`NArk.Core/Services/DelegationMonitorService.cs`**
- `ProcessVtxoAsync(ArkVtxo vtxo)` — scope opened right after `walletId` is resolved from `contract.WalletIdentifier`

**`NArk.Core/Services/SweeperService.cs`**
- `Sweep(HashSet<ArkCoin>)` per-coin loop — the coin set may span multiple wallets, so the scope is per iteration, not per call

## What still isn't scoped (and why)

`VtxoSynchronizationService` polls / streams span **all** active wallets at once. A single log line can pertain to many wallets, so a per-wallet scope would be misleading. Sinks that want per-wallet routing of indexer activity will need a different mechanism (e.g. inspecting the script→wallet map at log time).

## Behaviour

No behavioural changes. The `using (...)` blocks only add scope context to the existing async flow. `continue` inside the new `using` blocks still targets the surrounding `foreach` (the using's finally disposes the scope before the iteration exits).

## Test plan

- [x] `dotnet build NArk.sln` — 0 errors
- [x] `dotnet test NArk.Tests` — 273 / 273 pass
- [ ] CI: build + unit + e2e green