### PR TITLE
fix(efcore): opt-in DateTimeOffset → long ticks mapping so SQLite ORDER BY works

### DIFF
--- a/NArk.Storage.EfCore/ArkStorageOptions.cs
+++ b/NArk.Storage.EfCore/ArkStorageOptions.cs
@@ -28,4 +28,30 @@ public class ArkStorageOptions
     /// </summary>
     public Func<IQueryable<ArkWalletContractEntity>, string, IQueryable<ArkWalletContractEntity>>?
         ContractSearchProvider { get; set; }
+
+    /// <summary>
+    /// When true, stores every <see cref="DateTimeOffset"/> column as <see cref="long"/>
+    /// UTC ticks (BIGINT on Postgres/MSSQL, INTEGER on SQLite). Needed for SQLite consumers
+    /// because EF Core's SQLite provider rejects <c>ORDER BY</c> on the default TEXT
+    /// representation of <see cref="DateTimeOffset"/> — every paged query in this SDK
+    /// (<c>GetVtxos</c>, <c>GetContracts</c>, <c>GetIntents</c>, …) breaks otherwise.
+    ///
+    /// <para>
+    /// <b>Off by default</b> to preserve native column types (<c>timestamptz</c> / <c>datetimeoffset</c>)
+    /// for existing Postgres/MSSQL consumers. Enabling this is a schema change: stored values
+    /// switch from TEXT/timestamp to BIGINT and the original offset is dropped (read-back is
+    /// always UTC, offset zero). On-disk size is unchanged.
+    /// </para>
+    ///
+    /// <para>
+    /// Migration path for existing SQLite consumers:
+    /// <list type="number">
+    /// <item>If you can drop the DB (e.g. local cache), delete the file and let <c>EnsureCreated</c>
+    /// re-create the schema with INTEGER columns.</item>
+    /// <item>Otherwise run a one-off SQL migration to convert TEXT columns to INTEGER ticks
+    /// before enabling this flag.</item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    public bool StoreDateTimeOffsetAsTicks { get; set; }
 }

--- a/NArk.Storage.EfCore/ModelBuilderExtensions.cs
+++ b/NArk.Storage.EfCore/ModelBuilderExtensions.cs
@@ -78,12 +78,35 @@ public static class ModelBuilderExtensions
         return modelBuilder;
     }
 
