### PR TITLE
sample(wallet): dogfood ArkBip21.Parse + surface pending-tx + StillPending count

### DIFF
--- a/samples/NArk.Wallet/NArk.Wallet.Client/Pages/Send.razor
+++ b/samples/NArk.Wallet/NArk.Wallet.Client/Pages/Send.razor
@@ -5,6 +5,7 @@
 @inject IJSRuntime JS
 @inject LnurlHelper Lnurl
 @using NArk.Wallet.Client.Services
+@using NArk.Abstractions.Payments
 @using NArk.Swaps.Boltz
 
 <div class="page-header">
@@ -262,52 +263,17 @@
 
         input = input.Trim();
 
-        // BIP21 URI: bitcoin:address?amount=X&ark=tark1q...&asset=...
-        if (input.StartsWith("bitcoin:", StringComparison.OrdinalIgnoreCase))
+        // Delegate BIP21 URIs, Ark/BTC addresses, and raw Lightning invoices to
+        // the SDK's ArkBip21.Parse — single source of truth for payment-string
+        // recognition. LNURL/Lightning-address still goes through LnurlHelper
+        // since the SDK parser doesn't resolve LNURL endpoints.
+        var info = ArkBip21.Parse(input);
+        if (info is not null)
         {
-            ParseBip21(input);
+            MapBip21PaymentInfo(info);
             return;
         }
 
-        // Lightning invoice
-        if (input.StartsWith("lnbc", StringComparison.OrdinalIgnoreCase) ||
-            input.StartsWith("lntbs", StringComparison.OrdinalIgnoreCase) ||
-            input.StartsWith("lntb", StringComparison.OrdinalIgnoreCase) ||
-            input.StartsWith("lnbcrt", StringComparison.OrdinalIgnoreCase))
-        {
-            _parsedType = "lightning";
-            _parsedAddress = input;
-            return;
-        }
-
-        // Ark address
-        if (input.StartsWith("tark1", StringComparison.OrdinalIgnoreCase) ||
-            input.StartsWith("ark1", StringComparison.OrdinalIgnoreCase))
-        {
-            _parsedType = "ark";
-            _parsedAddress = input;
-            return;
-        }
-
-        // On-chain Bitcoin address (bech32)
-        if (input.StartsWith("bc1", StringComparison.OrdinalIgnoreCase) ||
-            input.StartsWith("tb1", StringComparison.OrdinalIgnoreCase) ||
-            input.StartsWith("bcrt1", StringComparison.OrdinalIgnoreCase))
-        {
-            _parsedType = "onchain";
-            _parsedAddress = input;
-            return;
-        }
-
-        // Legacy addresses
-        if (input.StartsWith("1") || input.StartsWith("3") || input.StartsWith("m") || input.StartsWith("n") || input.StartsWith("2"))
-        {
-            _parsedType = "onchain";
-            _parsedAddress = input;
-            return;
-        }
-
-        // LNURL / Lightning Address
         if (LnurlHelper.IsLnurl(input))
         {
             _parsedType = "lnurl";
@@ -319,65 +285,28 @@
         _parseError = "Unrecognized address format";
     }
 
