### PR TITLE
fix(assets): deterministic group ordering + ts-sdk cross-SDK fixture parity

### DIFF
--- a/NArk.Core/Assets/AssetPacketBuilder.cs
+++ b/NArk.Core/Assets/AssetPacketBuilder.cs
@@ -45,8 +45,15 @@ public static class AssetPacketBuilder
         var allAssetIds = new HashSet<string>(inputsByAsset.Keys);
         allAssetIds.UnionWith(outputsByAsset.Keys);
 
+        // Emit groups in a deterministic order. The AssetId string is the
+        // lowercase hex of its 34-byte serialization (txid ‖ groupIndex LE),
+        // so an ordinal sort yields the same (txid, groupIndex) ordering the
+        // rust-sdk applies. Without this the order followed HashSet
+        // enumeration and the same transfer could serialize to different
+        // OP_RETURN bytes across runs/SDKs, breaking reproducibility and
+        // cross-implementation fixture stability.
         var groups = new List<AssetGroup>();
-        foreach (var assetIdStr in allAssetIds)
+        foreach (var assetIdStr in allAssetIds.OrderBy(id => id, StringComparer.Ordinal))
         {
             var assetId = AssetId.FromString(assetIdStr);
             var groupInputs = inputsByAsset.GetValueOrDefault(assetIdStr)?

--- a/NArk.Tests/AssetPacketBuilderTests.cs
+++ b/NArk.Tests/AssetPacketBuilderTests.cs
@@ -94,6 +94,39 @@ public class AssetPacketBuilderTests
     }
 
     [Test]
