### PR TITLE
fix(sync): derive active-scripts view fresh each poll so detection can't desync

### DIFF
--- a/NArk.Core/Services/VtxoSynchronizationService.cs
+++ b/NArk.Core/Services/VtxoSynchronizationService.cs
@@ -24,13 +24,23 @@ public class VtxoSynchronizationService : IAsyncDisposable
     private CancellationTokenSource? _restartCts;
     private Task? _streamTask;
 
-    private HashSet<string> _lastViewOfScripts = [];
+    /// <summary>
+    /// The script set the subscription stream is currently subscribed to.
+    /// This is bookkeeping for the long-lived gRPC subscription only — it tells
+    /// us when to restart the stream (the subscribed set differs from the
+    /// freshly-derived active set). It is NOT the source of truth for what to
+    /// poll: <see cref="RoutinePoll"/> re-derives the active set fresh from the
+    /// providers every tick, so a drift here can never hide a script from
+    /// detection — the next poll catches it and re-syncs the stream.
+    /// </summary>
+    private HashSet<string> _subscribedScripts = [];
 
     /// <summary>
-    /// Gets the set of scripts currently being listened to for VTXO updates.
-    /// This is useful for debugging to see which contracts are actively tracked.
+    /// The scripts the subscription stream is currently subscribed to (for
+    /// debugging/observability). The 5-second safety-net poll always operates
+    /// on a freshly-derived active set, independent of this value.
     /// </summary>
-    public IReadOnlySet<string> ListenedScripts => _lastViewOfScripts;
+    public IReadOnlySet<string> ListenedScripts => _subscribedScripts;
 
     private readonly SemaphoreSlim _viewSyncLock = new(1);
 
@@ -198,7 +208,8 @@ public class VtxoSynchronizationService : IAsyncDisposable
     // has been seen to take 10-30s to make the VTXO queryable. The 5-second tick
     // with a 2-minute `after` window bounds detection latency while staying
     // cheap (each tick is one gRPC call with a small result set).
-    private static readonly TimeSpan RoutinePollInterval = TimeSpan.FromSeconds(5);
+    // Tunable for tests via the internal init property.
+    internal TimeSpan RoutinePollInterval { get; init; } = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan RoutinePollLookback = TimeSpan.FromMinutes(2);
     private Task? _routinePollTask;
 
