### PR TITLE
feat(sync): update the indexer script subscription in place instead of restarting it

### DIFF
--- a/NArk.Core/Services/VtxoSynchronizationService.cs
+++ b/NArk.Core/Services/VtxoSynchronizationService.cs
@@ -21,8 +21,19 @@ public class VtxoSynchronizationService : IAsyncDisposable
     private readonly CancellationTokenSource _shutdownCts = new();
     private Task? _queryTask;
 
-    private CancellationTokenSource? _restartCts;
+    // The long-lived stream supervisor task. It keeps exactly one GetSubscription
+    // stream open and updates the watched set IN PLACE (Subscribe/Unsubscribe) rather
+    // than tearing the stream down on every script change.
     private Task? _streamTask;
+    // Cancelled to interrupt the supervisor's current stream so it re-reads the
+    // subscription state (on recreate or teardown). A fresh instance per generation.
+    private CancellationTokenSource? _streamGenerationCts;
+    // Released when a subscription is (re)created from the idle/no-subscription state,
+    // to wake the supervisor out of its idle wait.
+    private readonly SemaphoreSlim _streamWakeup = new(0);
+    // arkd subscription id for the current in-place subscription; null when there is
+    // none (empty active set, or torn down).
+    private string? _subscriptionId;
 
     /// <summary>
     /// The script set the subscription stream is currently subscribed to.
@@ -211,6 +222,8 @@ public class VtxoSynchronizationService : IAsyncDisposable
     // Tunable for tests via the internal init property.
     internal TimeSpan RoutinePollInterval { get; init; } = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan RoutinePollLookback = TimeSpan.FromMinutes(2);
+    // Backoff before reconnecting the subscription stream after a transient fault.
+    private static readonly TimeSpan StreamReconnectDelay = TimeSpan.FromSeconds(1);
     private Task? _routinePollTask;
 
     public async Task StartAsync(CancellationToken cancellationToken)
@@ -219,6 +232,9 @@ public class VtxoSynchronizationService : IAsyncDisposable
         var multiToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
         _queryTask = StartQueryLogic(multiToken.Token);
         _routinePollTask = RoutinePoll(multiToken.Token);
+        // The supervisor starts idle and wakes once UpdateScriptsView creates the
+        // initial subscription below.
+        _streamTask = RunStreamSupervisorAsync(multiToken.Token);
         await UpdateScriptsView(multiToken.Token);
     }
 
@@ -322,94 +338,78 @@ public class VtxoSynchronizationService : IAsyncDisposable
         await _viewSyncLock.WaitAsync(token);
         try
         {
-            var newViewOfScripts = await GatherActiveScriptsAsync(token);
+            var newView = await GatherActiveScriptsAsync(token);
 
-            if (newViewOfScripts.Count == 0)
-                return;
-
-            // We already have a stream with this exact script list
-            if (newViewOfScripts.SetEquals(_subscribedScripts) && _streamTask is not null && !_streamTask.IsCompleted)
+            // Empty active set → tear the subscription down (no point holding an empty
+            // subscription open). The supervisor goes idle until scripts return.
+            if (newView.Count == 0)
             {
-                _logger?.LogDebug("UpdateScriptsView: unchanged ({Count} scripts), skipping stream restart", newViewOfScripts.Count);
-                return;
-            }
-
-            var newlyAdded = newViewOfScripts.Except(_subscribedScripts).ToHashSet();
-            _logger?.LogInformation("UpdateScriptsView: script set changed from {OldCount} to {NewCount} scripts, restarting stream. New scripts: [{NewScripts}]",
-                _subscribedScripts.Count, newViewOfScripts.Count,
-                string.Join(", ", newlyAdded));
-
-            try
-            {
-                if (_restartCts is not null)
-                    await _restartCts.CancelAsync();
-                if (_streamTask is not null)
-                    await _streamTask;
-            }
-            catch (Exception ex)
-            {
-                _logger?.LogDebug(0, ex, "Error cancelling previous stream during scripts view update");
-            }
-
-            _subscribedScripts = newViewOfScripts;
-            _restartCts = CancellationTokenSource.CreateLinkedTokenSource(token, _shutdownCts.Token);
-            // Start a new subscription stream for the whole view.
-            _streamTask = StartStreamLogic(newViewOfScripts, _restartCts.Token);
-            // Catch-up poll: only newly-added scripts need a full-history fetch
-            // (already-known scripts have been synced and will receive stream
-            // events for future changes). Skip when the set only shrank.
-            if (newlyAdded.Count > 0)
-            {
-                // First-startup nuance: at this point _subscribedScripts WAS
-                // empty (we're populating it from cold), so "newly added" =
-                // entire set. Without a persisted cursor we'd re-fetch every
-                // script's full VTXO history every cold start. Use
-                // MIN(per-wallet vtxo.lastFullPollAt) as the `after` filter
-                // on this one call so the cold-start catch-up window equals
-                // "since last shutdown" rather than "all of history".
-                DateTimeOffset? catchupAfter = null;
-                var isInitialCatchup = _isFirstStartupCatchup;
-                if (isInitialCatchup && _walletStorage is not null)
+                if (_subscriptionId is not null)
                 {
+                    var torndown = _subscriptionId;
+                    _logger?.LogInformation("UpdateScriptsView: active set empty — tearing down subscription {Id}", torndown);
+                    _subscriptionId = null;
+                    SignalStreamGenerationChange();
                     try
                     {
-                        catchupAfter = await ReadCursorMinAcrossWalletsAsync(token);
-                        if (catchupAfter is not null)
-                        {
-                            _logger?.LogInformation(
-                                "First-startup catch-up: using MIN(per-wallet {Key})={After} as `after` filter for {Count} script(s)",
-                                LastFullPollAtMetadataKey, catchupAfter.Value.ToString("O"), newlyAdded.Count);
-                        }
+                        await _arkClientTransport.UnsubscribeForScriptsAsync(torndown, scripts: null, token);
                     }
                     catch (Exception ex)
                     {
-                        _logger?.LogWarning(ex,
-                            "First-startup catch-up: failed to read per-wallet {Key}; falling back to full-history fetch",
-                            LastFullPollAtMetadataKey);
+                        _logger?.LogDebug(0, ex, "UpdateScriptsView: unsubscribe-all during teardown failed (subscription may already be gone)");
                     }
                 }
-                _isFirstStartupCatchup = false;
-
-                // The cold-start catch-up IS a full-set snapshot: at this moment
-                // newlyAdded equals the entire active script view (cold start →
-                // _subscribedScripts was empty before it was assigned above), and `catchupAfter`
-                // is the stored cursor (or null for first-ever startup). On its
-                // successful completion we both flip the gate flag and advance
-                // the cursor to its StartedAt — eliminating the 5-second window
-                // between catch-up success and the first routine poll's cursor
-                // write. Subsequent UpdateScriptsView calls (script set grows
-                // mid-flight) only carry newly-added scripts and stay
-                // IsFullSetSnapshot=false.
-                var startedAt = isInitialCatchup ? DateTimeOffset.UtcNow : default;
-                await _readyToPoll.Writer.WriteAsync(
-                    new PollRequest(
-                        newlyAdded,
-                        catchupAfter,
-                        IsFullSetSnapshot: isInitialCatchup,
-                        StartedAt: startedAt,
-                        IsColdStartCatchup: isInitialCatchup),
-                    token);
+                _subscribedScripts = [];
+                return;
             }
+
+            // No live subscription (cold start, or returning from empty) → create one,
+            // wake the supervisor to stream it, and full-history catch-up the whole set.
+            if (_subscriptionId is null)
+            {
+                _subscriptionId = await _arkClientTransport.SubscribeForScriptsAsync(newView, subscriptionId: null, token);
+                _subscribedScripts = newView;
+                _logger?.LogInformation("UpdateScriptsView: created subscription {Id} for {Count} script(s)", _subscriptionId, newView.Count);
+                await EnqueueCatchupPollAsync(newView, token);
+                SignalStreamWakeup();
+                return;
+            }
+
+            // Live subscription → update the watched set IN PLACE. No stream restart:
+            // arkd routes the added/removed scripts onto the already-open stream.
+            var added = newView.Except(_subscribedScripts).ToHashSet();
+            var removed = _subscribedScripts.Except(newView).ToHashSet();
+            if (added.Count == 0 && removed.Count == 0)
+            {
+                _logger?.LogDebug("UpdateScriptsView: unchanged ({Count} scripts)", newView.Count);
+                return;
+            }
+
+            _logger?.LogInformation(
+                "UpdateScriptsView: in-place update +{Added}/-{Removed} (now {Count}) on subscription {Id}",
+                added.Count, removed.Count, newView.Count, _subscriptionId);
+            try
+            {
+                if (added.Count > 0)
+                    await _arkClientTransport.SubscribeForScriptsAsync(added, _subscriptionId, token);
+                if (removed.Count > 0)
+                    await _arkClientTransport.UnsubscribeForScriptsAsync(_subscriptionId, removed, token);
+            }
+            catch (Exception ex) when (IsSubscriptionNotFound(ex))
+            {
+                // arkd GC'd the subscription (TTL after a disconnect). Recreate it and make
+                // the supervisor re-read the new id; full-history catch-up the whole set.
+                _logger?.LogInformation("UpdateScriptsView: subscription {Id} not found — recreating", _subscriptionId);
+                _subscriptionId = await _arkClientTransport.SubscribeForScriptsAsync(newView, subscriptionId: null, token);
+                _subscribedScripts = newView;
+                await EnqueueCatchupPollAsync(newView, token);
+                SignalStreamGenerationChange();
+                return;
+            }
+
+            if (added.Count > 0)
+                await EnqueueCatchupPollAsync(added, token);
+            _subscribedScripts = newView;
         }
         finally
         {
@@ -417,62 +417,202 @@ public class VtxoSynchronizationService : IAsyncDisposable
         }
     }
 