-    private void ParseBip21(string uri)
+    /// <summary>
+    /// Translates the SDK's <see cref="Bip21PaymentInfo"/> into the page's
+    /// existing <c>_parsedType</c>/<c>_parsedAddress</c>/<c>_parsedAmountSats</c>
+    /// fields so the rest of the rendering logic doesn't need to change.
+    /// </summary>
+    private void MapBip21PaymentInfo(Bip21PaymentInfo info)
     {
-        try
+        _parsedType = info.PreferredMethod switch
         {
-            // bitcoin:address?param=value&...
-            var withoutScheme = uri["bitcoin:".Length..];
-            var qIdx = withoutScheme.IndexOf('?');
-            var address = qIdx >= 0 ? withoutScheme[..qIdx] : withoutScheme;
-            var queryParams = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            ArkPaymentMethod.ArkSend         => "ark",
+            ArkPaymentMethod.SubmarineSwap   => "lightning",
+            ArkPaymentMethod.ChainSwap       => "onchain",
+            ArkPaymentMethod.CollaborativeExit => "onchain",
+            _ => null,
+        };
 
-            if (qIdx >= 0)
-            {
-                var queryString = withoutScheme[(qIdx + 1)..];
-                foreach (var pair in queryString.Split('&'))
-                {
-                    var eqIdx = pair.IndexOf('=');
-                    if (eqIdx > 0)
-                    {
-                        queryParams[Uri.UnescapeDataString(pair[..eqIdx])] = Uri.UnescapeDataString(pair[(eqIdx + 1)..]);
-                    }
-                }
-            }
+        _parsedAddress = info.Recipient;
+        _parsedAsset = info.AssetId;
+        _parsedAmountSats = info.AmountSats is { } sats ? (long)sats : 0L;
 
-            // Check for ark query parameter — takes priority
-            if (queryParams.TryGetValue("ark", out var arkAddress) && !string.IsNullOrWhiteSpace(arkAddress))
-            {
-                _parsedType = "ark";
-                _parsedAddress = arkAddress;
-            }
-            else if (!string.IsNullOrWhiteSpace(address))
-            {
-                _parsedType = "onchain";
-                _parsedAddress = address;
-            }
-
-            // Parse amount (BIP21 amount is in BTC)
-            if (queryParams.TryGetValue("amount", out var amountStr) &&
-                decimal.TryParse(amountStr, System.Globalization.NumberStyles.Any,
-                    System.Globalization.CultureInfo.InvariantCulture, out var btcAmount))
-            {
-                _parsedAmountSats = (long)(btcAmount * 100_000_000m);
-            }
-
-            // Asset param — restricts to Ark only
-            if (queryParams.TryGetValue("asset", out var assetId) && !string.IsNullOrWhiteSpace(assetId))
-            {
-                _parsedAsset = assetId;
-                _parsedType = "ark"; // Force Ark — assets can't traverse other channels
-                if (_parsedAddress is null && !string.IsNullOrWhiteSpace(address))
-                    _parsedAddress = address;
-            }
-
-            if (_parsedAddress is null)
-                _parseError = "Could not parse address from BIP21 URI";
-        }
-        catch
-        {
-            _parseError = "Invalid BIP21 URI";
-        }
+        if (_parsedAddress is null)
+            _parseError = "Could not extract a recipient from the payment string";
     }
 
     private bool IsWithinChainSwapLimits()

--- a/samples/NArk.Wallet/NArk.Wallet.Client/Pages/Settings.razor
+++ b/samples/NArk.Wallet/NArk.Wallet.Client/Pages/Settings.razor
@@ -117,6 +117,27 @@
             </div>
         }
 
+        <!-- Maintenance -->
+        <div class="section-header mt-24" style="padding:0;">
+            <span class="section-title">Maintenance</span>
+        </div>
+
+        <div class="glass-card mt-12 mb-16">
+            <p style="font-size:14px;font-weight:600;margin-bottom:4px;">Force pending-tx recovery</p>
+            <p class="text-secondary" style="font-size:12px;margin-bottom:8px;">
+                Re-runs the Arkade pending-tx sweep for this wallet. The host already does this
+                automatically on startup; use this button if a tx looks stuck after a crash and
+                you don't want to wait for the next restart.
+            </p>
+            <button class="btn btn-sm btn-secondary" @onclick="ForcePendingTxRecovery" disabled="@_recoveryInFlight">
+                @(_recoveryInFlight ? "Recovering..." : "Run recovery now")
+            </button>
+            @if (_recoveryMessage is not null)
+            {
+                <p class="text-secondary mt-12" style="font-size:11px;">@_recoveryMessage</p>
+            }
+        </div>
+
         <!-- Danger Zone -->
         <div class="section-header mt-24" style="padding:0;">
             <span class="section-title" style="color:var(--arkade-red);">Danger Zone</span>
@@ -170,6 +191,8 @@
     private int _intentCount;
     private string? _copiedField;
     private bool _confirmDelete;
