### PR TITLE
feat(hosting): ArkNetworkConfig defaults for Esplora + Electrum (WS / TCP)

### DIFF
--- a/NArk.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/NArk.Core/Hosting/ServiceCollectionExtensions.cs
@@ -40,28 +40,54 @@ public record ArkNetworkConfig(
     string? BoltzUri = null,
 
     [property: JsonPropertyName("explorer")]
-    string? ExplorerUri = null)
+    string? ExplorerUri = null,
+
+    /// <summary>
+    /// Default Esplora REST API endpoint for this network. Used by
+    /// <see cref="NArk.Core.Blockchain.EsploraBlockchain"/> when an app
+    /// needs an <see cref="NArk.Abstractions.Blockchain.IBitcoinBlockchain"/>
+    /// without running its own NBXplorer / bitcoind. Values mirror the
+    /// per-network defaults shipped by the canonical Arkade ts-sdk.
+    /// </summary>
+    [property: JsonPropertyName("esplora")]
+    string? EsploraUri = null,
+
+    /// <summary>
+    /// Default Electrum websocket endpoint for this network (mirrors the
+    /// ts-sdk's <c>WS_DEFAULT_URLS</c>). Optional — only consumed by clients
+    /// that want a websocket-driven Electrum chain source.
+    /// </summary>
+    [property: JsonPropertyName("electrum-ws")]
+    string? ElectrumWsUri = null)
 {
     /// <summary>Mainnet configuration.</summary>
     public static readonly ArkNetworkConfig Mainnet = new(
         ArkUri: "https://arkade.computer",
         ArkadeWalletUri: "https://arkade.money",
         BoltzUri: "https://api.boltz.exchange/",
-        ExplorerUri: "https://arkade.space");
+        ExplorerUri: "https://arkade.space",
+        EsploraUri: "https://mempool.arkade.sh/api",
+        ElectrumWsUri: "wss://electrum.arkade.sh");
 
     /// <summary>Mutinynet (signet) configuration.</summary>
     public static readonly ArkNetworkConfig Mutinynet = new(
         ArkUri: "https://mutinynet.arkade.sh",
         ArkadeWalletUri: "https://mutinynet.arkade.money",
         BoltzUri: "https://api.boltz.mutinynet.arkade.sh/",
-        ExplorerUri: "https://explorer.mutinynet.arkade.sh");
+        ExplorerUri: "https://explorer.mutinynet.arkade.sh",
+        EsploraUri: "https://mempool.mutinynet.arkade.sh/api",
+        ElectrumWsUri: "wss://electrum.mutinynet.arkade.sh");
 
     /// <summary>Local regtest configuration.</summary>
     public static readonly ArkNetworkConfig Regtest = new(
         ArkUri: "http://localhost:7070",
         ArkadeWalletUri: "http://localhost:3002",
         BoltzUri: "http://localhost:9069/",
-        ExplorerUri: "http://localhost:7080");
+        ExplorerUri: "http://localhost:7080",
+        // ts-sdk regtest Esplora default: a local mempool/Chopsticks deployment.
+        // No Electrum WS default for regtest — ts-sdk assumes a locally-run
+        // electrum-ws websocat bridge whose URL is environment-specific.
+        EsploraUri: "http://localhost:3000");
 
 }
 