-    private async Task StartStreamLogic(HashSet<string> scripts, CancellationToken token)
+    /// <summary>
+    /// Enqueues a catch-up poll for <paramref name="scripts"/>, recovering any VTXO that
+    /// landed before these scripts were being watched. The first call after startup is the
+    /// cold-start catch-up: it reads MIN(per-wallet vtxo.lastFullPollAt) as its <c>after</c>
+    /// filter (so wallets with long history don't refetch everything) and advances the
+    /// persisted cursor on success. Every later call is a full-history fetch
+    /// (<c>after = null</c>). Caller holds <see cref="_viewSyncLock"/>.
+    /// </summary>
+    private async Task EnqueueCatchupPollAsync(HashSet<string> scripts, CancellationToken token)
     {
-        _logger?.LogInformation(
-            "VTXO subscription stream starting for {ScriptCount} script(s)", scripts.Count);
-        var endedGracefully = false;
-        try
+        if (scripts.Count == 0)
+            return;
+
+        DateTimeOffset? catchupAfter = null;
+        var isInitialCatchup = _isFirstStartupCatchup;
+        if (isInitialCatchup && _walletStorage is not null)
         {
-            var restartableToken =
-                CancellationTokenSource.CreateLinkedTokenSource(token, _shutdownCts.Token);
-            await foreach (var vtxosToPoll in _arkClientTransport.GetVtxoToPollAsStream(scripts, restartableToken.Token))
+            try
             {
-                _logger?.LogInformation(
-                    "VTXO subscription stream: arkd pushed update for {Count} script(s): [{Scripts}]",
-                    vtxosToPoll.Count, string.Join(", ", vtxosToPoll));
-                // Enqueue a single immediate poll for the pushed scripts. The earlier
-                // 750ms/3s/8s retry schedule was added when arkd v0.9.0-rc.1's indexer
-                // could lag the subscription event by up to ~30s; on current arkd builds
-                // (v0.9.5+) plus the routine 5s safety-net poll, that schedule is dead
-                // weight — it only delayed detection on the happy path. If the immediate
-                // poll loses the race against arkd's indexer, RoutinePoll catches it
-                // within ~5s using the same after-window semantics.
-                try
+                catchupAfter = await ReadCursorMinAcrossWalletsAsync(token);
+                if (catchupAfter is not null)
+                    _logger?.LogInformation(
+                        "First-startup catch-up: using MIN(per-wallet {Key})={After} as `after` filter for {Count} script(s)",
+                        LastFullPollAtMetadataKey, catchupAfter.Value.ToString("O"), scripts.Count);
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex,
+                    "First-startup catch-up: failed to read per-wallet {Key}; falling back to full-history fetch",
+                    LastFullPollAtMetadataKey);
+            }
+        }
+        _isFirstStartupCatchup = false;
+
+        // The cold-start catch-up is a full-set snapshot: on success the gate flips and the
+        // per-wallet cursor advances to StartedAt. Later catch-ups (script set grew) stay
+        // IsFullSetSnapshot=false and full-history (catchupAfter=null).
+        var startedAt = isInitialCatchup ? DateTimeOffset.UtcNow : default;
+        await _readyToPoll.Writer.WriteAsync(
+            new PollRequest(scripts, catchupAfter, IsFullSetSnapshot: isInitialCatchup,
+                StartedAt: startedAt, IsColdStartCatchup: isInitialCatchup),
+            token);
+    }
+
+    /// <summary>
+    /// The long-lived stream supervisor. Keeps one GetSubscription stream open for the
+    /// current subscription, enqueuing a poll for every pushed script. The watched set is
+    /// mutated in place by <see cref="UpdateScriptsView"/> (Subscribe/Unsubscribe) without
+    /// touching this loop. The loop only re-reads state when signalled: a generation change
+    /// (recreate/teardown) cancels the current stream token, and a wakeup ends the idle wait
+    /// after a subscription is created. On a stream drop it re-asserts the subscription
+    /// (recreating if arkd GC'd it) and reconnects.
+    /// </summary>
+    private async Task RunStreamSupervisorAsync(CancellationToken shutdownToken)
+    {
+        while (!shutdownToken.IsCancellationRequested)
+        {
+            string? subscriptionId;
+            var streamToken = CancellationToken.None;
+            await _viewSyncLock.WaitAsync(shutdownToken);
+            try
+            {
+                subscriptionId = _subscriptionId;
+                if (subscriptionId is not null)
                 {
-                    var after = DateTimeOffset.UtcNow - StreamPollLookback;
-                    await _readyToPoll.Writer.WriteAsync(
-                        new PollRequest(vtxosToPoll, after), restartableToken.Token);
-                }
-                catch (OperationCanceledException) { }
-                catch (Exception ex)
-                {
-                    _logger?.LogWarning(ex, "Stream push: failed to enqueue immediate poll");
+                    _streamGenerationCts?.Dispose();
+                    _streamGenerationCts = CancellationTokenSource.CreateLinkedTokenSource(shutdownToken);
+                    streamToken = _streamGenerationCts.Token;
                 }
             }
-            endedGracefully = true;
+            finally
+            {
+                _viewSyncLock.Release();
+            }
+
+            if (subscriptionId is null)
+            {
+                // Idle: nothing to watch. Wait until a subscription is created.
+                try { await _streamWakeup.WaitAsync(shutdownToken); }
+                catch (OperationCanceledException) { return; }
+                continue;
+            }
+
+            var endedGracefully = false;
+            try
+            {
+                _logger?.LogInformation("VTXO subscription stream starting (subscription {Id})", subscriptionId);
+                await foreach (var changed in _arkClientTransport.GetVtxoSubscriptionStreamAsync(subscriptionId, streamToken))
+                {
+                    _logger?.LogInformation(
+                        "VTXO subscription stream: arkd pushed update for {Count} script(s): [{Scripts}]",
+                        changed.Count, string.Join(", ", changed));
+                    // Single immediate poll for the pushed scripts; the 5s safety-net poll
+                    // is the backstop if this loses the race against arkd's indexer.
+                    try
+                    {
+                        var after = DateTimeOffset.UtcNow - StreamPollLookback;
+                        await _readyToPoll.Writer.WriteAsync(new PollRequest(changed, after), streamToken);
+                    }
+                    catch (OperationCanceledException) { }
+                    catch (Exception ex)
+                    {
+                        _logger?.LogWarning(ex, "Stream push: failed to enqueue immediate poll");
+                    }
+                }
+                endedGracefully = true;
+            }
+            catch (OperationCanceledException) when (shutdownToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (OperationCanceledException)
+            {
+                // Generation change (recreate/teardown) — re-read state on the next loop.
+                continue;
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogWarning(ex, "VTXO subscription stream faulted — reconnecting");
+                try { await Task.Delay(StreamReconnectDelay, shutdownToken); }
+                catch (OperationCanceledException) { return; }
+            }
+
+            if (endedGracefully)
+                _logger?.LogWarning("VTXO subscription stream ended (arkd closed it) — reconnecting");
+
+            // Re-assert the subscription so a TTL-GC'd listener is recreated, then loop to reconnect.
+            await ReassertSubscriptionAsync(subscriptionId, shutdownToken);
         }
-        catch (Exception ex) when (!token.IsCancellationRequested)
+    }
+
+    /// <summary>
+    /// After the supervisor's stream dropped, re-asserts the subscription's topics on the
+    /// same id (a no-op while the listener is alive within its TTL). If arkd GC'd the
+    /// listener, recreates it and full-history catch-up the set. The fresh-derive safety-net
+    /// poll covers detection regardless, so a transient failure here is non-fatal.
+    /// </summary>
+    private async Task ReassertSubscriptionAsync(string staleSubscriptionId, CancellationToken shutdownToken)
+    {
+        await _viewSyncLock.WaitAsync(shutdownToken);
+        try
         {
-            _logger?.LogWarning(0, ex, "VTXO subscription stream failed — restarting scripts view");
-            await UpdateScriptsView(_shutdownCts.Token);
-            return;
+            // A concurrent UpdateScriptsView already recreated/tore down — let the supervisor
+            // re-read on the next loop instead of fighting it.
+            if (_subscriptionId != staleSubscriptionId)
+                return;
+            if (_subscribedScripts.Count == 0)
+            {
+                _subscriptionId = null;
+                return;
+            }
+
+            try
+            {
+                await _arkClientTransport.SubscribeForScriptsAsync(_subscribedScripts, staleSubscriptionId, shutdownToken);
+            }
+            catch (Exception ex) when (IsSubscriptionNotFound(ex))
+            {
+                _logger?.LogInformation("Reconnect: subscription {Id} was GC'd — recreating", staleSubscriptionId);
+                _subscriptionId = await _arkClientTransport.SubscribeForScriptsAsync(_subscribedScripts, subscriptionId: null, shutdownToken);
+                await EnqueueCatchupPollAsync(_subscribedScripts, shutdownToken);
+            }
+        }
+        catch (OperationCanceledException) when (shutdownToken.IsCancellationRequested)
+        {
         }
         catch (Exception ex)
         {
-            _logger?.LogDebug(0, ex, "VTXO subscription stream cancelled");
-            return;
+            _logger?.LogWarning(ex, "Failed to re-assert VTXO subscription on reconnect; safety-net poll still covers detection");
         }
-
-        // Graceful end: arkd closed the stream without an error. We must restart
-        // or we silently lose every subsequent VTXO notification for these scripts.
-        if (endedGracefully && !token.IsCancellationRequested)
+        finally
         {
-            _logger?.LogWarning(
-                "VTXO subscription stream ended without error — arkd closed the stream. Restarting scripts view.");
-            await UpdateScriptsView(_shutdownCts.Token);
+            _viewSyncLock.Release();
         }
     }
+
+    // Wake the supervisor out of its idle wait after a subscription is created from empty.
+    private void SignalStreamWakeup()
+    {
+        if (_streamWakeup.CurrentCount == 0)
+            _streamWakeup.Release();
+    }
+
+    // Interrupt the supervisor's current stream so it re-reads the subscription state
+    // (used on recreate and teardown — the supervisor is streaming, not idle).
+    private void SignalStreamGenerationChange()
+    {
+        try { _streamGenerationCts?.Cancel(); }
+        catch (ObjectDisposedException) { }
+    }
+
+    // arkd reports a missing subscription as "subscription <id> not found" (gRPC Internal,
+    // surfaced verbatim over REST too). Matched by message since there's no dedicated code.
+    private static bool IsSubscriptionNotFound(Exception ex)
+        => ex.Message.Contains("not found", StringComparison.OrdinalIgnoreCase)
+           || (ex.InnerException is { } inner && inner.Message.Contains("not found", StringComparison.OrdinalIgnoreCase));
 
     private async Task? StartQueryLogic(CancellationToken cancellationToken)
     {
@@ -710,6 +850,9 @@ public class VtxoSynchronizationService : IAsyncDisposable
         {
             _logger?.LogDebug("Routine poll task cancelled during disposal");
         }
+
+        _streamGenerationCts?.Dispose();
+        _streamWakeup.Dispose();
 
         _logger?.LogInformation("VTXO synchronization service disposed");
     }

--- a/NArk.Core/Transport/CachingClientTransport.cs
+++ b/NArk.Core/Transport/CachingClientTransport.cs
@@ -111,8 +111,14 @@ public class CachingClientTransport : IClientTransport
 
     // Pass-through methods - no caching needed for these
 
-    public IAsyncEnumerable<HashSet<string>> GetVtxoToPollAsStream(IReadOnlySet<string> scripts, CancellationToken token = default)
-        => _inner.GetVtxoToPollAsStream(scripts, token);
+    public Task<string> SubscribeForScriptsAsync(IReadOnlySet<string> scripts, string? subscriptionId, CancellationToken cancellationToken = default)
+        => _inner.SubscribeForScriptsAsync(scripts, subscriptionId, cancellationToken);
+
+    public Task UnsubscribeForScriptsAsync(string subscriptionId, IReadOnlySet<string>? scripts, CancellationToken cancellationToken = default)
+        => _inner.UnsubscribeForScriptsAsync(subscriptionId, scripts, cancellationToken);
+
+    public IAsyncEnumerable<HashSet<string>> GetVtxoSubscriptionStreamAsync(string subscriptionId, CancellationToken cancellationToken = default)
+        => _inner.GetVtxoSubscriptionStreamAsync(subscriptionId, cancellationToken);
 
     public IAsyncEnumerable<ArkVtxo> GetVtxoByScriptsAsSnapshot(IReadOnlySet<string> scripts, CancellationToken cancellationToken = default)
         => _inner.GetVtxoByScriptsAsSnapshot(scripts, cancellationToken);

--- a/NArk.Core/Transport/GrpcClient/GrpcClientTransport.Vtxo.cs
+++ b/NArk.Core/Transport/GrpcClient/GrpcClientTransport.Vtxo.cs
@@ -93,17 +93,31 @@ public partial class GrpcClientTransport
         }
     }
 
