### PR TITLE
chore(swaps): default Boltz ReferralId to "arkade-dotnet-sdk"

### DIFF
--- a/NArk.Swaps/Boltz/Models/BoltzClientOptions.cs
+++ b/NArk.Swaps/Boltz/Models/BoltzClientOptions.cs
@@ -2,15 +2,28 @@ namespace NArk.Swaps.Boltz.Models;
 
 public class BoltzClientOptions
 {
+    /// <summary>
+    /// Default referral identifier used when a consumer application does
+    /// not configure its own. Boltz uses this to credit the originating
+    /// integration for the swap; leaving the SDK-level default in place
+    /// means swaps from un-customised integrations are attributed to the
+    /// .NET SDK as a whole. Consumer apps that have their own referral
+    /// (e.g. the BTCPay plugin uses "btcpay-arkade", standalone wallet
+    /// integrations use "arkade-money") should override
+    /// <see cref="ReferralId"/> via <c>services.Configure&lt;BoltzClientOptions&gt;</c>.
+    /// </summary>
+    public const string DefaultReferralId = "arkade-dotnet-sdk";
+
     public required string BoltzUrl { get; set; }
     public required string WebsocketUrl { get; set; }
 
     /// <summary>
-    /// Optional referral identifier sent with every Boltz swap-creation
-    /// request (Submarine, Reverse, Chain). Boltz uses this to credit the
-    /// originating integration for the swap. Leave null to omit; consumer
-    /// apps should set it to the value Boltz issued them (e.g. wallet
-    /// integrations use "arkade-money", BTCPay plugin uses "btcpay-arkade").
+    /// Referral identifier sent with every Boltz swap-creation request
+    /// (Submarine, Reverse, Chain). Defaults to <see cref="DefaultReferralId"/>
+    /// (<c>"arkade-dotnet-sdk"</c>); set to <c>null</c> to omit the field
+    /// entirely from outgoing requests, or to a per-integration value
+    /// (e.g. <c>"btcpay-arkade"</c>, <c>"arkade-money"</c>) issued by
+    /// Boltz to claim attribution for that integration.
     /// </summary>
-    public string? ReferralId { get; set; }
+    public string? ReferralId { get; set; } = DefaultReferralId;
 }


### PR DESCRIPTION
## Summary

The optional \`ReferralId\` field added in #86 defaulted to \`null\` — un-customised SDK consumers therefore showed up to Boltz as anonymous traffic. Default it to \`\"arkade-dotnet-sdk\"\` so swaps from integrations that don't set their own referral are attributed to the .NET SDK as a whole.

## Behaviour

| Consumer | Pre-#86 | Pre-this-PR | Post-this-PR |
|---|---|---|---|
| Integration that sets its own referral (e.g. BTCPay plugin: \`btcpay-arkade\`) | n/a | their value | their value (unchanged — \`Configure<TOptions>\` runs after the property initializer) |
| Integration that doesn't set a referral | no field on the wire | no field on the wire | \`\"arkade-dotnet-sdk\"\` on the wire |
| Integration that explicitly opts out (\`o.ReferralId = null\`) | n/a | no field | no field (still respected — \`JsonIgnoreCondition.WhenWritingNull\`) |

## Surface

- New \`BoltzClientOptions.DefaultReferralId\` constant — \`\"arkade-dotnet-sdk\"\`. Exposed so tests / consumers can refer to it symbolically rather than hard-coding the string.
- \`BoltzClientOptions.ReferralId\` now initialises to \`DefaultReferralId\` instead of \`null\`.

## Test plan

- [x] \`dotnet build NArk.sln\` — 0 errors
- [x] \`dotnet test NArk.Tests\` — 285/285 pass
- [ ] CI: build + unit + e2e green