--- a/NArk.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/NArk.Core/Hosting/ServiceCollectionExtensions.cs
@@ -62,14 +62,29 @@ public record ArkNetworkConfig(
 
     /// <summary>
     /// Default Electrum endpoint hostname for raw-TCP consumers (mirrors
-    /// the ts-sdk's <c>ELECTRUM_TCP_HOST</c>; hostname only, no port — the
-    /// consumer picks the port: 50001 plain TCP, 50002 TCP+TLS, 50004 WSS
-    /// on the public Ark Labs Fulcrum instances). Optional and informational
+    /// the ts-sdk's <c>ELECTRUM_TCP_HOST</c>; hostname only, no port).
+    /// On the public Ark Labs Fulcrum instances (Mainnet / Mutinynet) the
+    /// caller picks the port: 50001 plain TCP, 50002 TCP+TLS, 50004 WSS —
+    /// so <see cref="ElectrumTcpPort"/> is intentionally null there.
+    /// For Regtest the port is non-standard (nigiri's <c>electrs</c> only
+    /// exposes 50000), so it's set explicitly. Optional and informational
     /// — no built-in NArk service consumes it; .NET clients that speak
     /// Electrum-over-TCP directly can pull it off the preset.
     /// </summary>
     [property: JsonPropertyName("electrum-tcp")]
-    string? ElectrumTcpHost = null)
+    string? ElectrumTcpHost = null,
+
+    /// <summary>
+    /// Default Electrum TCP port for this network. Null when the network
+    /// follows the public Fulcrum convention (caller picks 50001 / 50002 /
+    /// 50004 based on TLS preference). Set explicitly when the network
+    /// uses a non-standard port that the caller couldn't reasonably guess
+    /// — e.g. Regtest uses 50000 (nigiri's <c>electrs</c> binary-protocol
+    /// port; 30000 on the same host is electrs's HTTP REST, a different
+    /// protocol).
+    /// </summary>
+    [property: JsonPropertyName("electrum-tcp-port")]
+    int? ElectrumTcpPort = null)
 {
     /// <summary>Mainnet configuration.</summary>
     public static readonly ArkNetworkConfig Mainnet = new(
@@ -101,7 +116,11 @@ public record ArkNetworkConfig(
         EsploraUri: "http://localhost:3000",
         // Regtest WS bridge convention: electrum-ws on port 50003 (ts-sdk).
         ElectrumWsUri: "ws://localhost:50003",
-        ElectrumTcpHost: "localhost");
+        // nigiri's electrs binary-protocol port (verified against
+        // nigiri/cmd/nigiri/resources/docker-compose.yml). 30000 on the
+        // same container is electrs's HTTP REST — different protocol.
+        ElectrumTcpHost: "localhost",
+        ElectrumTcpPort: 50000);
 
 }
 

--- a/NArk.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/NArk.Core/Hosting/ServiceCollectionExtensions.cs
@@ -62,26 +62,23 @@ public record ArkNetworkConfig(
 
     /// <summary>
     /// Default Electrum endpoint hostname for raw-TCP consumers (mirrors
-    /// the ts-sdk's <c>ELECTRUM_TCP_HOST</c>; hostname only, no port).
-    /// On the public Ark Labs Fulcrum instances (Mainnet / Mutinynet) the
-    /// caller picks the port: 50001 plain TCP, 50002 TCP+TLS, 50004 WSS —
-    /// so <see cref="ElectrumTcpPort"/> is intentionally null there.
-    /// For Regtest the port is non-standard (nigiri's <c>electrs</c> only
-    /// exposes 50000), so it's set explicitly. Optional and informational
-    /// — no built-in NArk service consumes it; .NET clients that speak
+    /// the ts-sdk's <c>ELECTRUM_TCP_HOST</c>). Pair with
+    /// <see cref="ElectrumTcpPort"/>. Optional and informational — no
+    /// built-in NArk service consumes it; .NET clients that speak
     /// Electrum-over-TCP directly can pull it off the preset.
     /// </summary>
     [property: JsonPropertyName("electrum-tcp")]
     string? ElectrumTcpHost = null,
 
     /// <summary>
-    /// Default Electrum TCP port for this network. Null when the network
-    /// follows the public Fulcrum convention (caller picks 50001 / 50002 /
-    /// 50004 based on TLS preference). Set explicitly when the network
-    /// uses a non-standard port that the caller couldn't reasonably guess
-    /// — e.g. Regtest uses 50000 (nigiri's <c>electrs</c> binary-protocol
-    /// port; 30000 on the same host is electrs's HTTP REST, a different
-    /// protocol).
+    /// Default Electrum TCP port for this network. The public Ark Labs
+    /// Fulcrum instances (Mainnet, Mutinynet) only expose <b>50001</b>
+    /// (plain Electrum binary protocol over TCP). For TLS, use
+    /// <see cref="ElectrumWsUri"/> (Electrum-over-WSS terminates at the
+    /// host's port 443) — the conventional 50002 TLS port is not exposed.
+    /// Regtest uses <b>50000</b>, the only port nigiri's <c>electrs</c>
+    /// listens on for the Electrum binary protocol (30000 on the same
+    /// host is electrs's HTTP REST, a different protocol).
     /// </summary>
     [property: JsonPropertyName("electrum-tcp-port")]
     int? ElectrumTcpPort = null)