-    public async IAsyncEnumerable<HashSet<string>> GetVtxoToPollAsStream(IReadOnlySet<string> scripts,
-        [EnumeratorCancellation] CancellationToken token = default)
+    public async Task<string> SubscribeForScriptsAsync(IReadOnlySet<string> scripts,
+        string? subscriptionId, CancellationToken cancellationToken = default)
     {
-        var req = new SubscribeForScriptsRequest { SubscriptionId = string.Empty };
+        var req = new SubscribeForScriptsRequest { SubscriptionId = subscriptionId ?? string.Empty };
         req.Scripts.AddRange(scripts);
+        var res = await _indexerServiceClient.SubscribeForScriptsAsync(req, cancellationToken: cancellationToken);
+        return res.SubscriptionId;
+    }
 
-        var subscribeRes = await _indexerServiceClient.SubscribeForScriptsAsync(req, cancellationToken: token);
+    public async Task UnsubscribeForScriptsAsync(string subscriptionId,
+        IReadOnlySet<string>? scripts, CancellationToken cancellationToken = default)
+    {
+        var req = new UnsubscribeForScriptsRequest { SubscriptionId = subscriptionId };
+        if (scripts is not null)
+            req.Scripts.AddRange(scripts);
+        await _indexerServiceClient.UnsubscribeForScriptsAsync(req, cancellationToken: cancellationToken);
+    }
 