+    public void Build_GroupOrder_IsDeterministic_RegardlessOfInputOrder()
+    {
+        // FakeAssetId ("a1b2…") sorts before FakeAssetId2 ("b2c3…") ordinally.
+        var forward = new (string, ushort, ulong)[]
+        {
+            (FakeAssetId, 0, 500),
+            (FakeAssetId2, 1, 300)
+        };
+        var reversed = new (string, ushort, ulong)[]
+        {
+            (FakeAssetId2, 1, 300),
+            (FakeAssetId, 0, 500)
+        };
+
+        var r1 = AssetPacketBuilder.Build(forward, null, changeVout: 0);
+        var r2 = AssetPacketBuilder.Build(reversed, null, changeVout: 0);
+
+        Assert.That(r1, Is.Not.Null);
+        Assert.That(r2, Is.Not.Null);
+
+        // Same logical transfer must serialize to identical OP_RETURN bytes
+        // irrespective of the order inputs were supplied in.
+        Assert.That(r2!.ScriptPubKey.ToHex(), Is.EqualTo(r1!.ScriptPubKey.ToHex()),
+            "Asset packet must be order-independent (deterministic group ordering)");
+
+        // And groups must be in ascending ordinal AssetId order.
+        var packet = Packet.FromScript(r1.ScriptPubKey);
+        Assert.That(packet.Groups, Has.Count.EqualTo(2));
+        Assert.That(packet.Groups[0].AssetId!.ToString(), Is.EqualTo(FakeAssetId));
+        Assert.That(packet.Groups[1].AssetId!.ToString(), Is.EqualTo(FakeAssetId2));
+    }
+
+    [Test]
     public void Build_NoUnderflow_WhenOutputsExceedInputs()
     {
         // Asset only in outputs (no inputs) — should not underflow

--- a/NArk.Tests/Assets/FixtureTests.cs
+++ b/NArk.Tests/Assets/FixtureTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Text.Json;
 using NArk.Core.Assets;
 
@@ -191,6 +192,178 @@ public class FixtureTests
             var leafPacket = packet.LeafTxPacket(Convert.FromHexString(intentTxid));
             var leafSerialized = ToHex(leafPacket.SerializePacketData());
             Assert.That(leafSerialized, Is.EqualTo(expectedLeafHex), $"LeafTxPacket fixture '{name}' mismatch");
+        }
+    }
+
+    #endregion
+
+    #region AssetRef Fixtures (cross-SDK, ts-sdk asset_ref_fixtures.json)
+
+    [Test]
+    public void AssetRef_ValidFromId_MatchSerialization()
+    {
+        var fixture = LoadFixture("asset_ref_fixtures.json");
+        foreach (var tc in fixture.GetProperty("valid").GetProperty("newAssetRefFromId").EnumerateArray())
+        {
+            var name = tc.GetProperty("name").GetString()!;
+            var txid = tc.GetProperty("txid").GetString()!;
+            var index = unchecked((ushort)tc.GetProperty("index").GetInt64());
+            var expected = tc.GetProperty("serializedHex").GetString()!;
+            var refById = AssetRef.FromId(AssetId.Create(txid, index));
+            Assert.That(refById.ToString(), Is.EqualTo(expected), $"AssetRef FromId '{name}' mismatch");
+        }
+    }
+
+    [Test]
+    public void AssetRef_ValidFromGroup_MatchSerialization()
+    {
+        var fixture = LoadFixture("asset_ref_fixtures.json");
+        foreach (var tc in fixture.GetProperty("valid").GetProperty("newAssetRefFromGroup").EnumerateArray())
+        {
+            var name = tc.GetProperty("name").GetString()!;
+            // Fixtures intentionally include overflow (65536→0) / underflow
+            // (-1→65535); an unchecked ushort cast reproduces the wrap the
+            // vectors expect.
+            var index = unchecked((ushort)tc.GetProperty("index").GetInt64());
+            var expected = tc.GetProperty("serializedHex").GetString()!;
+            Assert.That(AssetRef.FromGroupIndex(index).ToString(), Is.EqualTo(expected),
+                $"AssetRef FromGroup '{name}' mismatch");
+        }
+    }
+
+    [Test]
+    public void AssetRef_InvalidFromString_AreRejected()
+    {
+        var fixture = LoadFixture("asset_ref_fixtures.json");
+        foreach (var tc in fixture.GetProperty("invalid").GetProperty("newAssetRefFromString").EnumerateArray())
+        {
+            var name = tc.GetProperty("name").GetString()!;
+            var hex = tc.GetProperty("serializedHex").GetString()!;
+            // The contract is "this vector is rejected" — assert the parse
+            // pipeline throws (FormatException for non-hex, or AssetRef's
+            // own validation). We don't pin exact messages: those are
+            // implementation detail and differ across SDKs.
+            Assert.That(() => AssetRef.FromBytes(Convert.FromHexString(hex)),
+                Throws.Exception, $"AssetRef invalid '{name}' should be rejected");
+        }
+    }
+
+    #endregion
+
+    #region AssetInput Fixtures (cross-SDK, ts-sdk asset_input_fixtures.json)
+
+    [Test]
+    public void AssetInput_ValidNewInput_MatchSerialization()
+    {
+        var fixture = LoadFixture("asset_input_fixtures.json");
+        foreach (var tc in fixture.GetProperty("valid").GetProperty("newInput").EnumerateArray())
+        {
+            var name = tc.GetProperty("name").GetString()!;
+            var type = tc.GetProperty("type").GetString()!;
+            var vin = (ushort)tc.GetProperty("vin").GetInt64();
+            var amount = (ulong)tc.GetProperty("amount").GetInt64();
+            var expected = tc.GetProperty("serializedHex").GetString()!;
+            var input = type == "intent"
+                ? AssetInput.CreateIntent(tc.GetProperty("txid").GetString()!, vin, amount)
+                : AssetInput.Create(vin, amount);
+            Assert.That(input.ToString(), Is.EqualTo(expected), $"AssetInput '{name}' mismatch");
+        }
+    }
+
+    [Test]
+    public void AssetInput_InvalidFromString_AreRejected()
+    {
+        var fixture = LoadFixture("asset_input_fixtures.json");
+        foreach (var tc in fixture.GetProperty("invalid").GetProperty("newInputFromString").EnumerateArray())
+        {
+            var name = tc.GetProperty("name").GetString()!;
+            var hex = tc.GetProperty("serializedHex").GetString()!;
+            Assert.That(() => AssetInput.FromReader(new BufferReader(Convert.FromHexString(hex))),
+                Throws.Exception, $"AssetInput invalid '{name}' should be rejected");
+        }
+    }
+
+    #endregion
+
+    #region AssetOutput Fixtures (cross-SDK, ts-sdk asset_output_fixtures.json)
+
+    [Test]
+    public void AssetOutput_ValidNewOutput_MatchSerialization()
+    {
+        var fixture = LoadFixture("asset_output_fixtures.json");
+        foreach (var tc in fixture.GetProperty("valid").GetProperty("newOutput").EnumerateArray())
+        {
+            var name = tc.GetProperty("name").GetString()!;
+            var vout = (ushort)tc.GetProperty("vout").GetInt64();
+            var amount = (ulong)tc.GetProperty("amount").GetInt64();
+            var expected = tc.GetProperty("serializedHex").GetString()!;
+            Assert.That(AssetOutput.Create(vout, amount).ToString(), Is.EqualTo(expected),
+                $"AssetOutput '{name}' mismatch");
+        }
+    }
+
+    [Test]
+    public void AssetOutput_InvalidFromString_AreRejected()
+    {
+        var fixture = LoadFixture("asset_output_fixtures.json");
+        foreach (var tc in fixture.GetProperty("invalid").GetProperty("newOutputFromString").EnumerateArray())
+        {
+            var name = tc.GetProperty("name").GetString()!;
+            var hex = tc.GetProperty("serializedHex").GetString()!;
+            Assert.That(() => AssetOutput.FromReader(new BufferReader(Convert.FromHexString(hex))),
+                Throws.Exception, $"AssetOutput invalid '{name}' should be rejected");
+        }
+    }
+
+    #endregion
+
+    #region Metadata Fixtures (cross-SDK, ts-sdk metadata_fixtures.json)
+
+    [Test]
+    public void Metadata_ValidNewMetadata_MatchSerialization()
+    {
+        var fixture = LoadFixture("metadata_fixtures.json");
+        foreach (var tc in fixture.GetProperty("valid").GetProperty("newMetadata").EnumerateArray())
+        {
+            var name = tc.GetProperty("name").GetString()!;
+            var key = tc.GetProperty("key").GetString()!;
+            var value = tc.GetProperty("value").GetString()!;
+            var expected = tc.GetProperty("serializedHex").GetString()!;
+            Assert.That(AssetMetadata.Create(key, value).ToString(), Is.EqualTo(expected),
+                $"Metadata '{name}' mismatch");
+        }
+    }
+
+    [Test]
+    public void Metadata_HashVectors_MatchCrossSdk()
+    {
+        var fixture = LoadFixture("metadata_fixtures.json");
+        foreach (var tc in fixture.GetProperty("valid").GetProperty("hash").EnumerateArray())
+        {
+            var name = tc.GetProperty("name").GetString()!;
+            var items = tc.GetProperty("metadata").EnumerateArray()
+                .Select(m => AssetMetadata.Create(
+                    m.GetProperty("key").GetString()!, m.GetProperty("value").GetString()!))
+                .ToList();
+            var expected = tc.GetProperty("expectedHash").GetString()!;
+            // The Merkle hash is the strongest cross-SDK conformance check:
+            // any spec-compliant SDK must produce identical roots.
+            Assert.That(ToHex(new MetadataList(items).Hash()), Is.EqualTo(expected),
+                $"MetadataList hash '{name}' mismatch");
+        }
+    }
+
+    [Test]
+    public void Metadata_InvalidNewMetadata_AreRejected()
+    {
+        var fixture = LoadFixture("metadata_fixtures.json");
+        foreach (var tc in fixture.GetProperty("invalid").GetProperty("newMetadata").EnumerateArray())
+        {
+            var name = tc.GetProperty("name").GetString()!;
+            var key = tc.TryGetProperty("key", out var k) ? k.GetString() ?? "" : "";
+            var value = tc.TryGetProperty("value", out var v) ? v.GetString() ?? "" : "";
+            Assert.That(() => AssetMetadata.Create(key, value),
+                Throws.Exception, $"Metadata invalid '{name}' should be rejected");
         }
     }
 

