### PR TITLE
fix(sync): quiet routine VtxoSynchronizationService poll logs

### DIFF
--- a/NArk.Core/Services/VtxoSynchronizationService.cs
+++ b/NArk.Core/Services/VtxoSynchronizationService.cs
@@ -446,7 +446,11 @@ public class VtxoSynchronizationService : IAsyncDisposable
             var started = DateTimeOffset.UtcNow;
             try
             {
-                _logger?.LogInformation(
+                // Pre-poll line is just "we're about to call arkd" — same
+                // info is in the result line below, so keep it at Debug to
+                // avoid doubling the per-tick spam on the 5-second safety
+                // net.
+                _logger?.LogDebug(
                     "StartQueryLogic: polling {Count} script(s) (after={After}): [{Scripts}]",
                     request.Scripts.Count,
                     request.After?.ToString("O") ?? "<none>",
@@ -458,9 +462,23 @@ public class VtxoSynchronizationService : IAsyncDisposable
                     found++;
                     await _vtxoStorage.UpsertVtxo(vtxo, cancellationToken);
                 }
-                _logger?.LogInformation(
-                    "StartQueryLogic: poll returned {Found} VTXO(s) across {Count} script(s) in {Elapsed}ms",
-                    found, request.Scripts.Count, (int)(DateTimeOffset.UtcNow - started).TotalMilliseconds);
+                // The productive case (found > 0 = a VTXO landed) is what
+                // operators want to see at Info. The cold-start catch-up
+                // also stays at Info even on 0 — it's a one-off first-tick
+                // signal worth seeing. Routine 5-second ticks that find
+                // nothing drop to Debug so they don't drown the log.
+                if (found > 0 || request.IsColdStartCatchup)
+                {
+                    _logger?.LogInformation(
+                        "StartQueryLogic: poll returned {Found} VTXO(s) across {Count} script(s) in {Elapsed}ms",
+                        found, request.Scripts.Count, (int)(DateTimeOffset.UtcNow - started).TotalMilliseconds);
+                }
+                else
+                {
+                    _logger?.LogDebug(
+                        "StartQueryLogic: poll returned 0 VTXO(s) across {Count} script(s) in {Elapsed}ms",
+                        request.Scripts.Count, (int)(DateTimeOffset.UtcNow - started).TotalMilliseconds);
+                }
 
                 // Mark the cold-start catch-up as complete on its first
                 // successful poll. Until this flips, routine polls below


### PR DESCRIPTION
## Quiet routine VtxoSynchronizationService poll logs

The 5-second safety-net poll in `VtxoSynchronizationService.RoutinePoll` is deliberate and cheap — it bounds the arkd-indexer detection gap that motivated the v2.1.13 fix, and each tick is one short gRPC call (≈ 2-3 ms with `after=now-2min` on a small script set). The work is fine.

The **log volume** isn't. Every tick fires two `LogInformation` lines in `StartQueryLogic`:

```
info: ... StartQueryLogic: polling 2 script(s) (after=...): [...]
info: ... StartQueryLogic: poll returned 0 VTXO(s) across 2 script(s) in 3ms
```

On an idle wallet that's 24 INFO lines/minute of pure noise, drowning anything else at the default log level. Surfaced in BTCPay-plugin operator review.

### Change
- **Pre-poll "polling …" line → Debug always.** Same info is in the result line below; the upcoming arkd call isn't a productive signal on its own.
- **Post-poll result line → conditional:** `Info` only when the poll produced a VTXO (the *productive* case — a payment landed) **or** when this is the first cold-start catch-up (one-off, worth seeing). Routine ticks that find 0 drop to `Debug`.

### Non-changes
- Same gRPC call schedule and cadence (`RoutinePollInterval = 5s`, `RoutinePollLookback = 2min`).
- Same upsert path, same cursor advance, same cold-start gating.
- Operators who want the chatter back set their log level to `Debug`.

No public-API surface touched — pure logging-verbosity tune.

### Test plan
- [x] `dotnet build NArk.Core/NArk.Core.csproj` clean (0 errors).
- [ ] CI: build + unit tests + E2E.
