### PR TITLE
fix(blockchain): cache last chain-time + fall back on transient RPC failure

### DIFF
--- a/NArk.Core/Blockchain/NBXplorer/ChainTimeProvider.cs
+++ b/NArk.Core/Blockchain/NBXplorer/ChainTimeProvider.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NArk.Abstractions.Blockchain;
 using NBitcoin;
@@ -5,24 +6,29 @@ using NBXplorer;
 
 namespace NArk.Blockchain.NBXplorer;
 
+/// <summary>
+/// Adapter that wires <see cref="RPCChainTimeProvider"/> against an
+/// NBXplorer <see cref="ExplorerClient"/>. Logger is optional and only
+/// used to surface warnings when the inner provider falls back to its
+/// cached chain time after a transient RPC failure.
+/// </summary>
 public class ChainTimeProvider : IChainTimeProvider
 {
     private readonly RPCChainTimeProvider _innerRpcProvider;
 
-    public ChainTimeProvider(Network network, Uri uri)
+    public ChainTimeProvider(Network network, Uri uri, ILogger<RPCChainTimeProvider>? logger = null)
     {
         var client = new ExplorerClient(new NBXplorerNetworkProvider(network.ChainName).GetBTC(), uri);
-        _innerRpcProvider = new RPCChainTimeProvider(client.RPCClient);
-
+        _innerRpcProvider = new RPCChainTimeProvider(client.RPCClient, logger);
     }
 
-    public ChainTimeProvider(ExplorerClient explorerClient)
+    public ChainTimeProvider(ExplorerClient explorerClient, ILogger<RPCChainTimeProvider>? logger = null)
     {
-        _innerRpcProvider = new RPCChainTimeProvider(explorerClient.RPCClient);
+        _innerRpcProvider = new RPCChainTimeProvider(explorerClient.RPCClient, logger);
     }
 
-    public ChainTimeProvider(IOptions<ChainTimeProviderOptions> options)
-        : this(options.Value.Network, options.Value.Uri) { }
+    public ChainTimeProvider(IOptions<ChainTimeProviderOptions> options, ILogger<RPCChainTimeProvider>? logger = null)
+        : this(options.Value.Network, options.Value.Uri, logger) { }
 
 
     public Task<TimeHeight> GetChainTime(CancellationToken cancellationToken = default)

--- a/NArk.Core/Blockchain/NBXplorer/RPCChainTimeProvider.cs
+++ b/NArk.Core/Blockchain/NBXplorer/RPCChainTimeProvider.cs
@@ -1,29 +1,70 @@
-﻿using NArk.Abstractions.Blockchain;
+using Microsoft.Extensions.Logging;
+using NArk.Abstractions.Blockchain;
 using NBitcoin.RPC;
 using Newtonsoft.Json;
 
 namespace NArk.Blockchain.NBXplorer;
 
+/// <summary>
+/// <see cref="IChainTimeProvider"/> backed by Bitcoin Core RPC
+/// (typically the NBXplorer-managed node). Caches the last successful
+/// chain-time result and falls back to it when a subsequent RPC call
+/// fails — Bitcoin Core periodically returns transient 5xx errors during
+/// reindex / IBD / heavy load, and a single blip should not be allowed
+/// to bubble unhandled exceptions through every caller (which crashes
+/// the host process when the provider is consumed by a controller
+/// action). The first call after construction must succeed; once cached,
+/// the provider is resilient to transient failures.
+/// </summary>
 public class RPCChainTimeProvider : IChainTimeProvider
 {
     private readonly RPCClient _client;
+    private readonly ILogger<RPCChainTimeProvider>? _logger;
+    private TimeHeight? _lastSuccessful;
 
-    public RPCChainTimeProvider(RPCClient client)
+    /// <summary>Creates a new provider against the supplied RPC client.</summary>
+    /// <param name="client">Configured Bitcoin Core RPC client.</param>
+    /// <param name="logger">Optional logger; only used to warn when an
+    /// RPC call fails and the cached value is being returned instead.</param>
+    public RPCChainTimeProvider(RPCClient client, ILogger<RPCChainTimeProvider>? logger = null)
     {
         _client = client;
+        _logger = logger;
     }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// On RPC failure: if a previous call has succeeded since this
+    /// provider was constructed the cached <see cref="TimeHeight"/> is
+    /// returned and a warning is logged. If there is no cached value
+    /// (cold-start failure) the underlying exception propagates.
+    /// </remarks>
     public async Task<TimeHeight> GetChainTime(CancellationToken cancellationToken = default)
     {
-        var response = await _client.SendCommandAsync("getblockchaininfo", cancellationToken);
-        if (response is null)
-            throw new Exception("NBXplorer RPC returned null when retrieving chain information");
-        var info = JsonConvert.DeserializeObject<GetBlockchainInfoResponse>(response.ResultString);
-        if (info is null)
-            throw new Exception("NBXplorer RPC returned invalid json when retrieving chain information");
-        return new TimeHeight(
-            DateTimeOffset.FromUnixTimeSeconds(info.MedianTime),
-            info.Blocks
-        );
+        try
+        {
+            var response = await _client.SendCommandAsync("getblockchaininfo", cancellationToken);
+            if (response is null)
+                throw new Exception("NBXplorer RPC returned null when retrieving chain information");
+            var info = JsonConvert.DeserializeObject<GetBlockchainInfoResponse>(response.ResultString);
+            if (info is null)
+                throw new Exception("NBXplorer RPC returned invalid json when retrieving chain information");
+            var result = new TimeHeight(
+                DateTimeOffset.FromUnixTimeSeconds(info.MedianTime),
+                info.Blocks
+            );
+            _lastSuccessful = result;
+            return result;
+        }
+        catch (Exception ex) when (_lastSuccessful is { } cached && ex is not OperationCanceledException)
+        {
+            _logger?.LogWarning(ex,
+                "Bitcoin Core RPC getblockchaininfo failed; falling back to cached chain time " +
+                "(median={MedianTime}, height={Height}). Caller balances/recoverability classification " +
+                "may be slightly stale until the node recovers.",
+                cached.Timestamp, cached.Height);
+            return cached;
+        }
     }
 
     internal class GetBlockchainInfoResponse


### PR DESCRIPTION
## Problem

`RPCChainTimeProvider.GetChainTime` propagated every Bitcoin Core RPC error as an unhandled exception. For controller-bound consumers (BTCPay Arkade plugin) that's fatal — when `getblockchaininfo` returned 500 during a `Send` POST in production, BTCPay's plugin manager caught the unhandled exception, **disabled the Arkade plugin entirely**, and the user had to manually re-enable it from server settings.

Reproduced in a real user's `btcpay-dump.log`:

\`\`\`
fail: Configuration: Unhandled exception caused by plugin 'BTCPayServer.Plugins.ArkPayServer', disabling it and restarting...
System.Net.Http.HttpRequestException: Response status code does not indicate success: 500 (Internal Server Error).
   at NBitcoin.RPC.RPCClient.SendCommandAsync
   at NArk.Blockchain.NBXplorer.RPCChainTimeProvider.GetChainTime
   at ArkController.GetArkBalances
   at ArkController.Send
\`\`\`

Bitcoin Core periodically returns transient 5xx during reindex / IBD / heavy load — a single blip should not be allowed to take a downstream service offline.

## Fix

`RPCChainTimeProvider` now caches the last successful `(Timestamp, Height)` it returned. On RPC failure:

- if a cached value exists → return it + log a warning ("falling back to cached chain time…")
- if no cache exists yet (cold-start failure) → propagate the exception as before

This trades a small amount of staleness (during the outage, recoverability classification uses the last-known chain time instead of the live one — typically off by minutes) for not crashing every consumer.

`ChainTimeProvider` (the NBXplorer-flavored wrapper) gains an optional `ILogger<RPCChainTimeProvider>?` parameter on each constructor so consumers can surface the fallback warning. Default-null keeps the change non-breaking.

## Surface

- `RPCChainTimeProvider..ctor(RPCClient, ILogger<RPCChainTimeProvider>? logger = null)` — new optional logger param
- `ChainTimeProvider..ctor(...)` — three overloads gain optional `ILogger<RPCChainTimeProvider>?` (forwarded to inner provider)
- No interface changes; `IChainTimeProvider.GetChainTime` semantics unchanged from a non-failing caller's perspective

## Test plan

- [x] `dotnet build NArk.sln` — 0 errors
- [x] `dotnet test NArk.Tests` — 273/273 pass
- [ ] CI: build + unit + e2e green
- [ ] Downstream: BTCPay plugin bumps NNark, optionally wires the logger so the warning shows up in plugin logs