--- a/NArk.Tests/Assets/Fixtures/asset_input_fixtures.json
+++ b/NArk.Tests/Assets/Fixtures/asset_input_fixtures.json
@@ -1,0 +1,183 @@
+{
+    "valid": {
+        "newInput": [
+            {
+                "name": "local",
+                "type": "local",
+                "vin": 5,
+                "amount": 10,
+                "serializedHex": "0105000a"
+            },
+            {
+                "name": "intent",
+                "type": "intent",
+                "amount": 500,
+                "txid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "vin": 77,
+                "serializedHex": "02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa4d00f403"
+            }
+        ],
+        "newInputs": [
+            {
+                "name": "single local input",
+                "inputs": [
+                    {
+                        "type": "local",
+                        "vin": 5,
+                        "amount": 10
+                    }
+                ],
+                "serializedHex": "010105000a"
+            },
+            {
+                "name": "many local inputs",
+                "inputs": [
+                    {
+                        "type": "local",
+                        "vin": 1,
+                        "amount": 10
+                    },
+                    {
+                        "type": "local",
+                        "vin": 0,
+                        "amount": 2100000000
+                    },
+                    {
+                        "type": "local",
+                        "vin": 25,
+                        "amount": 8400000000000
+                    }
+                ],
+                "serializedHex": "030101000a01000080eaade90701190080c090b8bcf401"
+            },
+            {
+                "name": "single intent input",
+                "inputs": [
+                    {
+                        "type": "intent",
+                        "amount": 500,
+                        "txid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "vin": 77
+                    }
+                ],
+                "serializedHex": "0102aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa4d00f403"
+            },
+            {
+                "name": "many intent input",
+                "inputs": [
+                    {
+                        "type": "intent",
+                        "amount": 500,
+                        "txid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "vin": 77
+                    },
+                    {
+                        "type": "intent",
+                        "amount": 100000000000,
+                        "txid": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                        "vin": 1
+                    }
+                ],
+                "serializedHex": "0202aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa4d00f40302bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb010080d0dbc3f402"
+            }
+        ]
+    },
+    "invalid": {
+        "newInput": [
+            {
+                "name": "missing txid",
+                "type": "intent",
+                "amount": 500,
+                "txid": "",
+                "vin": 10,
+                "expectedError": "missing input intent txid"
+            },
+            {
+                "name": "empty txid (zero)",
+                "type": "intent",
+                "amount": 500,
+                "txid": "0000000000000000000000000000000000000000000000000000000000000000",
+                "vin": 10,
+                "expectedError": "missing input intent txid"
+            },
+            {
+                "name": "invalid txid format",
+                "type": "intent",
+                "amount": 500,
+                "txid": "z000000000000000000000000000000000000000000000000000000000000000",
+                "vin": 10,
+                "expectedError": "invalid input intent txid format"
+            },
+            {
+                "name": "txid too short",
+                "type": "intent",
+                "amount": 500,
+                "txid": "aaaa",
+                "vin": 10,
+                "expectedError": "invalid input intent txid length"
+            }
+        ],
+        "newInputFromString": [
+            {
+                "name": "empty",
+                "serializedHex": "",
+                "expectedError": "missing asset input"
+            },
+            {
+                "name": "invalid format",
+                "serializedHex": "invalid",
+                "expectedError": "invalid asset input format"
+            },
+            {
+                "name": "unspecified type",
+                "serializedHex": "0005000a",
+                "expectedError": "asset input type unspecified"
+            },
+            {
+                "name": "unknown type",
+                "serializedHex": "0305000a",
+                "expectedError": "asset input type unknown"
+            },
+            {
+                "name": "invalid txid length",
+                "serializedHex": "0205000a",
+                "expectedError": "invalid asset input txid length"
+            }
+        ],
+        "newInputs": [
+            {
+                "name": "mixed input types",
+                "inputs": [
+                    {
+                        "type": "local",
+                        "vin": 1,
+                        "amount": 10
+                    },
+                    {
+                        "type": "intent",
+                        "amount": 500,
+                        "txid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                        "vin": 77
+                    }
+                ],
+                "expectedError": "asset inputs must be of the same type"
+            },
+            {
+                "name": "duplicated inputs",
+                "inputs": [
+                    {
+                        "type": "local",
+                        "vin": 1,
+                        "amount": 10
+                    },
+                    {
+                        "type": "local",
+                        "vin": 1,
+                        "amount": 200
+                    }
+                ],
+                "expectedError": "duplicated inputs vin"
+            }
+        ]
+    }
+}