@@ -226,9 +237,31 @@ public class VtxoSynchronizationService : IAsyncDisposable
 
             try
             {
-                var scripts = _lastViewOfScripts;
+                // Derive the active-script set FRESH from the providers every
+                // tick (provider-agnostic — we don't care whether a script comes
+                // from a contract or an existing VTXO). This is the drift-proof
+                // source of truth for what to poll: a stale or missed stream
+                // subscription can never hide a script from detection, because
+                // the next tick re-derives and polls it regardless. A single
+                // periodic derivation is cheap — the historical 11k×11k blow-up
+                // came from firing the change event per VTXO upsert, not from
+                // one periodic query.
+                var scripts = await GatherActiveScriptsAsync(cancellationToken);
                 if (scripts.Count == 0)
                     continue;
+
+                // Keep the subscription stream in sync with reality. If the
+                // freshly derived set differs from what the stream is subscribed
+                // to, refresh — UpdateScriptsView restarts the stream and runs a
+                // full-history catch-up for newly-added scripts, recovering any
+                // VTXO that landed while a script was unsubscribed.
+                if (!scripts.SetEquals(_subscribedScripts))
+                {
+                    _logger?.LogInformation(
+                        "RoutinePoll: active set ({Count}) differs from the stream subscription ({Subscribed}) — refreshing subscription",
+                        scripts.Count, _subscribedScripts.Count);
+                    await UpdateScriptsView(cancellationToken);
+                }
 
                 var startedAt = DateTimeOffset.UtcNow;
                 var after = startedAt - RoutinePollLookback;
@@ -253,26 +286,57 @@ public class VtxoSynchronizationService : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Derives the current active-script set by unioning every
+    /// <see cref="IActiveScriptsProvider"/>. Provider-agnostic: it does not care
+    /// whether a script is backed by a contract or an existing VTXO. A failing
+    /// provider is logged and skipped rather than aborting the whole refresh —
+    /// one storage hiccup must not blank the set and tear down the subscription
+    /// for every other provider's scripts; the next derivation re-includes it.
+    /// </summary>
+    private async Task<HashSet<string>> GatherActiveScriptsAsync(CancellationToken token)
+    {
+        var result = new HashSet<string>();
+        foreach (var provider in _activeScriptsProviders)
+        {
+            try
+            {
+                result.UnionWith(await provider.GetActiveScripts(token));
+            }
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex,
+                    "GetActiveScripts failed for provider {Provider}; skipping it for this refresh",
+                    provider.GetType().Name);
+            }
+        }
+        return result;
+    }
+
     private async Task UpdateScriptsView(CancellationToken token)
     {
         await _viewSyncLock.WaitAsync(token);
         try
         {
-            var newViewOfScripts = (await Task.WhenAll(_activeScriptsProviders.Select(p => p.GetActiveScripts(token)))).SelectMany(c => c).ToHashSet();
+            var newViewOfScripts = await GatherActiveScriptsAsync(token);
 
             if (newViewOfScripts.Count == 0)
                 return;
 
             // We already have a stream with this exact script list
-            if (newViewOfScripts.SetEquals(_lastViewOfScripts) && _streamTask is not null && !_streamTask.IsCompleted)
+            if (newViewOfScripts.SetEquals(_subscribedScripts) && _streamTask is not null && !_streamTask.IsCompleted)
             {
                 _logger?.LogDebug("UpdateScriptsView: unchanged ({Count} scripts), skipping stream restart", newViewOfScripts.Count);
                 return;
             }
 
-            var newlyAdded = newViewOfScripts.Except(_lastViewOfScripts).ToHashSet();
+            var newlyAdded = newViewOfScripts.Except(_subscribedScripts).ToHashSet();
             _logger?.LogInformation("UpdateScriptsView: script set changed from {OldCount} to {NewCount} scripts, restarting stream. New scripts: [{NewScripts}]",
-                _lastViewOfScripts.Count, newViewOfScripts.Count,
+                _subscribedScripts.Count, newViewOfScripts.Count,
                 string.Join(", ", newlyAdded));
 
             try
@@ -287,7 +351,7 @@ public class VtxoSynchronizationService : IAsyncDisposable
                 _logger?.LogDebug(0, ex, "Error cancelling previous stream during scripts view update");
             }
 
-            _lastViewOfScripts = newViewOfScripts;
+            _subscribedScripts = newViewOfScripts;
             _restartCts = CancellationTokenSource.CreateLinkedTokenSource(token, _shutdownCts.Token);
             // Start a new subscription stream for the whole view.
             _streamTask = StartStreamLogic(newViewOfScripts, _restartCts.Token);
@@ -296,7 +360,7 @@ public class VtxoSynchronizationService : IAsyncDisposable
             // events for future changes). Skip when the set only shrank.
             if (newlyAdded.Count > 0)
             {
-                // First-startup nuance: at this point _lastViewOfScripts WAS
+                // First-startup nuance: at this point _subscribedScripts WAS
                 // empty (we're populating it from cold), so "newly added" =
                 // entire set. Without a persisted cursor we'd re-fetch every
                 // script's full VTXO history every cold start. Use
@@ -328,7 +392,7 @@ public class VtxoSynchronizationService : IAsyncDisposable
 
                 // The cold-start catch-up IS a full-set snapshot: at this moment
                 // newlyAdded equals the entire active script view (cold start →
-                // _lastViewOfScripts was empty before line 291), and `catchupAfter`
+                // _subscribedScripts was empty before it was assigned above), and `catchupAfter`
                 // is the stored cursor (or null for first-ever startup). On its
                 // successful completion we both flip the gate flag and advance
                 // the cursor to its StartedAt — eliminating the 5-second window

--- a/NArk.Storage.EfCore/Storage/EfCoreVtxoStorage.cs
+++ b/NArk.Storage.EfCore/Storage/EfCoreVtxoStorage.cs
@@ -159,6 +159,25 @@ public class EfCoreVtxoStorage : IVtxoStorage
         return entities.Select(MapToArkVtxo).ToList();
     }
 
+    /// <summary>
+    /// Overrides the default <see cref="IVtxoStorage.GetActiveScripts"/> (which
+    /// materialises every unspent VTXO row) with a scripts-only projection. The
+    /// safety-net poll re-derives the active set every few seconds, so this runs
+    /// frequently — projecting <c>DISTINCT script</c> instead of full entities
+    /// keeps it cheap even for wallets with thousands of unspent VTXOs.
+    /// </summary>
+    public async Task<HashSet<string>> GetActiveScripts(CancellationToken cancellationToken = default)
+    {
+        await using var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+        var scripts = await db.Set<VtxoEntity>()
+            .Where(v => (v.SpentByTransactionId ?? "").Length == 0 &&
+                        (v.SettledByTransactionId ?? "").Length == 0)
+            .Select(v => v.Script)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+        return scripts.ToHashSet();
+    }
+
     private static ArkVtxo MapToArkVtxo(VtxoEntity entity)
     {
         return new ArkVtxo(

--- a/NArk.Tests/Sync/VtxoSynchronizationServiceViewUpdateTests.cs
+++ b/NArk.Tests/Sync/VtxoSynchronizationServiceViewUpdateTests.cs
@@ -1,0 +1,163 @@
+using System.Runtime.CompilerServices;
+using NArk.Abstractions.Scripts;
+using NArk.Abstractions.VTXOs;
+using NArk.Core.Services;
+using NArk.Core.Transport;
+using NSubstitute;
+
+namespace NArk.Tests.Sync;
+
+/// <summary>
+/// Covers how <see cref="VtxoSynchronizationService"/> keeps the set of polled
+/// scripts in sync with reality, and reproduces the "payment to a freshly-derived
+/// Active receive contract is not auto-detected" report: the safety-net poll must
+/// derive the active set fresh from the providers (provider-agnostic), so a stale
+/// or missed stream subscription can never hide a script from detection.
+/// </summary>
+[TestFixture]
+public class VtxoSynchronizationServiceViewUpdateTests
+{
+    private const string ReceiveScript = "5120b98a01252ca661028207db2cb3475a84a67691a53c5321a78504c03a0e2e5866";
+
+    private IVtxoStorage _vtxoStorage = null!;
+    private IClientTransport _transport = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _vtxoStorage = Substitute.For<IVtxoStorage>();
+        _transport = Substitute.For<IClientTransport>();
+        _transport.GetVtxoByScriptsAsSnapshot(
+                Arg.Any<IReadOnlySet<string>>(),
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<DateTimeOffset?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => System.Linq.AsyncEnumerable.Empty<ArkVtxo>());
+        // Keep the subscription stream open until its token is cancelled, so the
+        // service doesn't spin in graceful-restart while the test runs.
+        _transport.GetVtxoToPollAsStream(Arg.Any<IReadOnlySet<string>>(), Arg.Any<CancellationToken>())
+            .Returns(ci => BlockingStream(ci.ArgAt<CancellationToken>(1)));
+    }
+
+    [Test]
+    public async Task NewlyActiveContract_ViaEvent_StartsBeingListenedTo()
+    {
+        var contractScripts = new HashSet<string>();
+        var contractProvider = MakeProvider(() => contractScripts);
+
+        var sut = new VtxoSynchronizationService(
+            _vtxoStorage, _transport, [contractProvider], walletStorage: null);
+
+        await sut.StartAsync(CancellationToken.None);
+
+        // A new Receive contract is derived → contract store reports it active and
+        // raises ActiveScriptsChanged (mirrors EfCoreContractStorage.SaveContract).
+        contractScripts.Add(ReceiveScript);
+        contractProvider.ActiveScriptsChanged += Raise.Event<EventHandler>(contractProvider, EventArgs.Empty);
+
+        await WaitForAsync(() => sut.ListenedScripts.Contains(ReceiveScript));
+        await sut.DisposeAsync();
+
+        Assert.That(sut.ListenedScripts, Does.Contain(ReceiveScript));
+    }
+
+    [Test]
+    public async Task StaleSubscription_SelfHealsViaRoutinePoll()
+    {
+        // The bug: the contract is active in storage, but no ActiveScriptsChanged
+        // reached the service (lost/aborted event during the rapid swap setup), so
+        // the stream subscription never learned about it. The safety-net poll must
+        // still discover and poll the script, because it re-derives the active set
+        // fresh rather than trusting the (stale) subscription set.
+        var vtxoProvider = MakeProvider(() => new HashSet<string> { "5120aa", "5120bb" });
+        var contractScripts = new HashSet<string>();
+        var contractProvider = MakeProvider(() => contractScripts);
+
+        var sut = new VtxoSynchronizationService(
+            _vtxoStorage, _transport, [vtxoProvider, contractProvider], walletStorage: null)
+        {
+            RoutinePollInterval = TimeSpan.FromMilliseconds(100)
+        };
+
+        await sut.StartAsync(CancellationToken.None);
+        await WaitForAsync(() => sut.ListenedScripts.Count > 0);
+
+        // Contract becomes active WITHOUT raising the event.
+        contractScripts.Add(ReceiveScript);
+
+        // RoutinePoll re-derives the active set and must both poll the new script
+        // and resync the subscription to it.
+        await WaitForAsync(() => PolledScripts().Contains(ReceiveScript));
+        await WaitForAsync(() => sut.ListenedScripts.Contains(ReceiveScript));
+        await sut.DisposeAsync();
+
+        Assert.That(PolledScripts(), Does.Contain(ReceiveScript),
+            "The safety-net poll must derive the active set fresh and poll a contract the stream never subscribed to.");
+        Assert.That(sut.ListenedScripts, Does.Contain(ReceiveScript),
+            "RoutinePoll must resync the subscription to the freshly-discovered script.");
+    }
+
+    [Test]
+    public async Task OneProviderThrows_OtherProvidersStillPolled()
+    {
+        var healthy = MakeProvider(() => new HashSet<string> { "5120aa" });
+        var faulty = Substitute.For<IActiveScriptsProvider>();
+        faulty.GetActiveScripts(Arg.Any<CancellationToken>())
+            .Returns<Task<HashSet<string>>>(_ => throw new InvalidOperationException("provider down"));
+
+        var sut = new VtxoSynchronizationService(
+            _vtxoStorage, _transport, [healthy, faulty], walletStorage: null)
+        {
+            RoutinePollInterval = TimeSpan.FromMilliseconds(100)
+        };
+
+        await sut.StartAsync(CancellationToken.None);
+        await WaitForAsync(() => PolledScripts().Contains("5120aa"));
+        await sut.DisposeAsync();
+
+        Assert.That(sut.ListenedScripts, Does.Contain("5120aa"),
+            "A failing provider must be skipped, not abort the whole refresh and blank the set.");
+        Assert.That(PolledScripts(), Does.Contain("5120aa"));
+    }
+
+    private static IActiveScriptsProvider MakeProvider(Func<HashSet<string>> currentScripts)
+    {
+        var provider = Substitute.For<IActiveScriptsProvider>();
+        provider.GetActiveScripts(Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult(new HashSet<string>(currentScripts())));
+        return provider;
+    }
+
+    private HashSet<string> PolledScripts()
+    {
+        var polled = new HashSet<string>();
+        foreach (var call in _transport.ReceivedCalls()
+                     .Where(c => c.GetMethodInfo().Name == nameof(IClientTransport.GetVtxoByScriptsAsSnapshot)))
+        {
+            if (call.GetArguments()[0] is IReadOnlySet<string> scripts)
+                polled.UnionWith(scripts);
+        }
+        return polled;
+    }
+
+    private static async IAsyncEnumerable<HashSet<string>> BlockingStream(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var tcs = new TaskCompletionSource();
+        await using (ct.Register(() => tcs.TrySetResult()))
+        {
+            await tcs.Task;
+        }
+        yield break;
+    }
+
+    private static async Task WaitForAsync(Func<bool> predicate, int timeoutMs = 3000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate()) return;
+            await Task.Delay(10);
+        }
+    }
+}