@@ -94,7 +91,8 @@ public record ArkNetworkConfig(
         ExplorerUri: "https://arkade.space",
         EsploraUri: "https://mempool.arkade.sh/api",
         ElectrumWsUri: "wss://electrum.arkade.sh",
-        ElectrumTcpHost: "electrum.arkade.sh");
+        ElectrumTcpHost: "electrum.arkade.sh",
+        ElectrumTcpPort: 50001);
 
     /// <summary>Mutinynet (signet) configuration.</summary>
     public static readonly ArkNetworkConfig Mutinynet = new(
@@ -104,7 +102,8 @@ public record ArkNetworkConfig(
         ExplorerUri: "https://explorer.mutinynet.arkade.sh",
         EsploraUri: "https://mempool.mutinynet.arkade.sh/api",
         ElectrumWsUri: "wss://electrum.mutinynet.arkade.sh",
-        ElectrumTcpHost: "electrum.mutinynet.arkade.sh");
+        ElectrumTcpHost: "electrum.mutinynet.arkade.sh",
+        ElectrumTcpPort: 50001);
 
     /// <summary>Local regtest configuration.</summary>
     public static readonly ArkNetworkConfig Regtest = new(
@@ -116,9 +115,9 @@ public record ArkNetworkConfig(
         EsploraUri: "http://localhost:3000",
         // Regtest WS bridge convention: electrum-ws on port 50003 (ts-sdk).
         ElectrumWsUri: "ws://localhost:50003",
-        // nigiri's electrs binary-protocol port (verified against
-        // nigiri/cmd/nigiri/resources/docker-compose.yml). 30000 on the
-        // same container is electrs's HTTP REST — different protocol.
+        // nigiri's electrs binary-protocol port — verified against
+        // nigiri/cmd/nigiri/resources/docker-compose.yml. 30000 on the
+        // same container is electrs's HTTP REST, a different protocol.
         ElectrumTcpHost: "localhost",
         ElectrumTcpPort: 50000);
 

--- a/NArk.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/NArk.Core/Hosting/ServiceCollectionExtensions.cs
@@ -54,11 +54,22 @@ public record ArkNetworkConfig(
 
     /// <summary>
     /// Default Electrum websocket endpoint for this network (mirrors the
-    /// ts-sdk's <c>WS_DEFAULT_URLS</c>). Optional — only consumed by clients
+    /// ts-sdk's <c>ELECTRUM_WS_URL</c>). Optional — only consumed by clients
     /// that want a websocket-driven Electrum chain source.
     /// </summary>
     [property: JsonPropertyName("electrum-ws")]
-    string? ElectrumWsUri = null)
+    string? ElectrumWsUri = null,
+
+    /// <summary>
+    /// Default Electrum endpoint hostname for raw-TCP consumers (mirrors
+    /// the ts-sdk's <c>ELECTRUM_TCP_HOST</c>; hostname only, no port — the
+    /// consumer picks the port: 50001 plain TCP, 50002 TCP+TLS, 50004 WSS
+    /// on the public Ark Labs Fulcrum instances). Optional and informational
+    /// — no built-in NArk service consumes it; .NET clients that speak
+    /// Electrum-over-TCP directly can pull it off the preset.
+    /// </summary>
+    [property: JsonPropertyName("electrum-tcp")]
+    string? ElectrumTcpHost = null)
 {
     /// <summary>Mainnet configuration.</summary>
     public static readonly ArkNetworkConfig Mainnet = new(
@@ -67,7 +78,8 @@ public record ArkNetworkConfig(
         BoltzUri: "https://api.boltz.exchange/",
         ExplorerUri: "https://arkade.space",
         EsploraUri: "https://mempool.arkade.sh/api",
-        ElectrumWsUri: "wss://electrum.arkade.sh");
+        ElectrumWsUri: "wss://electrum.arkade.sh",
+        ElectrumTcpHost: "electrum.arkade.sh");
 
     /// <summary>Mutinynet (signet) configuration.</summary>
     public static readonly ArkNetworkConfig Mutinynet = new(
@@ -76,7 +88,8 @@ public record ArkNetworkConfig(
         BoltzUri: "https://api.boltz.mutinynet.arkade.sh/",
         ExplorerUri: "https://explorer.mutinynet.arkade.sh",
         EsploraUri: "https://mempool.mutinynet.arkade.sh/api",
-        ElectrumWsUri: "wss://electrum.mutinynet.arkade.sh");
+        ElectrumWsUri: "wss://electrum.mutinynet.arkade.sh",
+        ElectrumTcpHost: "electrum.mutinynet.arkade.sh");
 
     /// <summary>Local regtest configuration.</summary>
     public static readonly ArkNetworkConfig Regtest = new(
@@ -85,9 +98,10 @@ public record ArkNetworkConfig(
         BoltzUri: "http://localhost:9069/",
         ExplorerUri: "http://localhost:7080",
         // ts-sdk regtest Esplora default: a local mempool/Chopsticks deployment.
-        // No Electrum WS default for regtest — ts-sdk assumes a locally-run
-        // electrum-ws websocat bridge whose URL is environment-specific.
-        EsploraUri: "http://localhost:3000");
+        EsploraUri: "http://localhost:3000",
+        // Regtest WS bridge convention: electrum-ws on port 50003 (ts-sdk).
+        ElectrumWsUri: "ws://localhost:50003",
+        ElectrumTcpHost: "localhost");
 
 }
 