--- a/NArk.Tests/Assets/Fixtures/asset_output_fixtures.json
+++ b/NArk.Tests/Assets/Fixtures/asset_output_fixtures.json
@@ -1,0 +1,100 @@
+{
+    "valid": {
+        "newOutput": [
+            {
+                "name": "random",
+                "vout": 5,
+                "amount": 10,
+                "serializedHex": "0105000a"
+            }
+        ],
+        "newOutputs": [
+            {
+                "name": "single output",
+                "outputs": [
+                    {
+                        "vout": 5,
+                        "amount": 10
+                    }
+                ],
+                "serializedHex": "010105000a"
+            },
+            {
+                "name": "many outputs",
+                "outputs": [
+                    {
+                        "vout": 1,
+                        "amount": 10
+                    },
+                    {
+                        "vout": 0,
+                        "amount": 2100000000
+                    },
+                    {
+                        "vout": 25,
+                        "amount": 8400000000000
+                    }
+                ],
+                "serializedHex": "030101000a01000080eaade90701190080c090b8bcf401"
+            }
+        ]
+    },
+    "invalid": {
+        "newOutput": [
+            {
+                "name": "zero amount",
+                "vout": 0,
+                "amount": 0,
+                "expectedError": "asset output amount must be greater than 0"
+            }
+        ],
+        "newOutputFromString": [
+            {
+                "name": "empty",
+                "serializedHex": "",
+                "expectedError": "missing asset output"
+            },
+            {
+                "name": "invalid format",
+                "serializedHex": "invalid",
+                "expectedError": "invalid asset output format"
+            },
+            {
+                "name": "zero amount",
+                "serializedHex": "01050000",
+                "expectedError": "asset output amount must be greater than 0"
+            },
+            {
+                "name": "unspecified output type",
+                "serializedHex": "00050000",
+                "expectedError": "output type unspecified"
+            },
+            {
+                "name": "invalid output type",
+                "serializedHex": "03050000",
+                "expectedError": "unknown"
+            },
+            {
+                "name": "invalid vout length",
+                "serializedHex": "0105",
+                "expectedError": "invalid asset output vout length"
+            }
+        ],
+        "newOutputs": [
+            {
+                "name": "duplicated outputs",
+                "outputs": [
+                    {
+                        "vout": 5,
+                        "amount": 10
+                    },
+                    {
+                        "vout": 5,
+                        "amount": 70
+                    }
+                ],
+                "expectedError": "duplicated output vout"
+            }
+        ]
+    }
+}