### PR DESCRIPTION
## The bug
A payment to a freshly-derived **Active receive contract** was not auto-detected — neither the subscription stream nor the 5-second safety-net poll picked it up. A manual contract sync found it instantly. The debug page confirmed it: *7 scripts listened, 3 active contracts, Listening "-" on every active row* — the active contracts simply weren't in the watched set.

## Root cause
Both the stream and `RoutinePoll` operated on a **cached** `_lastViewOfScripts`, refreshed only *reactively* on `IContractStorage.ActiveScriptsChanged`. If that event is lost or its `UpdateScriptsView` aborts (the reverse-swap path fires two contract saves + a swap subscription + back-to-back stream restarts), the cache silently **desyncs** from the real active contracts and there is **no reconciliation** — the script stays unwatched until the next event or a restart. Manual sync works because it polls the contract's script *directly* (`PollScriptsForVtxos`, `after=null`), bypassing the cache.

(`after`/`before` units were also verified against arkd: **milliseconds**, filtering on **`updated_at`** — so that side is correct, not a unit bug.)

## Fix
- **`RoutinePoll` derives the active set fresh every tick** from the providers (provider-agnostic via `IActiveScriptsProvider` — no contract special-casing) and polls it. This is the drift-proof source of truth: a stale/missed stream subscription can never hide a script, because the next tick re-derives and polls it regardless.
- `RoutinePoll` then **reconciles the stream** — if the fresh set differs from what the stream is subscribed to, it refreshes (restart + full-history catch-up for newly-added scripts, recovering a VTXO that landed while unsubscribed).
- A single periodic derivation is cheap; the historical 11k-VTXO blow-up came from firing the change event **per upsert**, not from one query.
- `_lastViewOfScripts` → renamed **`_subscribedScripts`**, demoted to pure stream-subscription bookkeeping.
- **`GatherActiveScriptsAsync`** isolates per-provider failures (one storage hiccup is logged + skipped instead of blanking the whole set).
- **`EfCoreVtxoStorage.GetActiveScripts`** now projects `DISTINCT script` instead of materialising every unspent row, keeping the per-tick derive cheap at scale.

## Test plan
- [x] `dotnet build NArk.sln` — 0 errors
- [x] `dotnet test NArk.Tests` — 400/400 pass
- [x] New `VtxoSynchronizationServiceViewUpdateTests`: self-heal (active contract with **no** event fired is polled + resubscribed via `RoutinePoll`), event path, and per-provider isolation
- [x] Existing `VtxoSynchronizationServiceSyncStateTests` (cursor/cold-start) still green