--- a/NArk.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/NArk.Core/Hosting/ServiceCollectionExtensions.cs
@@ -61,27 +61,21 @@ public record ArkNetworkConfig(
     string? ElectrumWsUri = null,
 
     /// <summary>
-    /// Default Electrum endpoint hostname for raw-TCP consumers (mirrors
-    /// the ts-sdk's <c>ELECTRUM_TCP_HOST</c>). Pair with
-    /// <see cref="ElectrumTcpPort"/>. Optional and informational — no
-    /// built-in NArk service consumes it; .NET clients that speak
-    /// Electrum-over-TCP directly can pull it off the preset.
+    /// Default Electrum TCP endpoint for this network as a
+    /// <c>tcp://host:port</c> URI — pair to <see cref="ElectrumWsUri"/>
+    /// for callers that prefer raw TCP over WebSocket. Verified at the
+    /// protocol level against <c>server.version</c>: the public Ark
+    /// Labs Fulcrum instances (Mainnet, Mutinynet) only expose
+    /// <b>:50001</b> (plain Electrum binary protocol); the conventional
+    /// 50002 TLS port is not exposed — for TLS use the WSS endpoint via
+    /// <see cref="ElectrumWsUri"/>. Regtest uses <b>:50000</b>, the only
+    /// port nigiri's <c>electrs</c> listens on for the binary protocol
+    /// (30000 on the same host is electrs's HTTP REST, a different
+    /// protocol). Optional and informational — no built-in NArk service
+    /// consumes it.
     /// </summary>
     [property: JsonPropertyName("electrum-tcp")]
-    string? ElectrumTcpHost = null,
-
-    /// <summary>
-    /// Default Electrum TCP port for this network. The public Ark Labs
-    /// Fulcrum instances (Mainnet, Mutinynet) only expose <b>50001</b>
-    /// (plain Electrum binary protocol over TCP). For TLS, use
-    /// <see cref="ElectrumWsUri"/> (Electrum-over-WSS terminates at the
-    /// host's port 443) — the conventional 50002 TLS port is not exposed.
-    /// Regtest uses <b>50000</b>, the only port nigiri's <c>electrs</c>
-    /// listens on for the Electrum binary protocol (30000 on the same
-    /// host is electrs's HTTP REST, a different protocol).
-    /// </summary>
-    [property: JsonPropertyName("electrum-tcp-port")]
-    int? ElectrumTcpPort = null)
+    string? ElectrumTcpUri = null)
 {
     /// <summary>Mainnet configuration.</summary>
     public static readonly ArkNetworkConfig Mainnet = new(
@@ -91,8 +85,7 @@ public record ArkNetworkConfig(
         ExplorerUri: "https://arkade.space",
         EsploraUri: "https://mempool.arkade.sh/api",
         ElectrumWsUri: "wss://electrum.arkade.sh",
-        ElectrumTcpHost: "electrum.arkade.sh",
-        ElectrumTcpPort: 50001);
+        ElectrumTcpUri: "tcp://electrum.arkade.sh:50001");
 
     /// <summary>Mutinynet (signet) configuration.</summary>
     public static readonly ArkNetworkConfig Mutinynet = new(
@@ -102,8 +95,7 @@ public record ArkNetworkConfig(
         ExplorerUri: "https://explorer.mutinynet.arkade.sh",
         EsploraUri: "https://mempool.mutinynet.arkade.sh/api",
         ElectrumWsUri: "wss://electrum.mutinynet.arkade.sh",
-        ElectrumTcpHost: "electrum.mutinynet.arkade.sh",
-        ElectrumTcpPort: 50001);
+        ElectrumTcpUri: "tcp://electrum.mutinynet.arkade.sh:50001");
 
     /// <summary>Local regtest configuration.</summary>
     public static readonly ArkNetworkConfig Regtest = new(
@@ -118,8 +110,7 @@ public record ArkNetworkConfig(
         // nigiri's electrs binary-protocol port — verified against
         // nigiri/cmd/nigiri/resources/docker-compose.yml. 30000 on the
         // same container is electrs's HTTP REST, a different protocol.
-        ElectrumTcpHost: "localhost",
-        ElectrumTcpPort: 50000);
+        ElectrumTcpUri: "tcp://localhost:50000");
 
 }
 