--- a/NArk.Tests/Assets/Fixtures/asset_ref_fixtures.json
+++ b/NArk.Tests/Assets/Fixtures/asset_ref_fixtures.json
@@ -1,0 +1,68 @@
+{
+    "valid": {
+        "newAssetRefFromId": [
+            {
+                "name": "random",
+                "txid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "index": 42,
+                "serializedHex": "01aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2a00"
+            }
+        ],
+        "newAssetRefFromGroup": [
+            {
+                "name": "zero index",
+                "index": 0,
+                "serializedHex": "020000"
+            },
+            {
+                "name": "random index",
+                "index": 5,
+                "serializedHex": "020500"
+            },
+            {
+                "name": "max index",
+                "index": 65535,
+                "serializedHex": "02ffff"
+            },
+            {
+                "name": "index overflow",
+                "index": 65536,
+                "serializedHex": "020000"
+            },
+            {
+                "name": "index underflow",
+                "index": -1,
+                "serializedHex": "02ffff"
+            }
+        ]
+    },
+    "invalid": {
+        "newAssetRefFromString": [
+            {
+                "name": "empty ref",
+                "serializedHex": "",
+                "expectedError": "missing asset ref"
+            },
+            {
+                "name": "invalid ref",
+                "serializedHex": "invalid",
+                "expectedError": "invalid asset ref format"
+            },
+            {
+                "name": "invalid ref length",
+                "serializedHex": "0200",
+                "expectedError": "invalid asset ref length"
+            },
+            {
+                "name": "unspecified ref type",
+                "serializedHex": "000005",
+                "expectedError": "asset ref type unspecified"
+            },
+            {
+                "name": "unknown ref type",
+                "serializedHex": "030005",
+                "expectedError": "asset ref type unknown"
+            }
+        ]
+    }
+}

