### PR TITLE
fix(sync): demote PollScriptsForVtxos curl debug-aid log to Debug

### DIFF
--- a/NArk.Core/Services/VtxoSynchronizationService.cs
+++ b/NArk.Core/Services/VtxoSynchronizationService.cs
@@ -612,11 +612,16 @@ public class VtxoSynchronizationService : IAsyncDisposable
         _logger?.LogInformation("PollScriptsForVtxos: querying arkd indexer for {Count} scripts (after={After}): [{Scripts}]",
             scripts.Count, after?.ToString("O") ?? "<none>", string.Join(", ", scripts));
 
-        // Log equivalent REST API URL for manual testing (substitute your arkd host:port).
-        var queryParams = string.Join("&", scripts.Select(s => $"scripts={Uri.EscapeDataString(s)}"));
-        if (after.HasValue)
-            queryParams += $"&after={after.Value.ToUnixTimeMilliseconds()}";
-        _logger?.LogInformation("PollScriptsForVtxos: curl http://localhost:7070/v1/indexer/vtxos?{QueryParams}", queryParams);
+        // Debug aid: equivalent REST API URL for manual testing (substitute your arkd host:port).
+        // Kept at Debug — at Info this fires on every poll cycle (default 5s) and floods the log
+        // with the same query whether VTXOs landed or not.
+        if (_logger?.IsEnabled(LogLevel.Debug) == true)
+        {
+            var queryParams = string.Join("&", scripts.Select(s => $"scripts={Uri.EscapeDataString(s)}"));
+            if (after.HasValue)
+                queryParams += $"&after={after.Value.ToUnixTimeMilliseconds()}";
+            _logger.LogDebug("PollScriptsForVtxos: curl http://localhost:7070/v1/indexer/vtxos?{QueryParams}", queryParams);
+        }
 
         var count = 0;
 


### PR DESCRIPTION
## Summary
- `VtxoSynchronizationService.PollScriptsForVtxos` logs an equivalent `curl http://localhost:7070/v1/indexer/vtxos?…` line each invocation as a manual-testing aid. The line was `LogInformation`, so it fired on every 5-second safety-net poll cycle regardless of result — exactly the routine-poll noise PR #95 was meant to remove.
- Demoted to `LogDebug` and gated on `_logger.IsEnabled(LogLevel.Debug)` so the query-string formatting cost is skipped when Debug isn't enabled.

## Test plan
- [ ] At default Info log level, the `PollScriptsForVtxos: curl …` line no longer appears.
- [ ] At Debug log level, the same line appears unchanged so it stays useful as a manual-testing aid.