--- a/README.md
+++ b/README.md
@@ -379,7 +379,13 @@ var onchainAddress = boardingContract.GetOnchainAddress(network);
 
 ```csharp
 // Option A: Esplora (mempool.space, Chopsticks, etc.)
-services.AddEsploraBlockchain(new Uri("https://mempool.space/api/"));
+// ArkNetworkConfig.{Mainnet,Mutinynet,Regtest}.EsploraUri carries
+// per-network defaults that mirror the canonical Arkade ts-sdk:
+//   Mainnet   → https://mempool.arkade.sh/api
+//   Mutinynet → https://mempool.mutinynet.arkade.sh/api
+//   Regtest   → http://localhost:3000
+services.AddEsploraBlockchain(new Uri(ArkNetworkConfig.Mainnet.EsploraUri!));
+// or pass your own URL: services.AddEsploraBlockchain(new Uri("https://mempool.space/api/"));
 
 // Option B: NBXplorer (BTCPay Server, self-hosted)
 services.AddNBXplorerBlockchain(network, new Uri("http://localhost:32838"));

--- a/README.md
+++ b/README.md
@@ -382,19 +382,20 @@ var onchainAddress = boardingContract.GetOnchainAddress(network);
 // ArkNetworkConfig.{Mainnet,Mutinynet,Regtest} carry per-network
 // endpoint defaults that mirror the canonical Arkade ts-sdk:
 //
-//   Network    EsploraUri                                 ElectrumWsUri                              ElectrumTcpHost                ElectrumTcpPort
-//   Mainnet    https://mempool.arkade.sh/api              wss://electrum.arkade.sh                   electrum.arkade.sh             50001
-//   Mutinynet  https://mempool.mutinynet.arkade.sh/api    wss://electrum.mutinynet.arkade.sh         electrum.mutinynet.arkade.sh   50001
-//   Regtest    http://localhost:3000                      ws://localhost:50003                       localhost                      50000 (nigiri electrs)
+//   Network    EsploraUri                                 ElectrumWsUri                              ElectrumTcpUri
+//   Mainnet    https://mempool.arkade.sh/api              wss://electrum.arkade.sh                   tcp://electrum.arkade.sh:50001
+//   Mutinynet  https://mempool.mutinynet.arkade.sh/api    wss://electrum.mutinynet.arkade.sh         tcp://electrum.mutinynet.arkade.sh:50001
+//   Regtest    http://localhost:3000                      ws://localhost:50003                       tcp://localhost:50000
 //
-// ElectrumWsUri is the websocket URL (scheme://host[:port]); wss://electrum.arkade.sh
-// terminates at the host's port 443. The public Ark Labs Fulcrum
-// instances only expose 50001 (plain Electrum binary protocol over TCP)
-// — for TLS use the WSS endpoint via ElectrumWsUri. (50002 TCP+TLS is
-// NOT exposed on the public hosts; ts-sdk's source comment listing
-// 50001/50002/50003 is stale.) Regtest uses nigiri's electrs which
-// exposes only 50000 for the Electrum binary protocol (30000 on the
-// same host is electrs's HTTP REST, a different protocol).
+// ElectrumWsUri is the websocket URL — wss://electrum.arkade.sh
+// terminates at the host's port 443. ElectrumTcpUri is verified at the
+// protocol layer against `server.version`: public Ark Labs Fulcrum
+// instances only expose :50001 (plain Electrum binary protocol). 50002
+// TCP+TLS is NOT exposed — for TLS use the WSS endpoint via
+// ElectrumWsUri. (ts-sdk's source comment listing 50001/50002/50003 is
+// stale.) Regtest uses nigiri's electrs on :50000 for the binary
+// protocol — 30000 on the same host is electrs's HTTP REST, a
+// different protocol.
 services.AddEsploraBlockchain(new Uri(ArkNetworkConfig.Mainnet.EsploraUri!));
 // or pass your own URL: services.AddEsploraBlockchain(new Uri("https://mempool.space/api/"));
 

--- a/README.md
+++ b/README.md
@@ -382,17 +382,19 @@ var onchainAddress = boardingContract.GetOnchainAddress(network);
 // ArkNetworkConfig.{Mainnet,Mutinynet,Regtest} carry per-network
 // endpoint defaults that mirror the canonical Arkade ts-sdk:
 //
-//   Network    EsploraUri                                 ElectrumWsUri                              ElectrumTcpHost              ElectrumTcpPort
-//   Mainnet    https://mempool.arkade.sh/api              wss://electrum.arkade.sh                   electrum.arkade.sh           null (pick: 50001/50002/50004)
-//   Mutinynet  https://mempool.mutinynet.arkade.sh/api    wss://electrum.mutinynet.arkade.sh         electrum.mutinynet.arkade.sh null (pick: 50001/50002/50004)
-//   Regtest    http://localhost:3000                      ws://localhost:50003                       localhost                    50000 (nigiri electrs TCP)
+//   Network    EsploraUri                                 ElectrumWsUri                              ElectrumTcpHost                ElectrumTcpPort
+//   Mainnet    https://mempool.arkade.sh/api              wss://electrum.arkade.sh                   electrum.arkade.sh             50001
+//   Mutinynet  https://mempool.mutinynet.arkade.sh/api    wss://electrum.mutinynet.arkade.sh         electrum.mutinynet.arkade.sh   50001
+//   Regtest    http://localhost:3000                      ws://localhost:50003                       localhost                      50000 (nigiri electrs)
 //
-// ElectrumWsUri is the websocket URL (full scheme://host[:port]); the
-// public Ark Labs Fulcrum instances also expose plain TCP (50001),
-// TCP+TLS (50002), and WSS (50004), so ElectrumTcpPort is null there —
-// the caller picks based on TLS preference. Regtest uses nigiri's
-// electrs which exposes only 50000 for the Electrum binary protocol
-// (30000 on the same host is electrs's HTTP REST, a different protocol).
+// ElectrumWsUri is the websocket URL (scheme://host[:port]); wss://electrum.arkade.sh
+// terminates at the host's port 443. The public Ark Labs Fulcrum
+// instances only expose 50001 (plain Electrum binary protocol over TCP)
+// — for TLS use the WSS endpoint via ElectrumWsUri. (50002 TCP+TLS is
+// NOT exposed on the public hosts; ts-sdk's source comment listing
+// 50001/50002/50003 is stale.) Regtest uses nigiri's electrs which
+// exposes only 50000 for the Electrum binary protocol (30000 on the
+// same host is electrs's HTTP REST, a different protocol).
 services.AddEsploraBlockchain(new Uri(ArkNetworkConfig.Mainnet.EsploraUri!));
 // or pass your own URL: services.AddEsploraBlockchain(new Uri("https://mempool.space/api/"));
 

--- a/README.md
+++ b/README.md
@@ -379,11 +379,18 @@ var onchainAddress = boardingContract.GetOnchainAddress(network);
 
 ```csharp
 // Option A: Esplora (mempool.space, Chopsticks, etc.)
