### PR TITLE
perf(sync): single immediate poll per stream push, drop 750ms/3s/8s retry schedule

### DIFF
--- a/NArk.Core/Services/VtxoSynchronizationService.cs
+++ b/NArk.Core/Services/VtxoSynchronizationService.cs
@@ -38,18 +38,6 @@ public class VtxoSynchronizationService : IAsyncDisposable
     // UpdateScriptsView full-syncs newly-added scripts with After=null.
     private static readonly TimeSpan StreamPollLookback = TimeSpan.FromMinutes(5);
 
-    // Delays between arkd's subscription push and our follow-up indexer poll(s).
-    // arkd can emit the event before the indexer query path has the VTXO visible,
-    // and we've observed the commit lag range from <1s to ~30s. Rather than pick a
-    // single tuned delay, enqueue a short retry schedule; each poll uses an `after`
-    // window so repeated fetches of unchanged data are no-ops in the upsert path.
-    private static readonly TimeSpan[] StreamPushPollSchedule =
-    [
-        TimeSpan.FromMilliseconds(750),
-        TimeSpan.FromSeconds(3),
-        TimeSpan.FromSeconds(8),
-    ];
-
     /// <summary>
     /// Internal poll work item.
     /// </summary>
@@ -379,12 +367,24 @@ public class VtxoSynchronizationService : IAsyncDisposable
                 _logger?.LogInformation(
                     "VTXO subscription stream: arkd pushed update for {Count} script(s): [{Scripts}]",
                     vtxosToPoll.Count, string.Join(", ", vtxosToPoll));
-                // arkd's subscription event can fire well before its indexer query path
-                // has committed the new VTXO — we've observed anywhere from <1s to
-                // ~30s. Fire a short schedule of retry polls rather than relying on a
-                // single tuned delay. All polls use an `after` window so repeated
-                // fetches of unchanged state are no-ops on the upsert side.
-                _ = FirePollSchedule(vtxosToPoll, restartableToken.Token);
+                // Enqueue a single immediate poll for the pushed scripts. The earlier
+                // 750ms/3s/8s retry schedule was added when arkd v0.9.0-rc.1's indexer
+                // could lag the subscription event by up to ~30s; on current arkd builds
+                // (v0.9.5+) plus the routine 5s safety-net poll, that schedule is dead
+                // weight — it only delayed detection on the happy path. If the immediate
+                // poll loses the race against arkd's indexer, RoutinePoll catches it
+                // within ~5s using the same after-window semantics.
+                try
+                {
+                    var after = DateTimeOffset.UtcNow - StreamPollLookback;
+                    await _readyToPoll.Writer.WriteAsync(
+                        new PollRequest(vtxosToPoll, after), restartableToken.Token);
+                }
+                catch (OperationCanceledException) { }
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning(ex, "Stream push: failed to enqueue immediate poll");
+                }
             }
             endedGracefully = true;
         }
@@ -407,30 +407,6 @@ public class VtxoSynchronizationService : IAsyncDisposable
             _logger?.LogWarning(
                 "VTXO subscription stream ended without error — arkd closed the stream. Restarting scripts view.");
             await UpdateScriptsView(_shutdownCts.Token);
-        }
-    }
-
-    private async Task FirePollSchedule(HashSet<string> scripts, CancellationToken token)
-    {
-        for (var i = 0; i < StreamPushPollSchedule.Length; i++)
-        {
-            try
-            {
-                await Task.Delay(StreamPushPollSchedule[i], token);
-            }
-            catch (OperationCanceledException) { return; }
-
-            try
-            {
-                var after = DateTimeOffset.UtcNow - StreamPollLookback;
-                await _readyToPoll.Writer.WriteAsync(new PollRequest(scripts, after), token);
-            }
-            catch (OperationCanceledException) { return; }
-            catch (Exception ex)
-            {
-                _logger?.LogWarning(ex, "FirePollSchedule: failed to enqueue retry poll ({Attempt}/{Total})",
-                    i + 1, StreamPushPollSchedule.Length);
-            }
         }
     }
 


### PR DESCRIPTION
## Summary
`VtxoSynchronizationService` fanned out every arkd subscription push into three follow-up polls scheduled at +750ms / +3s / +8s. That schedule was tuned for arkd v0.9.0-rc.1's indexer commit-lag (observed range <1s to ~30s). On v0.9.5+ the indexer is essentially in sync with the subscription event, and we also still run a 5-second routine safety-net poll across every active script — so the retry schedule is now dead weight:

- Happy path waits **750ms before the first poll** even fires, so a direct-arkade transaction that was instant on arkd's side took ≥750ms before the VTXO landed in storage.
- The +3s and +8s retries are no-op `UpsertVtxo` calls (already-seen data, no `VtxosChanged` fired).

Replaced with a single immediate enqueue on each stream push. Any race the immediate poll loses against arkd's indexer is caught within ~5s by `RoutinePoll`, which already sweeps every active script with the same `after`-windowed semantics.

Removed:
- `StreamPushPollSchedule[]` (the [750ms, 3s, 8s] array)
- `FirePollSchedule` method (the per-push fan-out)

## Test plan
- [ ] `dotnet build NArk.Core` succeeds (0 errors).
- [ ] After arkd pushes an update, `UpsertVtxo: inserted ...` lands within tens of ms (vs. ~777ms before).
- [ ] If the immediate poll happens to return zero (arkd indexer lag), `RoutinePoll` catches it on the next 5s tick.
- [ ] No regression in the existing arkd-restart / stream-end-grace paths (untouched code).