+    private bool _recoveryInFlight;
+    private string? _recoveryMessage;
 
     protected override async Task OnInitializedAsync()
     {
@@ -220,6 +243,28 @@
             await Ark.DeleteWallet(State.ActiveWalletId);
             State.SetActiveWallet(null);
             _confirmDelete = false;
+        }
+    }
+
+    private async Task ForcePendingTxRecovery()
+    {
+        if (State.ActiveWalletId is null) return;
+        _recoveryInFlight = true;
+        _recoveryMessage = null;
+        try
+        {
+            var finalized = await Ark.FinalizePendingArkTransactions(State.ActiveWalletId);
+            _recoveryMessage = finalized.Count == 0
+                ? "No pending Arkade transactions to recover."
+                : $"Finalized {finalized.Count} pending tx(s): {string.Join(", ", finalized.Select(id => id[..Math.Min(12, id.Length)]))}.";
+        }
+        catch (Exception ex)
+        {
+            _recoveryMessage = $"Recovery failed: {ex.Message}";
+        }
+        finally
+        {
+            _recoveryInFlight = false;
         }
     }
 

--- a/samples/NArk.Wallet/NArk.Wallet.Client/Pages/Swaps.razor
+++ b/samples/NArk.Wallet/NArk.Wallet.Client/Pages/Swaps.razor
@@ -23,10 +23,17 @@
             <div class="mt-12">
                 @{
                     var recoverable = _recoveryReport.Where(r => r.Status == SwapRecoveryStatus.Recoverable).ToList();
+                    var stillPending = _recoveryReport.Count(r => r.Status == SwapRecoveryStatus.StillPending);
                 }
                 @if (recoverable.Count == 0)
                 {
-                    <p class="text-secondary" style="font-size:12px;">No swaps with stranded funds.</p>
+                    <p class="text-secondary" style="font-size:12px;">
+                        No swaps with stranded funds.
+                        @if (stillPending > 0)
+                        {
+                            <span> @stillPending still in flight — recovery is a no-op until they settle or fail.</span>
+                        }
+                    </p>
                 }
                 else
                 {
@@ -37,6 +44,12 @@
                             <li>@entry.SwapId[..Math.Min(12, entry.SwapId.Length)]…  <strong>@entry.AmountSats.ToString("N0") sats</strong> at @entry.VtxoCount vtxo(s)</li>
                         }
                     </ul>
+                    @if (stillPending > 0)
+                    {
+                        <p class="text-secondary mt-12" style="font-size:11px;">
+                            (@stillPending swap(s) still in flight — those aren't recovery candidates yet.)
+                        </p>
+                    }
                 }
             </div>
         }


### PR DESCRIPTION
## Summary

Three drift fixes for the Blazor sample wallet to keep it current with what landed in PRs #75, #90, and #89.

1. **`Send.razor` uses `ArkBip21.Parse`** — replaces a 60+ line hand-rolled BIP21 / address parser with the SDK helper PR #75 shipped. LNURL still goes through `LnurlHelper` (the SDK deliberately doesn't resolve LNURL endpoints). Closes the dogfooding loop: the sample now exercises its own SDK's payment-string parser instead of competing with it.

2. **`Settings.razor` "Force pending-tx recovery" button** — surfaces the `FinalizePendingArkTransactions` API that PR #90 added on `ArkWalletService`. `ArkHostedLifecycle` already runs the sweep on startup, but a manual button is useful right after a crash if a tx looks stuck and you don't want to wait for the next restart.

3. **`Swaps.razor` shows `SwapRecoveryStatus.StillPending` count** — distinguishes "you have no active swaps" from "you have active swaps but recovery is correctly skipping them." Tells the user why a scan came up empty.

## Files

- `samples/NArk.Wallet/NArk.Wallet.Client/Pages/Send.razor` — drop custom `ParseBip21` (~60 lines), call `ArkBip21.Parse` + new `MapBip21PaymentInfo` helper. LNURL handling unchanged.
- `samples/NArk.Wallet/NArk.Wallet.Client/Pages/Settings.razor` — new Maintenance section with the recovery button + result message; calls `ArkWalletService.FinalizePendingArkTransactions`.
- `samples/NArk.Wallet/NArk.Wallet.Client/Pages/Swaps.razor` — show `StillPending` count alongside `Recoverable`.

## Test plan

- [x] \`dotnet build samples/NArk.Wallet/NArk.Wallet.Client/NArk.Wallet.Client.csproj\` — clean
- [x] \`dotnet test NArk.Tests\` — 349/349 pass
- [ ] CI build + E2E green