-// ArkNetworkConfig.{Mainnet,Mutinynet,Regtest}.EsploraUri carries
-// per-network defaults that mirror the canonical Arkade ts-sdk:
-//   Mainnet   → https://mempool.arkade.sh/api
-//   Mutinynet → https://mempool.mutinynet.arkade.sh/api
-//   Regtest   → http://localhost:3000
+// ArkNetworkConfig.{Mainnet,Mutinynet,Regtest} carry per-network
+// endpoint defaults that mirror the canonical Arkade ts-sdk:
+//
+//   Network    EsploraUri                                 ElectrumWsUri                              ElectrumTcpHost
+//   Mainnet    https://mempool.arkade.sh/api              wss://electrum.arkade.sh                   electrum.arkade.sh
+//   Mutinynet  https://mempool.mutinynet.arkade.sh/api    wss://electrum.mutinynet.arkade.sh         electrum.mutinynet.arkade.sh
+//   Regtest    http://localhost:3000                      ws://localhost:50003                       localhost
+//
+// ElectrumWsUri is the websocket URL (full scheme://host[:port]); the
+// public Ark Labs Fulcrum instances also expose plain TCP (port 50001),
+// TCP+TLS (50002), and WSS (50004). ElectrumTcpHost is hostname-only —
+// the caller picks the port.
 services.AddEsploraBlockchain(new Uri(ArkNetworkConfig.Mainnet.EsploraUri!));
 // or pass your own URL: services.AddEsploraBlockchain(new Uri("https://mempool.space/api/"));
 