--- a/NArk.Tests/Assets/Fixtures/metadata_fixtures.json
+++ b/NArk.Tests/Assets/Fixtures/metadata_fixtures.json
@@ -1,0 +1,220 @@
+{
+    "valid": {
+        "newMetadata": [
+            {
+                "name": "simple",
+                "key": "testKey",
+                "value": "testValue",
+                "serializedHex": "07746573744b6579097465737456616c7565"
+            },
+            {
+                "name": "nested json",
+                "key": "{\"key\": \"key\"}",
+                "value": "{\"value\": \"value\"}",
+                "serializedHex": "0e7b226b6579223a20226b6579227d127b2276616c7565223a202276616c7565227d"
+            },
+            {
+                "name": "another alphabet",
+                "key": "钥匙",
+                "value": "价值",
+                "serializedHex": "06e992a5e58c9906e4bbb7e580bc"
+            },
+            {
+                "name": "emoji",
+                "key": "🔑",
+                "value": "👾",
+                "serializedHex": "04f09f949104f09f91be"
+            },
+            {
+                "name": "long key value",
+                "key": "lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+                "value": "lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+                "serializedHex": "786c6f72656d20697073756d20646f6c6f722073697420616d657420636f6e73656374657475722061646970697363696e6720656c69742073656420646f20656975736d6f642074656d706f7220696e6369646964756e74207574206c61626f726520657420646f6c6f7265206d61676e6120616c69717561786c6f72656d20697073756d20646f6c6f722073697420616d657420636f6e73656374657475722061646970697363696e6720656c69742073656420646f20656975736d6f642074656d706f7220696e6369646964756e74207574206c61626f726520657420646f6c6f7265206d61676e6120616c69717561"
+            },
+            {
+                "name": "short key value",
+                "key": "0",
+                "value": "1",
+                "serializedHex": "01300131"
+            }
+        ],
+        "newMetadataList": [
+            {
+                "name": "asset data (with icon url)",
+                "metadata": [
+                    {
+                        "key": "name",
+                        "value": "testAsset"
+                    },
+                    {
+                        "key": "ticker",
+                        "value": "TST"
+                    },
+                    {
+                        "key": "decimals",
+                        "value": "0"
+                    },
+                    {
+                        "key": "icon",
+                        "value": "https://example.com/icon.png"
+                    }
+                ],
+                "serializedHex": "04046e616d6509746573744173736574067469636b65720354535408646563696d616c7301300469636f6e1c68747470733a2f2f6578616d706c652e636f6d2f69636f6e2e706e67"
+            },
+            {
+                "name": "asset data (with icon embedded)",
+                "metadata": [
+                    {
+                        "key": "name",
+                        "value": "testAsset"
+                    },
+                    {
+                        "key": "ticker",
+                        "value": "TST"
+                    },
+                    {
+                        "key": "decimals",
+                        "value": "0"
+                    },
+                    {
+                        "key": "icon",
+                        "value": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA"
+                    }
+                ],
+                "serializedHex": "04046e616d6509746573744173736574067469636b65720354535408646563696d616c7301300469636f6e32646174613a696d6167652f706e673b6261736536342c6956424f5277304b47676f414141414e535568455567414141415541"
+            },
+            {
+                "name": "random data",
+                "metadata": [
+                    {
+                        "key": "testKey",
+                        "value": "testValue"
+                    },
+                    {
+                        "key": "{\"key\": \"key\"}",
+                        "value": "{\"value\": \"value\"}"
+                    },
+                    {
+                        "key": "钥匙",
+                        "value": "价值"
+                    }
+                ],
+                "serializedHex": "0307746573744b6579097465737456616c75650e7b226b6579223a20226b6579227d127b2276616c7565223a202276616c7565227d06e992a5e58c9906e4bbb7e580bc"
+            }
+        ],
+        "hash": [
+            {
+                "name": "asset data (with icon url)",
+                "metadata": [
+                    {
+                        "key": "name",
+                        "value": "testAsset"
+                    },
+                    {
+                        "key": "ticker",
+                        "value": "TST"
+                    },
+                    {
+                        "key": "decimals",
+                        "value": "0"
+                    },
+                    {
+                        "key": "icon",
+                        "value": "https://example.com/icon.png"
+                    }
+                ],
+                "expectedHash": "3a95a202409e237d575c8425685daa3a5880cd16e3c069b0df5c6228a234ce7b"
+            },
+            {
+                "name": "asset data (with icon embedded)",
+                "metadata": [
+                    {
+                        "key": "name",
+                        "value": "testAsset"
+                    },
+                    {
+                        "key": "ticker",
+                        "value": "TST"
+                    },
+                    {
+                        "key": "decimals",
+                        "value": "0"
+                    },
+                    {
+                        "key": "icon",
+                        "value": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA"
+                    }
+                ],
+                "expectedHash": "99d136d0240c44d5915bfcc45c63e6030f9d02910956932bcfe7bca63fb582f4"
+            },
+            {
+                "name": "random data",
+                "metadata": [
+                    {
+                        "key": "testKey",
+                        "value": "testValue"
+                    },
+                    {
+                        "key": "{\"key\": \"key\"}",
+                        "value": "{\"value\": \"value\"}"
+                    },
+                    {
+                        "key": "钥匙",
+                        "value": "价值"
+                    }
+                ],
+                "expectedHash": "405828ca96e62f281e1e861e08f92813ac445d5ca2092877078dba25c8654596"
+            }
+        ]
+    },
+    "invalid": {
+        "newMetadata": [
+            {
+                "name": "empty key",
+                "key": "",
+                "value": "value",
+                "expectedError": "missing metadata key"
+            },
+            {
+                "name": "empty value",
+                "key": "key",
+                "value": "",
+                "expectedError": "missing metadata value"
+            }
+        ],
+        "newMetadataFromString": [
+            {
+                "name": "empty",
+                "serializedHex": "",
+                "expectedError": "missing metadata"
+            },
+            {
+                "name": "invalid format",
+                "serializedHex": "invalid",
+                "expectedError": "invalid metadata format"
+            },
+            {
+                "name": "invalid length",
+                "serializedHex": "013101",
+                "expectedError": "invalid metadata length"
+            }
+        ],
+        "newMetadataListFromString": [
+            {
+                "name": "empty",
+                "serializedHex": "",
+                "expectedError": "missing metadata list"
+            },
+            {
+                "name": "invalid format",
+                "serializedHex": "invalid",
+                "expectedError": "invalid metadata list format"
+            },
+            {
+                "name": "invalid length",
+                "serializedHex": "01013101",
+                "expectedError": "invalid metadata length"
+            }
+        ]
+    }
+}

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ var txId = await spendingService.Spend(
 
 The SDK supports issuing, transferring, and burning assets on Arkade. Assets are encoded as `AssetGroup` entries inside an OP_RETURN output (an "asset packet") attached to each Arkade transaction. The asset ID is derived from `{txid, groupIndex}` after submission.
 
+Asset packets are **deterministic**: `AssetPacketBuilder` emits groups in a stable order (by asset id, then group index) regardless of input order, so the same logical transaction always serializes to identical bytes. This matches the ordering used by the other Arkade SDKs (ts-sdk / rust-sdk) and makes packets reproducible and cross-SDK fixture-comparable.
+
 ### Issuance
 
 Use `IAssetManager` to create new assets:


### PR DESCRIPTION
## Asset parity audit (go-sdk / ts-sdk / rust-sdk → NNark)

Format/ops parity verified: NNark already passes ts-sdk shared vectors
(131/131); meets/exceeds canonical ts-sdk (NNark has REST+gRPC GetAsset,
BIP-341 taptree, hex metadata decode, 7 asset e2e tests vs ts-sdk's 0).

### GAP B — deterministic group ordering
`AssetPacketBuilder.Build` emitted groups in `HashSet` enumeration order;
the same transfer could serialize to different OP_RETURN bytes per run.
Now sorted by AssetId (ordinal hex = txid‖groupIndex byte order), matching
rust-sdk's `(txid, groupIndex)` ordering. + order-independence unit test.

### GAP C — import ts-sdk cross-SDK fixture vectors
Added the 4 conformance fixture files NNark's dir lacked (`asset_ref`,
`asset_input`, `asset_output`, `metadata`; fetched verbatim from
`arkade-os/ts-sdk@master`) + fixture-driven tests, including the
`MetadataList` Merkle-hash vectors (strongest cross-SDK check).

### GAP A — intentionally not implemented
rust-sdk's `ControlAssetConfig::New` (same-tx new control asset) is a
rust-only convenience; ts-sdk's `AssetManager.issue()` is also id-only.
NNark already matches the cross-SDK contract.

Full NNark unit suite: **393/393 green**.