### PR TITLE
fix(swaps): make AddBoltzProvider self-contained (register BoltzClient)

### DIFF
--- a/NArk.Swaps/Hosting/SwapApplicationBuilderExtensions.cs
+++ b/NArk.Swaps/Hosting/SwapApplicationBuilderExtensions.cs
@@ -40,6 +40,9 @@ public static class SwapApplicationBuilderExtensions
                 services.Configure(boltzOptionsConfigure);
             }
 
+            // BoltzClient registration moved into AddBoltzProvider (called by AddArkSwapServices)
+            // so direct-DI consumers get a self-contained call. The line kept here as a no-op
+            // safety net for any external caller relying on the prior call ordering.
             services.AddHttpClient<BoltzClient>();
             services.AddArkSwapServices();
         });

--- a/NArk.Swaps/Hosting/SwapServiceCollectionExtensions.cs
+++ b/NArk.Swaps/Hosting/SwapServiceCollectionExtensions.cs
@@ -37,13 +37,21 @@ public static class SwapServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Registers the Boltz swap provider and its dependencies.
-    /// Can be called separately if using manual provider registration.
+    /// Registers the Boltz swap provider and its dependencies, including the typed
+    /// <see cref="BoltzClient"/> HttpClient. Self-contained — no other DI calls are
+    /// required to make <see cref="BoltzSwapProvider"/> resolvable.
     /// </summary>
     public static IServiceCollection AddBoltzProvider(this IServiceCollection services, Action<BoltzClientOptions>? configure = null)
     {
         if (configure != null)
             services.Configure(configure);
+
+        // BoltzSwapProvider depends on BoltzClient, which is a typed HttpClient. Registering it
+        // here makes the call site self-contained so consumers that wire DI directly (no
+        // ArkApplicationBuilder) don't get an opaque "Unable to resolve BoltzClient" error.
+        // AddHttpClient<T> is idempotent, so existing callers that already registered it
+        // separately (e.g. via EnableSwaps) keep working.
+        services.AddHttpClient<BoltzClient>();
 
         services.AddSingleton<IContractDiscoveryProvider, BoltzSwapDiscoveryProvider>();
 

--- a/NArk.Tests/SwapServiceRegistrationTests.cs
+++ b/NArk.Tests/SwapServiceRegistrationTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.DependencyInjection;
+using NArk.Core.Models.Options;
+using NArk.Hosting;
+using NArk.Swaps.Boltz.Client;
+
+namespace NArk.Tests;
+
+/// <summary>
+/// Pins the contract that the swap-services DI helpers are self-contained for what they own.
+/// A previous version of the SDK split <see cref="BoltzClient"/> registration out into the
+/// <c>ArkApplicationBuilder.EnableSwaps</c> helper, which silently broke direct-DI consumers
+/// with an opaque <c>Unable to resolve service for type 'BoltzClient'</c> when the swap
+/// provider was first resolved.
+/// </summary>
+[TestFixture]
+public class SwapServiceRegistrationTests
+{
+    /// <summary>
+    /// <see cref="SwapServiceCollectionExtensions.AddBoltzProvider"/> alone must be enough to
+    /// resolve <see cref="BoltzClient"/> — no manual <c>AddHttpClient&lt;BoltzClient&gt;</c>
+    /// call required from the consumer.
+    /// </summary>
+    [Test]
+    public void AddBoltzProvider_RegistersBoltzClient()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(new ArkNetworkConfig("https://example/ark", "", "https://boltz.example", ""));
+        services.AddBoltzProvider();
+
+        using var provider = services.BuildServiceProvider();
+
+        var client = provider.GetRequiredService<BoltzClient>();
+        Assert.That(client, Is.Not.Null);
+    }
+
+    /// <summary>
+    /// <see cref="SwapServiceCollectionExtensions.AddArkSwapServices"/> transitively registers
+    /// <see cref="BoltzClient"/> too (it calls <c>AddBoltzProvider</c> internally).
+    /// </summary>
+    [Test]
+    public void AddArkSwapServices_RegistersBoltzClient()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(new ArkNetworkConfig("https://example/ark", "", "https://boltz.example", ""));
+        services.AddArkSwapServices();
+
+        using var provider = services.BuildServiceProvider();
+
+        var client = provider.GetRequiredService<BoltzClient>();
+        Assert.That(client, Is.Not.Null);
+    }
+}


### PR DESCRIPTION
## Summary

- \`AddArkSwapServices\` / \`AddBoltzProvider\` no longer require the caller to manually register \`BoltzClient\` — the typed HttpClient is now registered inside \`AddBoltzProvider\` itself.
- Adds two regression tests pinning the invariant so the dependency can't drift back out again.

## Why

The XML doc on \`AddArkSwapServices\` describes it as *the backward-compatible entry point that registers everything needed*. In practice it isn't — \`BoltzSwapProvider\` depends on \`BoltzClient\`, and \`BoltzClient\` was only registered inside the higher-level \`ArkApplicationBuilder.EnableSwaps\` helper (\`services.AddHttpClient<BoltzClient>()\`).

Consumers that wire DI directly hit:

\`\`\`
System.InvalidOperationException: Unable to resolve service for type 'NArk.Swaps.Boltz.Client.BoltzClient' while attempting to activate 'NArk.Swaps.Boltz.BoltzSwapProvider'.
   at NArk.Hosting.SwapServiceCollectionExtensions.<>c.<AddBoltzProvider>b__1_0(IServiceProvider sp)
\`\`\`

(WalletWasabi's Arkade integration; reproduced in the new tests by calling \`AddBoltzProvider()\` on a bare \`ServiceCollection\` and resolving \`BoltzClient\`.)

## Approach

- Move \`services.AddHttpClient<BoltzClient>()\` into \`AddBoltzProvider\`. \`AddHttpClient<T>\` is idempotent, so the call site inside \`EnableSwaps\` stays as a no-op safety net for any external caller relying on the previous ordering.
- Pin the invariant with two tests under \`NArk.Tests/SwapServiceRegistrationTests.cs\`:
  - \`AddBoltzProvider_RegistersBoltzClient\` — direct call
  - \`AddArkSwapServices_RegistersBoltzClient\` — transitive call

## Test plan

- [x] \`dotnet test NArk.Tests\` — 382 pass (380 existing + 2 new)
- [x] Wired into WalletWasabi's \`ArkServiceCollectionExtensions\` (no \`AddHttpClient<BoltzClient>\` needed at the consumer site after this lands)