--- a/README.md
+++ b/README.md
@@ -382,15 +382,17 @@ var onchainAddress = boardingContract.GetOnchainAddress(network);
 // ArkNetworkConfig.{Mainnet,Mutinynet,Regtest} carry per-network
 // endpoint defaults that mirror the canonical Arkade ts-sdk:
 //
-//   Network    EsploraUri                                 ElectrumWsUri                              ElectrumTcpHost
-//   Mainnet    https://mempool.arkade.sh/api              wss://electrum.arkade.sh                   electrum.arkade.sh
-//   Mutinynet  https://mempool.mutinynet.arkade.sh/api    wss://electrum.mutinynet.arkade.sh         electrum.mutinynet.arkade.sh
-//   Regtest    http://localhost:3000                      ws://localhost:50003                       localhost
+//   Network    EsploraUri                                 ElectrumWsUri                              ElectrumTcpHost              ElectrumTcpPort
+//   Mainnet    https://mempool.arkade.sh/api              wss://electrum.arkade.sh                   electrum.arkade.sh           null (pick: 50001/50002/50004)
+//   Mutinynet  https://mempool.mutinynet.arkade.sh/api    wss://electrum.mutinynet.arkade.sh         electrum.mutinynet.arkade.sh null (pick: 50001/50002/50004)
+//   Regtest    http://localhost:3000                      ws://localhost:50003                       localhost                    50000 (nigiri electrs TCP)
 //
 // ElectrumWsUri is the websocket URL (full scheme://host[:port]); the
