### PR TITLE
chore(contracts): include contract type + script in derive/import logs

### DIFF
--- a/NArk.Core/Services/ContractService.cs
+++ b/NArk.Core/Services/ContractService.cs
@@ -70,7 +70,8 @@ public class ContractService(
         await contractStorage.SaveContract(entity, cancellationToken);
 
         await eventHandlers.SafeHandleEventAsync(new NewContractActionEvent(contract, walletId), cancellationToken);
-        logger?.LogInformation("Derived {Purpose} contract for wallet {WalletId}", purpose, walletId);
+        logger?.LogInformation("Derived {Purpose} contract for wallet {WalletId} (type={ContractType}, script={Script})",
+            purpose, walletId, entity.Type, entity.Script);
         return contract;
     }
 
@@ -94,6 +95,7 @@ public class ContractService(
             entity = entity with { Metadata = metadata };
         await contractStorage.SaveContract(entity, cancellationToken);
         await eventHandlers.SafeHandleEventAsync(new NewContractActionEvent(contract, walletId), cancellationToken);
-        logger?.LogInformation("Imported contract for wallet {WalletId}", walletId);
+        logger?.LogInformation("Imported contract for wallet {WalletId} (type={ContractType}, script={Script})",
+            walletId, entity.Type, entity.Script);
     }
 }


### PR DESCRIPTION
## Summary
- `ImportContract` and `DeriveContract` now log the persisted contract `Type` and `Script` alongside the existing `WalletId` (and `Purpose` for derive).
- Pre-change, both info lines only carried the wallet id, which made multi-derive flows (invoice payment + boarding co-derivation, swap restore) impossible to follow at INFO level.

## Test plan
- [ ] `dotnet build NArk.Core` succeeds (verified locally — 0 errors, only pre-existing warnings).
- [ ] At INFO, the produced lines read `Imported contract for wallet abc (type=Boarding, script=51209...)` and `Derived Receive contract for wallet abc (type=Payment, script=5120ee...)`.