-        var stream = _indexerServiceClient.GetSubscription(new GetSubscriptionRequest { SubscriptionId = subscribeRes.SubscriptionId }, cancellationToken: token);
+    public async IAsyncEnumerable<HashSet<string>> GetVtxoSubscriptionStreamAsync(string subscriptionId,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var stream = _indexerServiceClient.GetSubscription(
+            new GetSubscriptionRequest { SubscriptionId = subscriptionId }, cancellationToken: cancellationToken);
 
-        await foreach (var response in stream.ResponseStream.ReadAllAsync(token))
+        await foreach (var response in stream.ResponseStream.ReadAllAsync(cancellationToken))
         {
             if (response == null) continue;
             switch (response.DataCase)

--- a/NArk.Core/Transport/IClientTransport.cs
+++ b/NArk.Core/Transport/IClientTransport.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using NArk.Abstractions.Batches;
 using NArk.Abstractions.Batches.ServerEvents;
 using NArk.Abstractions.Intents;
@@ -10,7 +11,50 @@ namespace NArk.Core.Transport;
 public interface IClientTransport
 {
     Task<ArkServerInfo> GetServerInfoAsync(CancellationToken cancellationToken = default);
-    IAsyncEnumerable<HashSet<string>> GetVtxoToPollAsStream(IReadOnlySet<string> scripts, CancellationToken token = default);
+
+    /// <summary>
+    /// Creates a new VTXO-script subscription (when <paramref name="subscriptionId"/> is null
+    /// or empty) or adds scripts to an existing one. Returns the subscription id to open the
+    /// stream with via <see cref="GetVtxoSubscriptionStreamAsync"/>.
+    /// <para>
+    /// arkd's subscription is mutable while its stream is open: scripts added here are routed
+    /// onto the already-open stream, so the watched set can be updated in place without tearing
+    /// the stream down and resubscribing.
+    /// </para>
+    /// </summary>
+    Task<string> SubscribeForScriptsAsync(IReadOnlySet<string> scripts, string? subscriptionId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes scripts from an existing subscription. When <paramref name="scripts"/> is null or
+    /// empty, all scripts are removed and the subscription is torn down server-side.
+    /// </summary>
+    Task UnsubscribeForScriptsAsync(string subscriptionId, IReadOnlySet<string>? scripts,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Opens the long-lived server stream for a subscription, yielding the set of scripts whose
+    /// VTXOs changed on each push. The subscription's script set may be mutated in place via
+    /// <see cref="SubscribeForScriptsAsync"/> / <see cref="UnsubscribeForScriptsAsync"/> while
+    /// this stream stays open.
+    /// </summary>
+    IAsyncEnumerable<HashSet<string>> GetVtxoSubscriptionStreamAsync(string subscriptionId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Convenience: create a one-shot subscription for <paramref name="scripts"/> and stream it.
+    /// Built on the composable primitives above; it does not surface the subscription id, so it
+    /// cannot update the watched set in place — prefer the primitives when the set changes over
+    /// time (see <see cref="SubscribeForScriptsAsync"/>).
+    /// </summary>
+    async IAsyncEnumerable<HashSet<string>> GetVtxoToPollAsStream(IReadOnlySet<string> scripts,
+        [EnumeratorCancellation] CancellationToken token = default)
+    {
+        var subscriptionId = await SubscribeForScriptsAsync(scripts, subscriptionId: null, token);
+        await foreach (var changed in GetVtxoSubscriptionStreamAsync(subscriptionId, token))
+            yield return changed;
+    }
+
     IAsyncEnumerable<ArkVtxo> GetVtxoByScriptsAsSnapshot(IReadOnlySet<string> scripts,
         CancellationToken cancellationToken = default);
 

--- a/NArk.Core/Transport/RestClient/RestClientTransport.Vtxo.cs
+++ b/NArk.Core/Transport/RestClient/RestClientTransport.Vtxo.cs
@@ -79,25 +79,46 @@ public partial class RestClientTransport
         }
     }
 
-    public async IAsyncEnumerable<HashSet<string>> GetVtxoToPollAsStream(
-        IReadOnlySet<string> scripts,
-        [EnumeratorCancellation] CancellationToken token = default)
+    public async Task<string> SubscribeForScriptsAsync(IReadOnlySet<string> scripts,
+        string? subscriptionId, CancellationToken cancellationToken = default)
     {
-        // Step 1: Subscribe for scripts
-        var subReq = new { scripts = scripts.ToArray(), subscription_id = "" };
-        var subResponse = await _http.PostAsJsonAsync("/v1/indexer/script/subscribe", subReq, JsonOpts, token);
-        subResponse.EnsureSuccessStatusCode();
-        var subJson = await subResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOpts, token);
-        var subscriptionId = subJson.GetProperty("subscription_id").GetString()!;
+        var subReq = new { scripts = scripts.ToArray(), subscription_id = subscriptionId ?? "" };
+        var subResponse = await _http.PostAsJsonAsync("/v1/indexer/script/subscribe", subReq, JsonOpts, cancellationToken);
+        await EnsureSuccessWithBodyAsync(subResponse, "SubscribeForScripts", cancellationToken);
+        var subJson = await subResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOpts, cancellationToken);
+        return subJson.GetProperty("subscription_id").GetString()!;
+    }
 
-        // Step 2: Stream subscription events via SSE (gRPC-gateway server streaming → newline-delimited JSON)
+    public async Task UnsubscribeForScriptsAsync(string subscriptionId,
+        IReadOnlySet<string>? scripts, CancellationToken cancellationToken = default)
+    {
+        // Empty scripts ⇒ arkd removes all topics and tears the subscription down.
+        var req = new { subscription_id = subscriptionId, scripts = scripts?.ToArray() ?? [] };
+        var response = await _http.PostAsJsonAsync("/v1/indexer/script/unsubscribe", req, JsonOpts, cancellationToken);
+        await EnsureSuccessWithBodyAsync(response, "UnsubscribeForScripts", cancellationToken);
+    }
+
+    // Surfaces the server error body in the exception message so callers can detect arkd's
+    // "subscription <id> not found" (the trigger for recreating a GC'd subscription).
+    private static async Task EnsureSuccessWithBodyAsync(HttpResponseMessage response, string op, CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode)
+            return;
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+        throw new HttpRequestException($"{op} failed ({(int)response.StatusCode}): {body}");
+    }
+
+    public async IAsyncEnumerable<HashSet<string>> GetVtxoSubscriptionStreamAsync(string subscriptionId,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        // Stream subscription events via SSE (gRPC-gateway server streaming → newline-delimited JSON)
         using var stream = await _http.GetStreamAsync(
-            $"/v1/indexer/script/subscription/{subscriptionId}", token);
+            $"/v1/indexer/script/subscription/{subscriptionId}", cancellationToken);
         using var reader = new StreamReader(stream);
 
-        while (!token.IsCancellationRequested)
+        while (!cancellationToken.IsCancellationRequested)
         {
-            var line = await reader.ReadLineAsync(token);
+            var line = await reader.ReadLineAsync(cancellationToken);
             if (line is null) break; // Stream closed
             if (string.IsNullOrWhiteSpace(line)) continue;
 

--- a/NArk.Tests.End2End/PendingArkTransactionRecoveryTests.cs
+++ b/NArk.Tests.End2End/PendingArkTransactionRecoveryTests.cs
@@ -143,8 +143,14 @@ public class PendingArkTransactionRecoveryTests
         public Task<ArkServerInfo> GetServerInfoAsync(CancellationToken cancellationToken = default)
             => _inner.GetServerInfoAsync(cancellationToken);
 
-        public IAsyncEnumerable<HashSet<string>> GetVtxoToPollAsStream(IReadOnlySet<string> scripts, CancellationToken token = default)
-            => _inner.GetVtxoToPollAsStream(scripts, token);
+        public Task<string> SubscribeForScriptsAsync(IReadOnlySet<string> scripts, string? subscriptionId, CancellationToken cancellationToken = default)
+            => _inner.SubscribeForScriptsAsync(scripts, subscriptionId, cancellationToken);
+
+        public Task UnsubscribeForScriptsAsync(string subscriptionId, IReadOnlySet<string>? scripts, CancellationToken cancellationToken = default)
+            => _inner.UnsubscribeForScriptsAsync(subscriptionId, scripts, cancellationToken);
+
+        public IAsyncEnumerable<HashSet<string>> GetVtxoSubscriptionStreamAsync(string subscriptionId, CancellationToken cancellationToken = default)
+            => _inner.GetVtxoSubscriptionStreamAsync(subscriptionId, cancellationToken);
 
         public IAsyncEnumerable<ArkVtxo> GetVtxoByScriptsAsSnapshot(IReadOnlySet<string> scripts, CancellationToken cancellationToken = default)
             => _inner.GetVtxoByScriptsAsSnapshot(scripts, cancellationToken);

--- a/NArk.Tests/Sync/VtxoSynchronizationServiceViewUpdateTests.cs
+++ b/NArk.Tests/Sync/VtxoSynchronizationServiceViewUpdateTests.cs
@@ -8,125 +8,214 @@ using NSubstitute;
 namespace NArk.Tests.Sync;
 
 /// <summary>
-/// Covers how <see cref="VtxoSynchronizationService"/> keeps the set of polled
-/// scripts in sync with reality, and reproduces the "payment to a freshly-derived
-/// Active receive contract is not auto-detected" report: the safety-net poll must
-/// derive the active set fresh from the providers (provider-agnostic), so a stale
-/// or missed stream subscription can never hide a script from detection.
+/// Covers the in-place subscription model: a script-set change updates arkd's subscription
+/// via Subscribe/Unsubscribe without tearing the stream down, the subscription is recreated
+/// when arkd GC's it, an empty set tears it down, and the fresh-derive safety-net poll still
+/// reconciles a drifted/missed subscription.
 /// </summary>
 [TestFixture]
 public class VtxoSynchronizationServiceViewUpdateTests
 {
-    private const string ReceiveScript = "5120b98a01252ca661028207db2cb3475a84a67691a53c5321a78504c03a0e2e5866";
+    private const string ScriptA = "5120aa";
+    private const string ScriptB = "5120bb";
+    private const string ScriptC = "5120cc";
 
     private IVtxoStorage _vtxoStorage = null!;
     private IClientTransport _transport = null!;
+    private int _subCounter;
 
     [SetUp]
     public void SetUp()
     {
+        _subCounter = 0;
         _vtxoStorage = Substitute.For<IVtxoStorage>();
         _transport = Substitute.For<IClientTransport>();
         _transport.GetVtxoByScriptsAsSnapshot(
-                Arg.Any<IReadOnlySet<string>>(),
-                Arg.Any<DateTimeOffset?>(),
-                Arg.Any<DateTimeOffset?>(),
-                Arg.Any<CancellationToken>())
+                Arg.Any<IReadOnlySet<string>>(), Arg.Any<DateTimeOffset?>(),
+                Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
             .Returns(_ => System.Linq.AsyncEnumerable.Empty<ArkVtxo>());
-        // Keep the subscription stream open until its token is cancelled, so the
-        // service doesn't spin in graceful-restart while the test runs.
-        _transport.GetVtxoToPollAsStream(Arg.Any<IReadOnlySet<string>>(), Arg.Any<CancellationToken>())
+        // Create (subscriptionId == null) ⇒ a fresh id; add-to-existing ⇒ echo the id back.
+        _transport.SubscribeForScriptsAsync(Arg.Any<IReadOnlySet<string>>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(ci.ArgAt<string?>(1) ?? $"sub-{Interlocked.Increment(ref _subCounter)}"));
+        // Keep the stream open until cancelled, so an in-place update can't be mistaken for a restart.
+        _transport.GetVtxoSubscriptionStreamAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(ci => BlockingStream(ci.ArgAt<CancellationToken>(1)));
     }
 
     [Test]
-    public async Task NewlyActiveContract_ViaEvent_StartsBeingListenedTo()
+    public async Task InitialActiveSet_CreatesSubscriptionAndOpensStream()
     {
-        var contractScripts = new HashSet<string>();
-        var contractProvider = MakeProvider(() => contractScripts);
-
-        var sut = new VtxoSynchronizationService(
-            _vtxoStorage, _transport, [contractProvider], walletStorage: null);
+        var provider = MutableProvider(ScriptA, ScriptB);
+        await using var sut = New([provider]);
 
         await sut.StartAsync(CancellationToken.None);
+        await WaitForAsync(() => StreamOpenCount() >= 1);
 
-        // A new Receive contract is derived → contract store reports it active and
-        // raises ActiveScriptsChanged (mirrors EfCoreContractStorage.SaveContract).
-        contractScripts.Add(ReceiveScript);
-        contractProvider.ActiveScriptsChanged += Raise.Event<EventHandler>(contractProvider, EventArgs.Empty);
+        await _transport.Received().SubscribeForScriptsAsync(
+            Arg.Is<IReadOnlySet<string>>(s => s.SetEquals(new HashSet<string> { ScriptA, ScriptB })),
+            Arg.Is<string?>(id => id == null), Arg.Any<CancellationToken>());
+        Assert.That(StreamOpenCount(), Is.EqualTo(1));
+    }
 
-        await WaitForAsync(() => sut.ListenedScripts.Contains(ReceiveScript));
-        await sut.DisposeAsync();
+    [Test]
+    public async Task ScriptAdded_UpdatesInPlace_WithoutRestartingStream()
+    {
+        var scripts = new HashSet<string> { ScriptA };
+        var provider = MutableProvider(scripts);
+        await using var sut = New([provider]);
 
-        Assert.That(sut.ListenedScripts, Does.Contain(ReceiveScript));
+        await sut.StartAsync(CancellationToken.None);
+        await WaitForAsync(() => StreamOpenCount() >= 1);
+
+        // A new contract is derived → fires ActiveScriptsChanged.
+        scripts.Add(ScriptC);
+        provider.ActiveScriptsChanged += Raise.Event<EventHandler>(provider, EventArgs.Empty);
+
+        await WaitForAsync(() => CallCount(nameof(IClientTransport.SubscribeForScriptsAsync)) >= 2);
+
+        // The new script was added to the EXISTING subscription (non-null id), not a fresh one.
+        await _transport.Received().SubscribeForScriptsAsync(
+            Arg.Is<IReadOnlySet<string>>(s => s.SetEquals(new HashSet<string> { ScriptC })),
+            Arg.Is<string?>(id => id != null), Arg.Any<CancellationToken>());
+        // And the stream was never reopened — the watched set changed in place.
+        Assert.That(StreamOpenCount(), Is.EqualTo(1), "in-place update must not restart the stream");
+    }
+
+    [Test]
+    public async Task ScriptRemoved_UnsubscribesInPlace()
+    {
+        var scripts = new HashSet<string> { ScriptA, ScriptB };
+        var provider = MutableProvider(scripts);
+        await using var sut = New([provider]);
+
+        await sut.StartAsync(CancellationToken.None);
+        await WaitForAsync(() => StreamOpenCount() >= 1);
+
+        scripts.Remove(ScriptB);
+        provider.ActiveScriptsChanged += Raise.Event<EventHandler>(provider, EventArgs.Empty);
+
+        await WaitForAsync(() => CallCount(nameof(IClientTransport.UnsubscribeForScriptsAsync)) >= 1);
+
+        await _transport.Received().UnsubscribeForScriptsAsync(
+            Arg.Any<string>(),
+            Arg.Is<IReadOnlySet<string>?>(s => s != null && s.SetEquals(new HashSet<string> { ScriptB })),
+            Arg.Any<CancellationToken>());
+        Assert.That(StreamOpenCount(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task EmptyActiveSet_TearsSubscriptionDown()
+    {
+        var scripts = new HashSet<string> { ScriptA };
+        var provider = MutableProvider(scripts);
+        await using var sut = New([provider]);
+
+        await sut.StartAsync(CancellationToken.None);
+        await WaitForAsync(() => StreamOpenCount() >= 1);
+
+        scripts.Clear();
+        provider.ActiveScriptsChanged += Raise.Event<EventHandler>(provider, EventArgs.Empty);
+
+        await WaitForAsync(() => CallCount(nameof(IClientTransport.UnsubscribeForScriptsAsync)) >= 1);
+
+        // Unsubscribe-all (null scripts) tears the subscription down server-side.
+        await _transport.Received().UnsubscribeForScriptsAsync(
+            Arg.Any<string>(), Arg.Is<IReadOnlySet<string>?>(s => s == null), Arg.Any<CancellationToken>());
+        Assert.That(sut.ListenedScripts, Is.Empty);
+    }
+
+    [Test]
+    public async Task SubscriptionGarbageCollected_Recreates()
+    {
+        var scripts = new HashSet<string> { ScriptA };
+        var provider = MutableProvider(scripts);
+
+        // The in-place add (non-null subscription id) fails as if arkd GC'd the listener;
+        // the recreate (null id) succeeds.
+        _transport.SubscribeForScriptsAsync(Arg.Any<IReadOnlySet<string>>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(ci => ci.ArgAt<string?>(1) is null
+                ? Task.FromResult($"sub-{Interlocked.Increment(ref _subCounter)}")
+                : Task.FromException<string>(new InvalidOperationException("subscription sub-1 not found")));
+
+        await using var sut = New([provider]);
+        await sut.StartAsync(CancellationToken.None);
+        await WaitForAsync(() => StreamOpenCount() >= 1);
+
+        scripts.Add(ScriptC);
+        provider.ActiveScriptsChanged += Raise.Event<EventHandler>(provider, EventArgs.Empty);
+
+        // Recreate ⇒ a second create call (null id) and a second stream open on the new id.
+        await WaitForAsync(() => CreateCount() >= 2 && StreamOpenCount() >= 2);
+
+        Assert.That(CreateCount(), Is.GreaterThanOrEqualTo(2), "GC'd subscription must be recreated with a fresh id");
+        Assert.That(sut.ListenedScripts, Does.Contain(ScriptC));
     }
 
     [Test]
     public async Task StaleSubscription_SelfHealsViaRoutinePoll()
     {
-        // The bug: the contract is active in storage, but no ActiveScriptsChanged
-        // reached the service (lost/aborted event during the rapid swap setup), so
-        // the stream subscription never learned about it. The safety-net poll must
-        // still discover and poll the script, because it re-derives the active set
-        // fresh rather than trusting the (stale) subscription set.
-        var vtxoProvider = MakeProvider(() => new HashSet<string> { "5120aa", "5120bb" });
+        var vtxoProvider = MutableProvider(ScriptA, ScriptB);
         var contractScripts = new HashSet<string>();
-        var contractProvider = MakeProvider(() => contractScripts);
+        var contractProvider = MutableProvider(contractScripts);
 
-        var sut = new VtxoSynchronizationService(
-            _vtxoStorage, _transport, [vtxoProvider, contractProvider], walletStorage: null)
-        {
-            RoutinePollInterval = TimeSpan.FromMilliseconds(100)
-        };
-
+        await using var sut = New([vtxoProvider, contractProvider], TimeSpan.FromMilliseconds(100));
         await sut.StartAsync(CancellationToken.None);
         await WaitForAsync(() => sut.ListenedScripts.Count > 0);
 
-        // Contract becomes active WITHOUT raising the event.
-        contractScripts.Add(ReceiveScript);
+        // Contract becomes active WITHOUT raising the event — only the safety-net poll can find it.
+        contractScripts.Add(ScriptC);
 
-        // RoutinePoll re-derives the active set and must both poll the new script
-        // and resync the subscription to it.
-        await WaitForAsync(() => PolledScripts().Contains(ReceiveScript));
-        await WaitForAsync(() => sut.ListenedScripts.Contains(ReceiveScript));
-        await sut.DisposeAsync();
+        await WaitForAsync(() => PolledScripts().Contains(ScriptC));
+        await WaitForAsync(() => sut.ListenedScripts.Contains(ScriptC));
 
-        Assert.That(PolledScripts(), Does.Contain(ReceiveScript),
-            "The safety-net poll must derive the active set fresh and poll a contract the stream never subscribed to.");
-        Assert.That(sut.ListenedScripts, Does.Contain(ReceiveScript),
-            "RoutinePoll must resync the subscription to the freshly-discovered script.");
+        Assert.That(PolledScripts(), Does.Contain(ScriptC));
+        Assert.That(sut.ListenedScripts, Does.Contain(ScriptC));
     }
 
     [Test]
     public async Task OneProviderThrows_OtherProvidersStillPolled()
     {
-        var healthy = MakeProvider(() => new HashSet<string> { "5120aa" });
+        var healthy = MutableProvider(ScriptA);
         var faulty = Substitute.For<IActiveScriptsProvider>();
         faulty.GetActiveScripts(Arg.Any<CancellationToken>())
             .Returns<Task<HashSet<string>>>(_ => throw new InvalidOperationException("provider down"));
 
-        var sut = new VtxoSynchronizationService(
-            _vtxoStorage, _transport, [healthy, faulty], walletStorage: null)
-        {
-            RoutinePollInterval = TimeSpan.FromMilliseconds(100)
-        };
-
+        await using var sut = New([healthy, faulty], TimeSpan.FromMilliseconds(100));
         await sut.StartAsync(CancellationToken.None);
-        await WaitForAsync(() => PolledScripts().Contains("5120aa"));
-        await sut.DisposeAsync();
+        await WaitForAsync(() => PolledScripts().Contains(ScriptA));
 
-        Assert.That(sut.ListenedScripts, Does.Contain("5120aa"),
-            "A failing provider must be skipped, not abort the whole refresh and blank the set.");
-        Assert.That(PolledScripts(), Does.Contain("5120aa"));
+        Assert.That(sut.ListenedScripts, Does.Contain(ScriptA),
+            "a failing provider must be skipped, not blank the set");
     }
 
-    private static IActiveScriptsProvider MakeProvider(Func<HashSet<string>> currentScripts)
+    private VtxoSynchronizationService New(IActiveScriptsProvider[] providers, TimeSpan? pollInterval = null) =>
+        new(_vtxoStorage, _transport, providers, walletStorage: null)
+        {
+            // Default to a long interval so event-driven tests aren't perturbed by the poll.
+            RoutinePollInterval = pollInterval ?? TimeSpan.FromSeconds(30)
+        };
+
+    private static IActiveScriptsProvider MutableProvider(params string[] scripts)
+        => MutableProvider(new HashSet<string>(scripts));
+
+    private static IActiveScriptsProvider MutableProvider(HashSet<string> backing)
     {
         var provider = Substitute.For<IActiveScriptsProvider>();
         provider.GetActiveScripts(Arg.Any<CancellationToken>())
-            .Returns(_ => Task.FromResult(new HashSet<string>(currentScripts())));
+            .Returns(_ => Task.FromResult(new HashSet<string>(backing)));
         return provider;
     }
+
+    private int CallCount(string method) =>
+        _transport.ReceivedCalls().Count(c => c.GetMethodInfo().Name == method);
+
+    private int StreamOpenCount() => CallCount(nameof(IClientTransport.GetVtxoSubscriptionStreamAsync));
+
+    // Number of "create" calls = SubscribeForScriptsAsync with a null subscription id.
+    private int CreateCount() =>
+        _transport.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == nameof(IClientTransport.SubscribeForScriptsAsync))
+            .Count(c => c.GetArguments()[1] is null);
 
     private HashSet<string> PolledScripts()
     {

--- a/docs/articles/architecture.md
+++ b/docs/articles/architecture.md
@@ -54,6 +54,16 @@ Communication with the Arkade server (arkd) uses gRPC:
 - **`RestClientTransport`** — REST/JSON fallback (e.g., for browser environments)
 - **`CachingClientTransport`** — caches server info to reduce round-trips
 
+### VTXO script subscription (in-place updates)
+
+arkd's indexer subscription is a long-lived stream whose watched script set can be mutated while it stays open. The transport exposes this as three composable primitives:
+
+- `SubscribeForScriptsAsync(scripts, subscriptionId)` — create a subscription (`subscriptionId == null`) or **add** scripts to an existing one.
+- `UnsubscribeForScriptsAsync(subscriptionId, scripts)` — **remove** scripts (or all, tearing the subscription down, when `scripts == null`).
+- `GetVtxoSubscriptionStreamAsync(subscriptionId)` — open the server stream; scripts added/removed via the calls above are routed onto this already-open stream.
+
+`VtxoSynchronizationService` uses these to keep one stream open and update the watched set **in place** when contracts come and go, rather than tearing the stream down and resubscribing on every change. It recreates the subscription if arkd reports it gone (TTL after a disconnect), and tears it down when the active set is empty. The 5-second fresh-derive safety-net poll remains the backstop, so detection never depends on the stream surviving. (`GetVtxoToPollAsStream` is kept as a one-shot convenience built on these primitives.)
+
 ## Opt-In Feature Wiring
 
 A few subsystems are intentionally not registered by `AddArkCoreServices` because they need consumer-supplied configuration:


### PR DESCRIPTION
## Summary
The VTXO sync used to tear down the whole arkd `GetSubscription` stream and create a **fresh** subscription on every script-set change (`SubscribeForScripts{subscription_id:""}` → new `GetSubscription`). arkd's subscription is **mutable while streaming** (the proto says so, and the server routes events from a per-subscription channel whose topic map is mutated under lock), so this churn is avoidable — and the teardown/recreate window is exactly when a pushed event can slip through.

## Transport
Split the monolithic `GetVtxoToPollAsStream` into three composable primitives on `IClientTransport` (gRPC + REST + caching wrapper):
- `SubscribeForScriptsAsync(scripts, subscriptionId)` — create (`null` id) or **add** to an existing subscription.
- `UnsubscribeForScriptsAsync(subscriptionId, scripts)` — **remove** a subset, or all (tear down) when `null`.
- `GetVtxoSubscriptionStreamAsync(subscriptionId)` — the long-lived stream; in-place add/remove are routed onto it.

`GetVtxoToPollAsStream` is kept as a one-shot convenience **default** built on these primitives, so external callers are unaffected.

## Sync service
`VtxoSynchronizationService` now keeps **one** stream open via a supervisor loop and mutates the watched set in place:
- A contract appearing/disappearing issues `Subscribe`/`Unsubscribe` deltas — **no stream restart**.
- Reconnects on the **same** subscription id; **recreates** it if arkd reports it gone (TTL after a disconnect — detected via the "subscription … not found" error, surfaced over both gRPC and REST).
- **Tears down** the subscription when the active set is empty.
- Keeps the 5-second **fresh-derive safety-net poll** (from #102) as the backstop, so detection never depends on the stream surviving.
- A failing provider in the active-set derivation is still isolated.

Design decisions confirmed with the maintainer: reconnect-same-id (recreate only on not-found), keep the poll backstop, tear down on empty.

## Test plan
- [x] `dotnet build NArk.sln` — 0 errors
- [x] `dotnet test NArk.Tests` — **404/404** green
- [x] 13 `VtxoSynchronizationService` tests incl. in-place add (asserts the stream is opened exactly once), in-place remove, GC recreate, empty teardown, poll self-heal, provider isolation, cold-start cursor
- [ ] CI green on this PR