-// public Ark Labs Fulcrum instances also expose plain TCP (port 50001),
-// TCP+TLS (50002), and WSS (50004). ElectrumTcpHost is hostname-only —
-// the caller picks the port.
+// public Ark Labs Fulcrum instances also expose plain TCP (50001),
+// TCP+TLS (50002), and WSS (50004), so ElectrumTcpPort is null there —
+// the caller picks based on TLS preference. Regtest uses nigiri's
+// electrs which exposes only 50000 for the Electrum binary protocol
+// (30000 on the same host is electrs's HTTP REST, a different protocol).
 services.AddEsploraBlockchain(new Uri(ArkNetworkConfig.Mainnet.EsploraUri!));
 // or pass your own URL: services.AddEsploraBlockchain(new Uri("https://mempool.space/api/"));
 


### PR DESCRIPTION
## Add per-network Esplora / Electrum defaults to `ArkNetworkConfig`

Three additive fields on `ArkNetworkConfig` carrying the per-network endpoints, mirroring the canonical Arkade ts-sdk + verified at the protocol level against real hosts.

| Field | Mainnet | Mutinynet | Regtest |
|---|---|---|---|
| `EsploraUri` | `https://mempool.arkade.sh/api` | `https://mempool.mutinynet.arkade.sh/api` | `http://localhost:3000` |
| `ElectrumWsUri` | `wss://electrum.arkade.sh` | `wss://electrum.mutinynet.arkade.sh` | `ws://localhost:50003` |
| `ElectrumTcpUri` | `tcp://electrum.arkade.sh:50001` | `tcp://electrum.mutinynet.arkade.sh:50001` | `tcp://localhost:50000` |

Both Electrum endpoints have **been verified at the protocol layer**, not just by port-reachability: sending `server.version` to `:50001` on the public hosts returns `{"jsonrpc":"2.0","result":["Fulcrum 2.1.0","1.4"]}`. The conventional 50002 (TLS) port is **not** exposed on the public Ark Labs hosts — TLS is served via WSS on `:443` (the default port the `wss://electrum.arkade.sh` URL resolves to). For Regtest, `:50000` is nigiri's `electrs` binary-protocol port (`:30000` on the same host is electrs's HTTP REST — different protocol).

### Why
Apps that need an `IBitcoinBlockchain` without standing up their own NBXplorer / bitcoind (e.g. when running alongside the BTCPay Electrum plugin, which removes NBXplorer entirely) can now pull the right endpoint straight off the preset:

```csharp
services.AddEsploraBlockchain(new Uri(
    ArkNetworkConfig.Mainnet.EsploraUri!));
```

Previously every consumer had to hard-code the URLs themselves.

### Compatibility
- **Additive**: new fields are appended to the positional record signature with nullable defaults, so existing named-args callers are untouched.
- **JSON**: new keys `"esplora"`, `"electrum-ws"`, `"electrum-tcp"` added under the same kebab-case convention as `"explorer"`. Old serialized configs that don't carry them deserialize fine (nullable).
- **No code paths changed** — only data on a config record. Callers opt in.

### Test plan
- [x] `dotnet build NArk.Core` clean (0 errors).
- [x] Electrum TCP ports verified at the protocol level (`server.version` round-trip against the live public Fulcrum hosts).
- [x] README updated with the per-network endpoint table (per docs policy).
- [ ] CI green.