+    // Restricted to Ark-owned entities so the converter never silently leaks onto a
+    // consumer's own entities sharing the same DbContext. Idempotent: calling
+    // ConfigureArkEntities AND ConfigureArkPaymentEntities with the flag won't apply
+    // the converter twice (SetValueConverter on an already-converted property is a no-op,
+    // but the type-filter short-circuits the second pass cleanly anyway).
+    private static readonly IReadOnlySet<Type> ArkOwnedEntityTypes = new HashSet<Type>
+    {
+        typeof(ArkWalletEntity),
+        typeof(ArkWalletContractEntity),
+        typeof(VtxoEntity),
+        typeof(ArkIntentEntity),
+        typeof(ArkIntentVtxoEntity),
+        typeof(ArkSwapEntity),
+        typeof(ArkPaymentEntity),
+        typeof(ArkPaymentRequestEntity),
+    };
+
     private static void ApplyDateTimeOffsetTicksConversion(ModelBuilder modelBuilder)
     {
         foreach (var entityType in modelBuilder.Model.GetEntityTypes())
         {
+            if (!ArkOwnedEntityTypes.Contains(entityType.ClrType))
+                continue;
+
             foreach (var property in entityType.GetProperties())
             {
+                if (property.GetValueConverter() is not null)
+                    continue;
+
                 if (property.ClrType == typeof(DateTimeOffset))
                     property.SetValueConverter(DateTimeOffsetToTicks);
                 else if (property.ClrType == typeof(DateTimeOffset?))

--- a/NArk.Storage.EfCore/ModelBuilderExtensions.cs
+++ b/NArk.Storage.EfCore/ModelBuilderExtensions.cs
@@ -1,10 +1,33 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NArk.Storage.EfCore.Entities;
 
 namespace NArk.Storage.EfCore;
 
 public static class ModelBuilderExtensions
 {
+    // DateTimeOffset → long (UTC ticks). Applied to every DateTimeOffset property across all
+    // Ark entities. Two reasons:
+    //
+    // 1) EF Core's SQLite provider rejects `ORDER BY` on `DateTimeOffset` columns because the
+    //    default TEXT representation is not chronologically sortable across different offsets.
+    //    Storing as INTEGER (long ticks) is natively orderable on SQLite — no fallback to
+    //    client-side evaluation needed for paged queries.
+    //
+    // 2) Round-trippable and indexable across all providers (BIGINT on Postgres/MSSQL,
+    //    INTEGER on SQLite). Same on-disk size as the native types.
+    //
+    // Cost: the round-trip strips the original offset (always reads back as UTC, offset zero).
+    // The Ark entities use these columns as instants ("when did this happen") rather than zoned
+    // moments, so the offset isn't load-bearing.
+    private static readonly ValueConverter<DateTimeOffset, long> DateTimeOffsetToTicks =
+        new(dto => dto.UtcTicks,
+            ticks => new DateTimeOffset(ticks, TimeSpan.Zero));
+
+    private static readonly ValueConverter<DateTimeOffset?, long?> NullableDateTimeOffsetToTicks =
+        new(dto => dto.HasValue ? dto.Value.UtcTicks : (long?)null,
+            ticks => ticks.HasValue ? new DateTimeOffset(ticks.Value, TimeSpan.Zero) : null);
+
     /// <summary>
     /// Configures core Ark SDK entity types on the given ModelBuilder.
     /// Call this from your DbContext's OnModelCreating.
@@ -27,6 +50,9 @@ public static class ModelBuilderExtensions
         ArkIntentVtxoEntity.Configure(modelBuilder.Entity<ArkIntentVtxoEntity>(), options);
         ArkSwapEntity.Configure(modelBuilder.Entity<ArkSwapEntity>(), options);
 
+        if (options.StoreDateTimeOffsetAsTicks)
+            ApplyDateTimeOffsetTicksConversion(modelBuilder);
+
         return modelBuilder;
     }
 
@@ -46,6 +72,23 @@ public static class ModelBuilderExtensions
         ArkPaymentEntity.Configure(modelBuilder.Entity<ArkPaymentEntity>(), options);
         ArkPaymentRequestEntity.Configure(modelBuilder.Entity<ArkPaymentRequestEntity>(), options);
 
+        if (options.StoreDateTimeOffsetAsTicks)
+            ApplyDateTimeOffsetTicksConversion(modelBuilder);
+
         return modelBuilder;
+    }
+
+    private static void ApplyDateTimeOffsetTicksConversion(ModelBuilder modelBuilder)
+    {
+        foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+        {
+            foreach (var property in entityType.GetProperties())
+            {
+                if (property.ClrType == typeof(DateTimeOffset))
+                    property.SetValueConverter(DateTimeOffsetToTicks);
+                else if (property.ClrType == typeof(DateTimeOffset?))
+                    property.SetValueConverter(NullableDateTimeOffsetToTicks);
+            }
+        }
     }
 }

--- a/NArk.Tests/EfCoreSqliteOrderByTests.cs
+++ b/NArk.Tests/EfCoreSqliteOrderByTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NArk.Storage.EfCore;
+using NArk.Storage.EfCore.Entities;
+
+namespace NArk.Tests;
+
+/// <summary>
+/// Pins the SQLite behaviour for the <see cref="ArkStorageOptions.StoreDateTimeOffsetAsTicks"/>
+/// opt-in: with it on, paged storage queries that <c>ORDER BY</c> a
+/// <see cref="DateTimeOffset"/> column run cleanly on SQLite. Round-trip strips the original
+/// offset (read-back is always UTC) — also pinned here so the trade-off is explicit.
+/// </summary>
+[TestFixture]
+public class EfCoreSqliteOrderByTests
+{
+    [Test]
+    public async Task TicksMapping_OrderByDateTimeOffset_WorksOnSqlite()
+    {
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+
+        var options = new DbContextOptionsBuilder<TicksMappingContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        using (var ctx = new TicksMappingContext(options))
+        {
+            ctx.Database.EnsureCreated();
+
+            ctx.Add(new ArkWalletEntity { Id = "w", Wallet = "mnemonic" });
+
+            var t0 = DateTimeOffset.UtcNow.AddHours(-2);
+            ctx.Add(new ArkWalletContractEntity { Script = "s1", WalletId = "w", Type = "t", CreatedAt = t0 });
+            ctx.Add(new ArkWalletContractEntity { Script = "s2", WalletId = "w", Type = "t", CreatedAt = t0.AddHours(1) });
+            ctx.Add(new ArkWalletContractEntity { Script = "s3", WalletId = "w", Type = "t", CreatedAt = t0.AddHours(2) });
+            await ctx.SaveChangesAsync();
+        }
+
+        await using var query = new TicksMappingContext(options);
+        var ordered = await query.Set<ArkWalletContractEntity>()
+            .OrderByDescending(c => c.CreatedAt)
+            .Select(c => c.Script)
+            .ToListAsync();
+
+        Assert.That(ordered, Is.EqualTo(new[] { "s3", "s2", "s1" }));
+    }
+
+    [Test]
+    public async Task TicksMapping_RoundTrip_StripsOffsetToUtc()
+    {
+        // Documented trade-off: round-trip drops the original offset (read-back is UTC).
+        // Consumers that need the original zoned moment must leave the opt-in off and live
+        // with the SQLite ORDER BY limitation.
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+
+        var options = new DbContextOptionsBuilder<TicksMappingContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        var originalOffset = TimeSpan.FromHours(5);
+        var written = new DateTimeOffset(2026, 1, 15, 12, 0, 0, originalOffset);
+
+        using (var ctx = new TicksMappingContext(options))
+        {
+            ctx.Database.EnsureCreated();
+            ctx.Add(new ArkWalletEntity { Id = "w", Wallet = "mnemonic" });
+            ctx.Add(new ArkWalletContractEntity { Script = "s", WalletId = "w", Type = "t", CreatedAt = written });
+            await ctx.SaveChangesAsync();
+        }
+
+        await using var read = new TicksMappingContext(options);
+        var loaded = await read.Set<ArkWalletContractEntity>().SingleAsync();
+
+        Assert.That(loaded.CreatedAt.UtcDateTime, Is.EqualTo(written.UtcDateTime));
+        Assert.That(loaded.CreatedAt.Offset, Is.EqualTo(TimeSpan.Zero));
+    }
+
+    [Test]
+    public async Task DefaultMapping_StillWorksForReadAndWrite()
+    {
+        // Backwards-compat: when the opt-in is off, DateTimeOffset is still stored and
+        // read back correctly. Only ORDER BY on those columns breaks on SQLite — and
+        // that's the bug the opt-in fixes.
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+
+        var options = new DbContextOptionsBuilder<DefaultMappingContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        var written = DateTimeOffset.UtcNow;
+        using (var ctx = new DefaultMappingContext(options))
+        {
+            ctx.Database.EnsureCreated();
+            ctx.Add(new ArkWalletEntity { Id = "w", Wallet = "mnemonic" });
+            ctx.Add(new ArkWalletContractEntity { Script = "s", WalletId = "w", Type = "t", CreatedAt = written });
+            await ctx.SaveChangesAsync();
+        }
+
+        await using var read = new DefaultMappingContext(options);
+        var loaded = await read.Set<ArkWalletContractEntity>().SingleAsync();
+        Assert.That(loaded.CreatedAt.UtcDateTime, Is.EqualTo(written.UtcDateTime).Within(TimeSpan.FromMilliseconds(1)));
+    }
+
+    private class DefaultMappingContext(DbContextOptions<DefaultMappingContext> options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.ConfigureArkEntities();
+    }
+
+    private class TicksMappingContext(DbContextOptions<TicksMappingContext> options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            => modelBuilder.ConfigureArkEntities(o => o.StoreDateTimeOffsetAsTicks = true);
+    }
+}

--- a/NArk.Tests/EfCoreSqliteOrderByTests.cs
+++ b/NArk.Tests/EfCoreSqliteOrderByTests.cs
@@ -104,6 +104,33 @@ public class EfCoreSqliteOrderByTests
         Assert.That(loaded.CreatedAt.UtcDateTime, Is.EqualTo(written.UtcDateTime).Within(TimeSpan.FromMilliseconds(1)));
     }
 
