### PR TITLE
feat(swaps): plumb optional referralId on Boltz swap creation

### DIFF
--- a/NArk.Swaps/Boltz/BoltzSwapsService.cs
+++ b/NArk.Swaps/Boltz/BoltzSwapsService.cs
@@ -40,6 +40,7 @@ internal class BoltzSwapService(BoltzClient boltzClient, IClientTransport client
                 (extractedSender.PubKey?.ToBytes() ?? extractedSender.XOnlyPubKey.ToBytes()).ToHexStringLower(),
             From = "ARK",
             To = "BTC",
+            ReferralId = boltzClient.ReferralId,
         }, cancellationToken);
 
         if (invoice.PaymentHash is null)
@@ -99,6 +100,7 @@ internal class BoltzSwapService(BoltzClient boltzClient, IClientTransport client
             DescriptionHash = createInvoiceRequest.DescriptionHash?.ToString(),
             Description = createInvoiceRequest.Description,
             InvoiceExpirySeconds = Convert.ToInt32(createInvoiceRequest.Expiry.TotalSeconds),
+            ReferralId = boltzClient.ReferralId,
         };
 
         var response = await boltzClient.CreateReverseSwapAsync(request, cancellationToken);
@@ -185,7 +187,8 @@ internal class BoltzSwapService(BoltzClient boltzClient, IClientTransport client
             PreimageHash = Encoders.Hex.EncodeData(preimageHash),
             ClaimPublicKey = claimPubKeyHex,
             RefundPublicKey = Encoders.Hex.EncodeData(ephemeralKey.PubKey.ToBytes()),
-            ServerLockAmount = amountSats
+            ServerLockAmount = amountSats,
+            ReferralId = boltzClient.ReferralId,
         };
 
         var response = await boltzClient.CreateChainSwapAsync(request, ct);
@@ -256,7 +259,8 @@ internal class BoltzSwapService(BoltzClient boltzClient, IClientTransport client
             PreimageHash = Encoders.Hex.EncodeData(preimageHash),
             ClaimPublicKey = Encoders.Hex.EncodeData(ephemeralKey.PubKey.ToBytes()),
             RefundPublicKey = refundPubKeyHex,
-            UserLockAmount = amountSats
+            UserLockAmount = amountSats,
+            ReferralId = boltzClient.ReferralId,
         };
 
         var response = await boltzClient.CreateChainSwapAsync(request, ct);

--- a/NArk.Swaps/Boltz/Client/BoltzClient.cs
+++ b/NArk.Swaps/Boltz/Client/BoltzClient.cs
@@ -28,6 +28,14 @@ public partial class BoltzClient
     }
 
     /// <summary>
+    /// Referral identifier configured for this client (or null if not set).
+    /// Stamped on every swap-creation request by <see cref="BoltzSwapService"/>
+    /// so Boltz can credit the originating integration. See
+    /// <see cref="BoltzClientOptions.ReferralId"/>.
+    /// </summary>
+    public string? ReferralId => _options.Value.ReferralId;
+
+    /// <summary>
     /// Derives the WebSocket URI from the base HTTP URI.
     /// </summary>
     /// <param name="baseHttpUri">The base HTTP URI of the Boltz API.</param>

--- a/NArk.Swaps/Boltz/Models/BoltzClientOptions.cs
+++ b/NArk.Swaps/Boltz/Models/BoltzClientOptions.cs
@@ -4,4 +4,13 @@ public class BoltzClientOptions
 {
     public required string BoltzUrl { get; set; }
     public required string WebsocketUrl { get; set; }
+
+    /// <summary>
+    /// Optional referral identifier sent with every Boltz swap-creation
+    /// request (Submarine, Reverse, Chain). Boltz uses this to credit the
+    /// originating integration for the swap. Leave null to omit; consumer
+    /// apps should set it to the value Boltz issued them (e.g. wallet
+    /// integrations use "arkade-money", BTCPay plugin uses "btcpay-arkade").
+    /// </summary>
+    public string? ReferralId { get; set; }
 }

--- a/NArk.Swaps/Boltz/Models/Swaps/Submarine/SubmarineRequest.cs
+++ b/NArk.Swaps/Boltz/Models/Swaps/Submarine/SubmarineRequest.cs
@@ -16,4 +16,6 @@ public class SubmarineRequest
     [JsonPropertyName("refundPublicKey")]
     public required string RefundPublicKey { get; set; }
 
+    [JsonPropertyName("referralId")]
+    public string? ReferralId { get; set; }
 }


### PR DESCRIPTION
## Summary

Mirrors [arkade-os/wallet#606](https://github.com/arkade-os/wallet/pull/606) (which added a \`referralId\` on the JS \`boltz-swap\` provider) on the .NET SDK side. Boltz uses the referralId to credit the originating integration for the swap; consumer apps pass their own identifier (the wallet uses \`arkade-money\`, the BTCPay plugin will use \`btcpay-arkade\` in a paired bump PR).

## Changes

- \`BoltzClientOptions\` gains an optional \`ReferralId\` property.
- \`BoltzClient\` exposes it as a public read-only property (so the swap orchestrator can stamp it without taking a second DI dependency).
- \`SubmarineRequest\` gains a \`ReferralId\` field. The other two swap-creation DTOs (\`ReverseRequest\`, \`ChainRequest\`) already had one — only Submarine was missing, so the JSON shape is now consistent across all three.
- \`BoltzSwapsService\` stamps \`boltzClient.ReferralId\` on every swap-create request: Submarine, Reverse, BTC→ARK chain, ARK→BTC chain.

## Surface change

Single field, opt-in, default null. Existing callers who don't configure a referral see no behavior change — \`JsonIgnoreCondition.WhenWritingNull\` (the existing client-level setting) keeps the field off the wire.

## Test plan

- [x] \`dotnet build NArk.sln\` — 0 errors
- [x] \`dotnet test NArk.Tests\` — 273/273 pass
- [ ] CI: build + unit + e2e green
- [ ] Downstream BTCPay PR sets \`ReferralId = "btcpay-arkade"\` and verifies a Submarine / Reverse / Chain swap goes out with that field