### PR TITLE
fix(spending): exclude unconfirmed boarding UTXOs from spendable coins

### DIFF
--- a/NArk.Abstractions/VTXOs/ArkVtxo.cs
+++ b/NArk.Abstractions/VTXOs/ArkVtxo.cs
@@ -21,6 +21,14 @@ public record ArkVtxo(
     IReadOnlyList<VtxoAsset>? Assets = null,
     Dictionary<string, string>? Metadata = null)
 {
+    /// <summary>
+    /// Metadata key carrying the on-chain confirmation state of an unrolled
+    /// (on-chain) VTXO, as <c>bool.ToString()</c> ("True"/"False"). Populated
+    /// by the boarding-UTXO sync from the explorer's confirmation status. The
+    /// writer (BoardingUtxoSyncService) and all readers share this constant.
+    /// </summary>
+    public const string ConfirmedMetadataKey = "Confirmed";
+
     public OutPoint OutPoint => new(new uint256(TransactionId), TransactionOutputIndex);
     public TxOut TxOut => new(Money.Satoshis(Amount), NBitcoin.Script.FromHex(Script));
 
@@ -56,6 +64,27 @@ public record ArkVtxo(
     public bool IsRecoverable(TimeHeight current)
     {
         return Swept || IsExpired(current) ;
+    }
+
+    /// <summary>
+    /// True when this VTXO is an on-chain output whose funding transaction is
+    /// not yet confirmed, and therefore cannot be spent or settled. Reads the
+    /// <see cref="ConfirmedMetadataKey"/> flag: a value other than "True"
+    /// (case-insensitive) means unconfirmed.
+    /// <para>
+    /// Today only boarding UTXOs carry this flag (set by the boarding-UTXO
+    /// sync from the explorer). VTXOs without the key — off-chain tree VTXOs
+    /// and arkd-reported unrolled VTXOs, which the indexer does not surface
+    /// confirmation data for — return <c>false</c>. If confirmation data is
+    /// later wired for arkd-reported unrolled VTXOs, setting the same flag
+    /// makes this (and every consumer) generalise without further changes.
+    /// </para>
+    /// </summary>
+    public bool IsUnconfirmedOnchain()
+    {
+        return Metadata is not null
+               && Metadata.TryGetValue(ConfirmedMetadataKey, out var confirmed)
+               && !string.Equals(confirmed, bool.TrueString, StringComparison.OrdinalIgnoreCase);
     }
     //
     // public bool RequiresForfeit()

--- a/NArk.Core/Services/BoardingUtxoSyncService.cs
+++ b/NArk.Core/Services/BoardingUtxoSyncService.cs
@@ -141,7 +141,7 @@ public class BoardingUtxoSyncService
 
             var metadata = new Dictionary<string, string>
             {
-                ["Confirmed"] = utxo.Confirmed.ToString()
+                [ArkVtxo.ConfirmedMetadataKey] = utxo.Confirmed.ToString()
             };
 
             var arkVtxo = new ArkVtxo(

--- a/NArk.Core/Services/SpendingService.cs
+++ b/NArk.Core/Services/SpendingService.cs
@@ -155,6 +155,18 @@ public class SpendingService(
         var vtxos = await vtxoStorage.GetVtxos(walletIds: [walletId], includeSpent: false,
             cancellationToken: cancellationToken);
 
+        // Exclude on-chain VTXOs whose funding tx hasn't confirmed yet
+        // (today: boarding UTXOs still in the mempool). arkd's
+        // validateBoardingInput rejects unconfirmed boarding inputs at settle
+        // time, so offering them as spendable coins is misleading and any
+        // spend built from them is doomed.
+        var spendableVtxos = vtxos.Where(v => !v.IsUnconfirmedOnchain()).ToList();
+        var skipped = vtxos.Count - spendableVtxos.Count;
+        if (skipped > 0)
+            logger?.LogDebug("Excluding {Count} unconfirmed on-chain VTXO(s) from available coins for wallet {WalletId}",
+                skipped, walletId);
+        vtxos = spendableVtxos;
+
         var scripts = vtxos.Select(v => v.Script).Distinct().ToArray();
         var contractByScript =
             (await contractStorage.GetContracts(walletIds: [walletId], scripts: scripts,

--- a/NArk.Tests/ArkVtxoTests.cs
+++ b/NArk.Tests/ArkVtxoTests.cs
@@ -1,0 +1,56 @@
+using NArk.Abstractions.VTXOs;
+
+namespace NArk.Tests;
+
+[TestFixture]
+public class ArkVtxoTests
+{
+    private static ArkVtxo MakeVtxo(bool unrolled, Dictionary<string, string>? metadata) =>
+        new(
+            Script: "0014" + new string('0', 40),
+            TransactionId: new string('a', 64),
+            TransactionOutputIndex: 0,
+            Amount: 50_000,
+            SpentByTransactionId: null,
+            SettledByTransactionId: null,
+            Swept: false,
+            CreatedAt: DateTimeOffset.UtcNow,
+            ExpiresAt: null,
+            ExpiresAtHeight: null,
+            Unrolled: unrolled,
+            Metadata: metadata);
+
+    [Test]
+    public void IsUnconfirmedOnchain_UnconfirmedBoarding_True()
+    {
+        // Boarding sync writes Metadata["Confirmed"] = bool.ToString() => "False".
+        var vtxo = MakeVtxo(unrolled: true,
+            new Dictionary<string, string> { [ArkVtxo.ConfirmedMetadataKey] = false.ToString() });
+        Assert.That(vtxo.IsUnconfirmedOnchain(), Is.True);
+    }
+
+    [Test]
+    public void IsUnconfirmedOnchain_ConfirmedBoarding_False()
+    {
+        var vtxo = MakeVtxo(unrolled: true,
+            new Dictionary<string, string> { [ArkVtxo.ConfirmedMetadataKey] = true.ToString() });
+        Assert.That(vtxo.IsUnconfirmedOnchain(), Is.False);
+    }
+
+    [Test]
+    public void IsUnconfirmedOnchain_NoConfirmedMetadata_False()
+    {
+        // Regular off-chain VTXOs and arkd-reported unrolled VTXOs carry no
+        // "Confirmed" key — they are not treated as unconfirmed-onchain.
+        Assert.That(MakeVtxo(unrolled: false, null).IsUnconfirmedOnchain(), Is.False);
+        Assert.That(MakeVtxo(unrolled: true, new Dictionary<string, string>()).IsUnconfirmedOnchain(), Is.False);
+    }
+
+    [Test]
+    public void IsUnconfirmedOnchain_CaseInsensitiveTrue_False()
+    {
+        var vtxo = MakeVtxo(unrolled: true,
+            new Dictionary<string, string> { [ArkVtxo.ConfirmedMetadataKey] = "true" });
+        Assert.That(vtxo.IsUnconfirmedOnchain(), Is.False);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -419,6 +419,8 @@ The `BoardingUtxoPollService` automatically checks for unspent boarding VTXOs ev
 
 Once a boarding UTXO is synced and confirmed, the SDK's `IntentGenerationService` automatically creates an intent for it. The next batch moves it into the VTXO tree.
 
+While a boarding UTXO is still in the mempool it is stored with `Metadata["Confirmed"] = "False"`. Such VTXOs report `ArkVtxo.IsUnconfirmedOnchain() == true`, are excluded from `SpendingService.GetAvailableCoins`, and cannot be settled (arkd rejects unconfirmed boarding inputs). Display them as pending rather than spendable until the funding tx confirms.
+
 ### 3. Handle Expired Boarding UTXOs (Optional)
 
 If a boarding UTXO isn't batched before its CSV timelock expires, `OnchainSweepService` detects it. Register a custom `IOnchainSweepHandler` to control what happens:

--- a/docs/articles/spending.md
+++ b/docs/articles/spending.md
@@ -32,6 +32,8 @@ var txId = await spendingService.Spend(
     cancellationToken);
 ```
 
+`GetAvailableCoins` excludes on-chain VTXOs whose funding tx hasn't confirmed yet — today, boarding UTXOs still in the mempool (`ArkVtxo.IsUnconfirmedOnchain() == true`). They are not selectable because arkd rejects unconfirmed boarding inputs at settle time.
+
 ## Sub-Dust Outputs
 
 Outputs below the dust threshold are converted to OP_RETURN outputs. The server configures the maximum number of OP_RETURN outputs per transaction (default: 3).

--- a/samples/NArk.Wallet/NArk.Wallet.Client/Pages/Vtxos.razor
+++ b/samples/NArk.Wallet/NArk.Wallet.Client/Pages/Vtxos.razor
@@ -70,8 +70,8 @@
                                 @vtxo.TransactionId[..16]...:@vtxo.TransactionOutputIndex
                             </p>
                         </div>
-                        <span class="pill @(vtxo.IsSpent() ? "pill-danger" : "pill-success")" style="font-size:9px;">
-                            @(vtxo.IsSpent() ? "SPENT" : "LIVE")
+                        <span class="pill @StatusPillClass(vtxo)" style="font-size:9px;">
+                            @StatusPillLabel(vtxo)
                         </span>
                     </div>
 
@@ -141,6 +141,14 @@
         "spent" => _vtxos.Where(v => v.IsSpent()),
         _ => _vtxos
     };
+
+    // Unconfirmed on-chain VTXOs (e.g. boarding UTXOs still in the mempool)
+    // aren't spendable or settleable yet — surface that instead of "LIVE".
+    private static string StatusPillClass(ArkVtxo vtxo) =>
+        vtxo.IsSpent() ? "pill-danger" : vtxo.IsUnconfirmedOnchain() ? "pill-warning" : "pill-success";
+
+    private static string StatusPillLabel(ArkVtxo vtxo) =>
+        vtxo.IsSpent() ? "SPENT" : vtxo.IsUnconfirmedOnchain() ? "PENDING" : "LIVE";
 
     protected override async Task OnInitializedAsync()
     {


### PR DESCRIPTION
## Summary
- A boarding UTXO still in the mempool was being offered as a spendable coin and rendered as live/settled, even though arkd's `validateBoardingInput` rejects unconfirmed boarding inputs at settle time — so any spend built from one is doomed.
- Adds `ArkVtxo.IsUnconfirmedOnchain()` (reads a shared `Confirmed` metadata flag via the new `ArkVtxo.ConfirmedMetadataKey` const) and filters such VTXOs out of `SpendingService.GetAvailableCoins`.
- The helper is **confirmation-centric**, not boarding-specific: only boarding sync populates the flag today, but arkd-reported unrolled VTXOs will generalise for free once they carry the same flag (deliberately deferred).

## Details
- `BoardingUtxoSyncService` now writes the flag via `ArkVtxo.ConfirmedMetadataKey` instead of a string literal, so writer and readers share one constant.
- Sample wallet (`Vtxos.razor`) surfaces the state as a `PENDING` pill instead of `LIVE`.
- Docs: README boarding section + `docs/articles/spending.md` note the exclusion.

## Test plan
- [x] `dotnet build NArk.sln` — 0 errors
- [x] `dotnet build samples/NArk.Wallet/NArk.Wallet.Client` — 0 errors
- [x] `dotnet test NArk.Tests` — 397/397 pass (4 new `ArkVtxoTests` covering unconfirmed/confirmed/no-metadata/case-insensitive)