+    [Test]
+    public void TicksMapping_DoesNotBleedIntoConsumerEntities()
+    {
+        // Scoping: the opt-in MUST only apply to Ark-owned entity types. If a consumer's
+        // own DbSet shares the same DbContext, its DateTimeOffset columns must keep their
+        // native EF Core mapping — the consumer didn't opt in for their own entities.
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+
+        var options = new DbContextOptionsBuilder<MixedEntitiesContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        using var ctx = new MixedEntitiesContext(options);
+        ctx.Database.EnsureCreated();
+
+        var arkProp = ctx.Model.FindEntityType(typeof(ArkWalletContractEntity))!
+            .FindProperty(nameof(ArkWalletContractEntity.CreatedAt))!;
+        var consumerProp = ctx.Model.FindEntityType(typeof(ConsumerEntity))!
+            .FindProperty(nameof(ConsumerEntity.CreatedAt))!;
+
+        Assert.That(arkProp.GetValueConverter(), Is.Not.Null,
+            "Ark entity DateTimeOffset must be converted to ticks.");
+        Assert.That(consumerProp.GetValueConverter(), Is.Null,
+            "Consumer entity DateTimeOffset must NOT be touched by the opt-in.");
+    }
+
     private class DefaultMappingContext(DbContextOptions<DefaultMappingContext> options) : DbContext(options)
     {
         protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -114,5 +141,23 @@ public class EfCoreSqliteOrderByTests
     {
         protected override void OnModelCreating(ModelBuilder modelBuilder)
             => modelBuilder.ConfigureArkEntities(o => o.StoreDateTimeOffsetAsTicks = true);
+    }
+
+    private class ConsumerEntity
+    {
+        public int Id { get; set; }
+        public DateTimeOffset CreatedAt { get; set; }
+    }
+
+    private class MixedEntitiesContext(DbContextOptions<MixedEntitiesContext> options) : DbContext(options)
+    {
+        public DbSet<ConsumerEntity> Consumer => Set<ConsumerEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<ConsumerEntity>().HasKey(c => c.Id);
+            modelBuilder.ConfigureArkEntities(o => o.StoreDateTimeOffsetAsTicks = true);
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -518,6 +518,16 @@ services.AddArkEfCoreStorage<MyDbContext>(opts =>
 });
 ```
 
+### SQLite consumers: enable `StoreDateTimeOffsetAsTicks`
+
+EF Core's SQLite provider rejects `ORDER BY` on `DateTimeOffset` columns, which breaks every paged query in this SDK (`GetVtxos`, `GetContracts`, `GetIntents`, …). Set `StoreDateTimeOffsetAsTicks = true` in `ConfigureArkEntities` (and `ConfigureArkPaymentEntities` if you use payment tracking) to store these columns as INTEGER ticks instead — `ORDER BY` then works natively.
+
+```csharp
+modelBuilder.ConfigureArkEntities(opts => opts.StoreDateTimeOffsetAsTicks = true);
+```
+
+Off by default to preserve native column types for Postgres/MSSQL consumers. Trade-off: the round-trip strips the original timezone offset (reads back as UTC). See [docs/articles/storage.md](docs/articles/storage.md#sqlite-storedatetimeoffsetastick-opt-in) for migration paths and details.
+
 ### Entities
 
 | Entity | Table | Primary Key |

--- a/docs/articles/storage.md
+++ b/docs/articles/storage.md
@@ -145,6 +145,8 @@ UPDATE Vtxos SET SeenAt = CAST((julianday(SeenAt) - 1721425.5) * 864000000000 AS
 -- repeat for other DateTimeOffset columns (CreatedAt, etc.)
 ```
 
+> **Requires SQLite ≥ 3.38.0.** Older versions of `julianday()` silently ignore the timezone offset on TEXT inputs (treating local times as UTC and producing wrong ticks). If your runtime ships an older SQLite, prefer the wipe-and-rebuild path below or normalize values to `…Z` before running the UPDATE.
+
 Or — for local caches where data isn't load-bearing — delete the SQLite file and let `EnsureCreated` rebuild the schema with INTEGER columns.
 
 For tests and other contexts where you're starting from scratch, just set the flag in `OnModelCreating` and run `EnsureCreated` — no migration needed.

--- a/docs/articles/storage.md
+++ b/docs/articles/storage.md
@@ -93,3 +93,58 @@ opts.UseInMemoryDatabase("test");
 ```
 
 `ArkStorageOptions.ContractSearchProvider` lets you inject provider-specific text-search for contract metadata (e.g. PostgreSQL `ILIKE`). See `ArkStorageOptions` for all configuration knobs.
+
+## SQLite: `StoreDateTimeOffsetAsTicks` (opt-in)
+
+Every paged storage query in this SDK (`GetVtxos`, `GetContracts`, `GetIntents`, `GetPayments`, `GetPaymentRequests`, `GetSwaps`) ends with an `ORDER BY` on a `DateTimeOffset` column (`SeenAt`, `CreatedAt`). EF Core's SQLite provider rejects that with:
+
+> SQLite does not support expressions of type 'DateTimeOffset' in ORDER BY clauses.
+
+The reason is that SQLite stores `DateTimeOffset` as TEXT, and the default representation isn't chronologically sortable when offsets differ. Postgres/MSSQL aren't affected — they sort `DateTimeOffset` natively.
+
+To fix SQLite without touching Postgres/MSSQL behaviour, opt in to a `DateTimeOffset → long` (UTC ticks) value conversion:
+
+```csharp
+modelBuilder.ConfigureArkEntities(opts =>
+{
+    opts.Schema = "ark";
+    opts.StoreDateTimeOffsetAsTicks = true;   // SQLite consumers: turn this on
+});
+
+// If you use payment tracking, set the same flag there too:
+modelBuilder.ConfigureArkPaymentEntities(opts =>
+{
+    opts.Schema = "ark";
+    opts.StoreDateTimeOffsetAsTicks = true;
+});
+```
+
+When on, every `DateTimeOffset` column in the Ark model is stored as INTEGER (SQLite) / BIGINT (Postgres/MSSQL). `ORDER BY` works natively; indexes still work; on-disk size is unchanged.
+
+### Trade-offs
+
+1. **Schema change.** Stored values switch from TEXT/timestamp to INTEGER/BIGINT. Existing data won't deserialize after flipping the flag.
+2. **Offset stripped on read-back.** The conversion stores UTC ticks only — the original `DateTimeOffset.Offset` is dropped (always reads back as `TimeSpan.Zero`). Consumers who need the original zoned moment should leave the flag off and accept the SQLite ORDER BY limitation.
+
+### When to enable
+
+| Provider | Recommendation |
+|---|---|
+| SQLite — paged queries failing with the ORDER BY error | **Enable.** This is the fix. |
+| SQLite — no paged queries (or you tolerate the failure) | Leave off. Default preserves native TEXT storage. |
+| PostgreSQL / MSSQL | Leave off. You don't have the bug. Default keeps `timestamptz` / `datetimeoffset` and their native date functions. |
+
+### Migrating existing SQLite data
+
+If you have an existing SQLite DB with TEXT-encoded `DateTimeOffset` columns and you want to flip the flag:
+
+```sql
+-- One-off migration: convert each DateTimeOffset column from TEXT to INTEGER ticks.
+-- Run BEFORE enabling StoreDateTimeOffsetAsTicks.
+UPDATE Vtxos SET SeenAt = CAST((julianday(SeenAt) - 1721425.5) * 864000000000 AS INTEGER);
+-- repeat for other DateTimeOffset columns (CreatedAt, etc.)
+```
+
+Or — for local caches where data isn't load-bearing — delete the SQLite file and let `EnsureCreated` rebuild the schema with INTEGER columns.
+
+For tests and other contexts where you're starting from scratch, just set the flag in `OnModelCreating` and run `EnsureCreated` — no migration needed.

--- a/samples/NArk.Wallet/NArk.Wallet.Client/Services/WalletDbContext.cs
+++ b/samples/NArk.Wallet/NArk.Wallet.Client/Services/WalletDbContext.cs
@@ -1,24 +1,18 @@
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NArk.Storage.EfCore;
 
 namespace NArk.Wallet.Client.Services;
 
 public class WalletDbContext(DbContextOptions<WalletDbContext> options) : DbContext(options)
 {
-    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
-    {
-        // SQLite cannot sort/filter DateTimeOffset natively — store as ticks (long)
-        configurationBuilder.Properties<DateTimeOffset>()
-            .HaveConversion<DateTimeOffsetToBinaryConverter>();
-        configurationBuilder.Properties<DateTimeOffset?>()
-            .HaveConversion<DateTimeOffsetToBinaryConverter>();
-    }
-
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);
-        modelBuilder.ConfigureArkEntities();
-        modelBuilder.ConfigureArkPaymentEntities();
+
+        // This is a SQLite-backed wallet — opt into the ticks-based DateTimeOffset
+        // storage so paged queries that ORDER BY a DateTimeOffset column (GetVtxos,
+        // GetIntents, etc.) work. See docs/articles/storage.md for the trade-offs.
+        modelBuilder.ConfigureArkEntities(o => o.StoreDateTimeOffsetAsTicks = true);
+        modelBuilder.ConfigureArkPaymentEntities(o => o.StoreDateTimeOffsetAsTicks = true);
     }
 }


### PR DESCRIPTION
## Problem

EF Core's SQLite provider rejects \`ORDER BY\` on \`DateTimeOffset\` columns:

> SQLite does not support expressions of type 'DateTimeOffset' in ORDER BY clauses. Convert the values to a supported type, or use LINQ to Objects to order the results on the client side.

This breaks every paged storage query in the SDK (\`GetVtxos\`, \`GetContracts\`, \`GetIntents\`, \`GetPayments\`, \`GetPaymentRequests\`, \`GetSwaps\`) when run against SQLite. Non-SQLite providers (Postgres / MSSQL) sort \`DateTimeOffset\` natively and aren't affected.

Reproduction: bundle NArk with a SQLite-backed \`ArkDbContext\` and call \`IVtxoStorage.GetVtxos(...)\` after any wallet activity. I hit this integrating NArk into Wasabi Wallet's Arkade flow — VTXO listing was unusable.

## Approach

Add \`ArkStorageOptions.StoreDateTimeOffsetAsTicks\` (default off). When on, applies a \`ValueConverter<DateTimeOffset, long>\` to every \`DateTimeOffset\` (and nullable) property in the Ark model — storage becomes BIGINT (Postgres/MSSQL) or INTEGER (SQLite), both natively sortable. Same on-disk size as the native types, fully indexable.

\`\`\`csharp
modelBuilder.ConfigureArkEntities(o => o.StoreDateTimeOffsetAsTicks = true);
\`\`\`

## Why an opt-in instead of always-on

I originally tried \"always-on\" but it's a schema change for *every* existing consumer regardless of provider:

- SQLite consumers: existing TEXT data wouldn't deserialize as long.
- Postgres/MSSQL consumers: existing \`timestamptz\` / \`datetimeoffset\` columns wouldn't load as BIGINT.

Default-off keeps that path safe. Consumers that hit the SQLite bug opt in explicitly and accept the trade-offs documented on the option:

1. Schema changes (TEXT/timestamp → BIGINT).
2. Round-trip strips the original offset (read-back is always UTC, offset zero) — the Ark entities use these columns as instants (\"when did this happen\") rather than zoned moments, so for the SDK's own usage this is fine.

Migration paths for existing SQLite consumers when enabling the flag:

1. Drop the DB file and let \`EnsureCreated\` rebuild with INTEGER columns (fine for local caches).
2. One-off SQL to convert TEXT columns to INTEGER ticks before flipping the flag.

## Tests

Added \`NArk.Tests/EfCoreSqliteOrderByTests.cs\`:

- \`TicksMapping_OrderByDateTimeOffset_WorksOnSqlite\` — proves the opt-in fix: \`ORDER BY CreatedAt DESC\` against SQLite returns rows in chronological order.
- \`TicksMapping_RoundTrip_StripsOffsetToUtc\` — pins the documented trade-off so it can't regress silently.
- \`DefaultMapping_StillWorksForReadAndWrite\` — backwards-compat: with the flag off, \`DateTimeOffset\` columns still store and read back correctly. (Only \`ORDER BY\` is broken on SQLite — the bug the opt-in fixes.)

All 352 tests pass (349 existing + 3 new).

## Out of scope

A future improvement could auto-detect SQLite and apply the conversion only there. That would still be a schema change for existing SQLite consumers though, so leaving the choice to the consumer feels right at this stage.