### PR TITLE
feat(swaps): BOLT 12 submarine swap support (Arkade → Lightning offer)

### DIFF
--- a/NArk.Swaps/Bolt12/Bolt12InvoiceParser.cs
+++ b/NArk.Swaps/Bolt12/Bolt12InvoiceParser.cs
@@ -1,0 +1,136 @@
+using NBitcoin.DataEncoders;
+
+namespace NArk.Swaps.Bolt12;
+
+/// <summary>
+/// Minimal parser for BOLT 12 invoice strings (<c>lni1…</c>).
+/// Decodes the bech32m envelope and walks the TLV stream to extract
+/// the fields we need for swap creation, without requiring a full
+/// BOLT 12 library.
+/// </summary>
+internal static class Bolt12InvoiceParser
+{
+    // BOLT 12 invoice TLV field types (bolt12.md, "Invoice TLV Stream")
+    private const ulong InvoicePaymentHashType = 168; // 0xA8
+
+    private const string InvoiceHrpPrefix = "lni";
+    private const string OfferHrpPrefix = "lno";
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="s"/> looks like a BOLT 12
+    /// invoice (<c>lni1…</c>).
+    /// </summary>
+    public static bool IsBolt12Invoice(string s) =>
+        !string.IsNullOrEmpty(s) &&
+        s.StartsWith(InvoiceHrpPrefix + "1", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="s"/> looks like a BOLT 12
+    /// offer (<c>lno1…</c>).
+    /// </summary>
+    public static bool IsBolt12Offer(string s) =>
+        !string.IsNullOrEmpty(s) &&
+        s.StartsWith(OfferHrpPrefix + "1", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Extracts the 32-byte SHA-256 payment hash from a BOLT 12 invoice string.
+    /// The invoice must be bech32m-encoded and contain a TLV type-168 record.
+    /// </summary>
+    /// <param name="bolt12Invoice">
+    /// A BOLT 12 invoice string with an <c>lni1</c> prefix.
+    /// </param>
+    /// <returns>32-byte payment hash.</returns>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="bolt12Invoice"/> is null or whitespace.
+    /// </exception>
+    /// <exception cref="FormatException">
+    /// The string is not a valid BOLT 12 invoice, uses wrong bech32 variant,
+    /// or does not contain a payment hash TLV record.
+    /// </exception>
+    public static byte[] ExtractPaymentHash(string bolt12Invoice)
+    {
+        if (string.IsNullOrWhiteSpace(bolt12Invoice))
+            throw new ArgumentException("Invoice must not be empty.", nameof(bolt12Invoice));
+
+        var lower = bolt12Invoice.ToLowerInvariant();
+
+        if (!lower.StartsWith(InvoiceHrpPrefix + "1", StringComparison.Ordinal))
+            throw new FormatException(
+                $"Expected a BOLT 12 invoice (lni1…). " +
+                $"Got: '{lower[..Math.Min(8, lower.Length)]}…'");
+
+        var hrp = lower[..lower.IndexOf('1')];
+        var encoder = Encoders.Bech32(hrp);
+        encoder.StrictLength = false;
+        encoder.SquashBytes = true;
+
+        byte[] tlv;
+        try
+        {
+            tlv = encoder.DecodeDataRaw(lower, out var encodingType);
+            if (encodingType != Bech32EncodingType.BECH32M)
+                throw new FormatException("BOLT 12 invoice must use bech32m encoding.");
+        }
+        catch (FormatException) { throw; }
+        catch (Exception ex)
+        {
+            throw new FormatException("Failed to decode BOLT 12 invoice envelope.", ex);
+        }
+
+        var hash = FindTlvRecord(tlv, InvoicePaymentHashType);
+        if (hash is null)
+            throw new FormatException(
+                $"Payment hash (TLV type {InvoicePaymentHashType}) not found in BOLT 12 invoice.");
+
+        if (hash.Length != 32)
+            throw new FormatException(
+                $"Payment hash TLV record has unexpected length {hash.Length} (expected 32).");
+
+        return hash;
+    }
+
+    /// <summary>
+    /// Scans a TLV byte stream and returns the value bytes of the first record
+    /// matching <paramref name="targetType"/>, or <c>null</c> if not found.
+    /// Records are encoded as [type: BigSize][length: BigSize][value: bytes].
+    /// </summary>
+    internal static byte[]? FindTlvRecord(byte[] tlv, ulong targetType)
+    {
+        var pos = 0;
+        while (pos < tlv.Length)
+        {
+            var type = ReadBigSize(tlv, ref pos);
+            if (pos >= tlv.Length) break;
+            var length = (int)ReadBigSize(tlv, ref pos);
+            if (pos + length > tlv.Length) break;
+
+            if (type == targetType)
+                return tlv[pos..(pos + length)];
+
+            pos += length;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Reads one Lightning BigSize-encoded <c>ulong</c> from <paramref name="data"/>
+    /// at <paramref name="pos"/> and advances <paramref name="pos"/> past it.
+    /// Encoding: 1 byte if value ≤ 0xFC, 3 bytes (0xFD + uint16-BE) for ≤ 0xFFFF,
+    /// 5 bytes (0xFE + uint32-BE) for ≤ 0xFFFFFFFF, 9 bytes (0xFF + uint64-BE) otherwise.
+    /// </summary>
+    internal static ulong ReadBigSize(byte[] data, ref int pos)
+    {
+        var b = data[pos++];
+        return b switch
+        {
+            <= 0xFC => b,
+            0xFD => (ulong)data[pos++] << 8 | data[pos++],
+            0xFE => (ulong)data[pos++] << 24 | (ulong)data[pos++] << 16
+                    | (ulong)data[pos++] << 8 | data[pos++],
+            _ => (ulong)data[pos++] << 56 | (ulong)data[pos++] << 48
+                 | (ulong)data[pos++] << 40 | (ulong)data[pos++] << 32
+                 | (ulong)data[pos++] << 24 | (ulong)data[pos++] << 16
+                 | (ulong)data[pos++] << 8 | data[pos++]
+        };
+    }
+}

--- a/NArk.Swaps/Bolt12/Bolt12InvoiceParser.cs
+++ b/NArk.Swaps/Bolt12/Bolt12InvoiceParser.cs
@@ -1,24 +1,48 @@
-using NBitcoin.DataEncoders;
-
 namespace NArk.Swaps.Bolt12;
 
 /// <summary>
-/// Minimal parser for BOLT 12 invoice strings (<c>lni1…</c>).
-/// Decodes the bech32m envelope and walks the TLV stream to extract
-/// the fields we need for swap creation, without requiring a full
-/// BOLT 12 library.
+/// Minimal parser for BOLT 12 invoice strings (<c>lni1…</c>) and offer strings (<c>lno1…</c>).
+/// Decodes the bech32-without-checksum envelope and walks the TLV stream to extract
+/// the fields needed for swap creation, without requiring a full BOLT 12 library.
 /// </summary>
+/// <remarks>
+/// BOLT 12 encoding uses bech32 <em>without</em> a checksum — unlike segwit addresses
+/// (bech32) or Taproot (bech32m), there are no checksum bytes appended. See
+/// https://github.com/lightning/bolts/blob/master/12-offer-encoding.md §3.
+///
+/// <b>Verification:</b> <see cref="VerifyInvoiceMatchesOffer"/> checks that
+/// <c>invoice_node_id</c> (TLV 176) equals <c>offer_issuer_id</c> (TLV 22), as required
+/// by the BOLT 12 spec. This covers offers with an explicit issuer key. Offers that
+/// expose only blinded paths (no <c>offer_issuer_id</c>) cannot be verified with a pubkey
+/// comparison alone; full Merkle-root verification would be needed for those.
+/// </remarks>
 internal static class Bolt12InvoiceParser
 {
-    // BOLT 12 invoice TLV field types (bolt12.md, "Invoice TLV Stream")
-    private const ulong InvoicePaymentHashType = 168; // 0xA8
+    // BOLT 12 TLV field types (bolt12.md).
+    private const ulong InvoicePaymentHashType = 168; // 0xA8 — invoice_payment_hash
+    private const ulong InvoiceNodeIdType       = 176; // 0xB0 — invoice_node_id
+    private const ulong OfferIssuerIdType       =  22; // 0x16 — offer_issuer_id
 
     private const string InvoiceHrpPrefix = "lni";
     private const string OfferHrpPrefix = "lno";
 
+    // Standard bech32 alphabet (same for bech32, bech32m, and no-checksum).
+    private const string Bech32Alphabet = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+    private static readonly byte[] Bech32CharMap = BuildCharMap();
+
+    private static byte[] BuildCharMap()
+    {
+        var map = new byte[128];
+        Array.Fill(map, (byte)255);
+        for (var i = 0; i < Bech32Alphabet.Length; i++)
+            map[(int)Bech32Alphabet[i]] = (byte)i;
+        return map;
+    }
+
     /// <summary>
     /// Returns <c>true</c> when <paramref name="s"/> looks like a BOLT 12
-    /// invoice (<c>lni1…</c>).
+    /// invoice (<c>lni1…</c>). Network-agnostic: both mainnet and testnet
+    /// invoices use the same <c>lni</c> HRP.
     /// </summary>
     public static bool IsBolt12Invoice(string s) =>
         !string.IsNullOrEmpty(s) &&
@@ -26,7 +50,8 @@ internal static class Bolt12InvoiceParser
 
     /// <summary>
     /// Returns <c>true</c> when <paramref name="s"/> looks like a BOLT 12
-    /// offer (<c>lno1…</c>).
+    /// offer (<c>lno1…</c>). Network-agnostic: both mainnet and testnet
+    /// offers use the same <c>lno</c> HRP.
     /// </summary>
     public static bool IsBolt12Offer(string s) =>
         !string.IsNullOrEmpty(s) &&
@@ -34,7 +59,8 @@ internal static class Bolt12InvoiceParser
 
     /// <summary>
     /// Extracts the 32-byte SHA-256 payment hash from a BOLT 12 invoice string.
-    /// The invoice must be bech32m-encoded and contain a TLV type-168 record.
+    /// The invoice must be bech32-without-checksum encoded and contain a TLV
+    /// type-168 record.
     /// </summary>
     /// <param name="bolt12Invoice">
     /// A BOLT 12 invoice string with an <c>lni1</c> prefix.
@@ -44,8 +70,8 @@ internal static class Bolt12InvoiceParser
     /// <paramref name="bolt12Invoice"/> is null or whitespace.
     /// </exception>
     /// <exception cref="FormatException">
-    /// The string is not a valid BOLT 12 invoice, uses wrong bech32 variant,
-    /// or does not contain a payment hash TLV record.
+    /// The string is not a valid BOLT 12 invoice or does not contain a
+    /// payment hash TLV record.
     /// </exception>
     public static byte[] ExtractPaymentHash(string bolt12Invoice)
     {
@@ -59,17 +85,10 @@ internal static class Bolt12InvoiceParser
                 $"Expected a BOLT 12 invoice (lni1…). " +
                 $"Got: '{lower[..Math.Min(8, lower.Length)]}…'");
 
-        var hrp = lower[..lower.IndexOf('1')];
-        var encoder = Encoders.Bech32(hrp);
-        encoder.StrictLength = false;
-        encoder.SquashBytes = true;
-
         byte[] tlv;
         try
         {
-            tlv = encoder.DecodeDataRaw(lower, out var encodingType);
-            if (encodingType != Bech32EncodingType.BECH32M)
-                throw new FormatException("BOLT 12 invoice must use bech32m encoding.");
+            tlv = DecodeBolt12Bech32(lower);
         }
         catch (FormatException) { throw; }
         catch (Exception ex)
@@ -88,6 +107,203 @@ internal static class Bolt12InvoiceParser
 
         return hash;
     }
+
+    /// <summary>
+    /// Extracts the 33-byte compressed public key from the <c>invoice_node_id</c>
+    /// field (TLV type 176) of a BOLT 12 invoice.
+    /// </summary>
+    /// <param name="bolt12Invoice">A BOLT 12 invoice string with an <c>lni1</c> prefix.</param>
+    /// <returns>33-byte compressed public key.</returns>
+    /// <exception cref="FormatException">
+    /// The string is not a valid BOLT 12 invoice or does not contain <c>invoice_node_id</c>.
+    /// </exception>
+    public static byte[] ExtractNodeId(string bolt12Invoice)
+    {
+        if (string.IsNullOrWhiteSpace(bolt12Invoice))
+            throw new ArgumentException("Invoice must not be empty.", nameof(bolt12Invoice));
+
+        var lower = bolt12Invoice.ToLowerInvariant();
+        if (!lower.StartsWith(InvoiceHrpPrefix + "1", StringComparison.Ordinal))
+            throw new FormatException(
+                $"Expected a BOLT 12 invoice (lni1…). Got: '{lower[..Math.Min(8, lower.Length)]}…'");
+
+        var tlv = DecodeBolt12Bech32(lower);
+        var nodeId = FindTlvRecord(tlv, InvoiceNodeIdType);
+
+        if (nodeId is null)
+            throw new FormatException(
+                $"invoice_node_id (TLV type {InvoiceNodeIdType}) not found in BOLT 12 invoice.");
+        if (nodeId.Length != 33)
+            throw new FormatException(
+                $"invoice_node_id TLV record has unexpected length {nodeId.Length} (expected 33).");
+
+        return nodeId;
+    }
+
+    /// <summary>
+    /// Extracts the 33-byte compressed public key from the <c>offer_issuer_id</c>
+    /// field (TLV type 22) of a BOLT 12 offer.
+    /// Returns <c>null</c> when the offer uses only blinded paths and carries no
+    /// explicit issuer key.
+    /// </summary>
+    /// <param name="bolt12Offer">A BOLT 12 offer string with an <c>lno1</c> prefix.</param>
+    /// <returns>33-byte compressed public key, or <c>null</c>.</returns>
+    /// <exception cref="FormatException">
+    /// The string is not a valid BOLT 12 offer, or the <c>offer_issuer_id</c> field
+    /// has an unexpected length.
+    /// </exception>
+    public static byte[]? ExtractOfferIssuerId(string bolt12Offer)
+    {
+        if (string.IsNullOrWhiteSpace(bolt12Offer))
+            throw new ArgumentException("Offer must not be empty.", nameof(bolt12Offer));
+
+        var lower = bolt12Offer.ToLowerInvariant();
+        if (!lower.StartsWith(OfferHrpPrefix + "1", StringComparison.Ordinal))
+            throw new FormatException(
+                $"Expected a BOLT 12 offer (lno1…). Got: '{lower[..Math.Min(8, lower.Length)]}…'");
+
+        var tlv = DecodeBolt12Bech32(lower);
+        var issuerId = FindTlvRecord(tlv, OfferIssuerIdType);
+
+        if (issuerId is null) return null; // blinded-path-only offer
+        if (issuerId.Length != 33)
+            throw new FormatException(
+                $"offer_issuer_id TLV record has unexpected length {issuerId.Length} (expected 33).");
+
+        return issuerId;
+    }
+
+    /// <summary>
+    /// Verifies that <paramref name="bolt12Invoice"/> was issued for
+    /// <paramref name="bolt12Offer"/> by asserting that
+    /// <c>invoice_node_id</c> (TLV 176) equals <c>offer_issuer_id</c> (TLV 22).
+    /// </summary>
+    /// <remarks>
+    /// Per BOLT 12 §Invoice: "if <c>offer_issuer_id</c> is present, MUST set
+    /// <c>invoice_node_id</c> to <c>offer_issuer_id</c>." Callers MUST reject the
+    /// invoice when this check fails — the invoice may have been substituted by
+    /// a man-in-the-middle (e.g. Boltz acting as the offer resolver).
+    ///
+    /// When the offer carries no explicit <c>offer_issuer_id</c> (blinded-path-only
+    /// offers), this method returns without error; full Merkle-root verification
+    /// would be needed to authenticate such invoices.
+    /// </remarks>
+    /// <param name="bolt12Invoice">The fetched BOLT 12 invoice (<c>lni1…</c>).</param>
+    /// <param name="bolt12Offer">The original BOLT 12 offer (<c>lno1…</c>) the invoice was requested for.</param>
+    /// <exception cref="FormatException">
+    /// Either string is not valid BOLT 12, or the invoice is missing <c>invoice_node_id</c>.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// <c>invoice_node_id</c> does not match <c>offer_issuer_id</c> — the invoice
+    /// was not issued by the offer's owner.
+    /// </exception>
+    public static void VerifyInvoiceMatchesOffer(string bolt12Invoice, string bolt12Offer)
+    {
+        var offerIssuerId = ExtractOfferIssuerId(bolt12Offer);
+        if (offerIssuerId is null) return; // blinded-path-only offer, cannot verify
+
+        var invoiceNodeId = ExtractNodeId(bolt12Invoice);
+
+        if (!invoiceNodeId.AsSpan().SequenceEqual(offerIssuerId))
+            throw new InvalidOperationException(
+                "BOLT 12 invoice_node_id does not match offer_issuer_id — " +
+                "the invoice was not issued by the offer's owner.");
+    }
+
+    // ─── Bech32 without-checksum codec ────────────────────────────────────────
+
+    /// <summary>
+    /// Decodes a bech32-without-checksum string (BOLT 12 encoding) and returns
+    /// the raw 8-bit byte payload. The HRP and the <c>1</c> separator are
+    /// stripped; no checksum is expected or validated.
+    /// </summary>
+    internal static byte[] DecodeBolt12Bech32(string lower)
+    {
+        var sep = lower.LastIndexOf('1');
+        if (sep < 0)
+            throw new FormatException("BOLT 12 string has no '1' separator.");
+
+        var dataPart = lower[(sep + 1)..];
+        if (dataPart.Length == 0)
+            throw new FormatException("BOLT 12 string has empty data part.");
+
+        var values = new byte[dataPart.Length];
+        for (var i = 0; i < dataPart.Length; i++)
+        {
+            var c = dataPart[i];
+            var v = c < 128 ? Bech32CharMap[(int)c] : (byte)255;
+            if (v == 255)
+                throw new FormatException(
+                    $"Invalid bech32 character '{c}' at position {sep + 1 + i}.");
+            values[i] = v;
+        }
+
+        return ConvertBits(values, fromBits: 5, toBits: 8);
+    }
+
+    /// <summary>
+    /// Encodes raw bytes as a bech32-without-checksum string.
+    /// Used by tests to construct synthetic BOLT 12 invoice/offer strings.
+    /// </summary>
+    internal static string EncodeBolt12Bech32(string hrp, byte[] data)
+    {
+        var fiveBit = ConvertBitsEncode(data);
+        var chars = new char[hrp.Length + 1 + fiveBit.Length];
+        hrp.ToLowerInvariant().CopyTo(0, chars, 0, hrp.Length);
+        chars[hrp.Length] = '1';
+        for (var i = 0; i < fiveBit.Length; i++)
+            chars[hrp.Length + 1 + i] = Bech32Alphabet[fiveBit[i]];
+        return new string(chars);
+    }
+
+    private static byte[] ConvertBits(byte[] data, int fromBits, int toBits)
+    {
+        var acc = 0;
+        var bits = 0;
+        var result = new List<byte>(data.Length * fromBits / toBits + 1);
+        var maxVal = (1 << toBits) - 1;
+
+        foreach (var v in data)
+        {
+            acc = (acc << fromBits) | v;
+            bits += fromBits;
+            while (bits >= toBits)
+            {
+                bits -= toBits;
+                result.Add((byte)((acc >> bits) & maxVal));
+            }
+        }
+
+        // Remaining bits must be zero padding and less than fromBits.
+        if (bits >= fromBits || ((acc << (toBits - bits)) & maxVal) != 0)
+            throw new FormatException("BOLT 12 bech32 data has invalid padding.");
+
+        return result.ToArray();
+    }
+
+    private static byte[] ConvertBitsEncode(byte[] data)
+    {
+        var acc = 0;
+        var bits = 0;
+        var result = new List<byte>(data.Length * 8 / 5 + 1);
+
+        foreach (var v in data)
+        {
+            acc = (acc << 8) | v;
+            bits += 8;
+            while (bits >= 5)
+            {
+                bits -= 5;
+                result.Add((byte)((acc >> bits) & 0x1f));
+            }
+        }
+        if (bits > 0)
+            result.Add((byte)((acc << (5 - bits)) & 0x1f));
+
+        return result.ToArray();
+    }
+
+    // ─── TLV helpers ──────────────────────────────────────────────────────────
 
     /// <summary>
     /// Scans a TLV byte stream and returns the value bytes of the first record
@@ -115,8 +331,6 @@ internal static class Bolt12InvoiceParser
     /// <summary>
     /// Reads one Lightning BigSize-encoded <c>ulong</c> from <paramref name="data"/>
     /// at <paramref name="pos"/> and advances <paramref name="pos"/> past it.
-    /// Encoding: 1 byte if value ≤ 0xFC, 3 bytes (0xFD + uint16-BE) for ≤ 0xFFFF,
-    /// 5 bytes (0xFE + uint32-BE) for ≤ 0xFFFFFFFF, 9 bytes (0xFF + uint64-BE) otherwise.
     /// </summary>
     internal static ulong ReadBigSize(byte[] data, ref int pos)
     {

--- a/NArk.Swaps/Bolt12/Bolt12InvoiceParser.cs
+++ b/NArk.Swaps/Bolt12/Bolt12InvoiceParser.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+
 namespace NArk.Swaps.Bolt12;
 
 /// <summary>
@@ -10,11 +12,11 @@ namespace NArk.Swaps.Bolt12;
 /// (bech32) or Taproot (bech32m), there are no checksum bytes appended. See
 /// https://github.com/lightning/bolts/blob/master/12-offer-encoding.md §3.
 ///
-/// <b>Verification:</b> <see cref="VerifyInvoiceMatchesOffer"/> checks that
-/// <c>invoice_node_id</c> (TLV 176) equals <c>offer_issuer_id</c> (TLV 22), as required
-/// by the BOLT 12 spec. This covers offers with an explicit issuer key. Offers that
-/// expose only blinded paths (no <c>offer_issuer_id</c>) cannot be verified with a pubkey
-/// comparison alone; full Merkle-root verification would be needed for those.
+/// <b>Verification:</b> <see cref="VerifyInvoiceMatchesOffer"/> performs three checks
+/// to confirm an invoice was generated from the specified offer:
+/// (1) <c>invoice_node_id</c> must match <c>offer_issuer_id</c> or the final blinded
+/// path hop; (2) the Merkle root of offer-range TLV fields (types 2–22) must be
+/// identical in offer and invoice.
 /// </remarks>
 internal static class Bolt12InvoiceParser
 {
@@ -23,6 +25,10 @@ internal static class Bolt12InvoiceParser
     private const ulong InvoiceNodeIdType       = 176; // 0xB0 — invoice_node_id
     private const ulong OfferIssuerIdType       =  22; // 0x16 — offer_issuer_id
     private const ulong OfferPathsType          =  16; // 0x10 — offer_paths
+
+    // Offer-range TLV types: types 2–22 are offer fields embedded in invoices.
+    private const ulong OfferRangeMin = 2;
+    private const ulong OfferRangeMax = 22;
 
     private const string InvoiceHrpPrefix = "lni";
     private const string OfferHrpPrefix = "lno";
@@ -176,17 +182,18 @@ internal static class Bolt12InvoiceParser
 
     /// <summary>
     /// Verifies that <paramref name="bolt12Invoice"/> was issued for
-    /// <paramref name="bolt12Offer"/> using two checks per BOLT 12 §Invoice:
+    /// <paramref name="bolt12Offer"/> using three checks per BOLT 12 §Invoice:
     /// <list type="number">
     ///   <item>If the offer has an explicit <c>offer_issuer_id</c> (TLV 22),
     ///   <c>invoice_node_id</c> (TLV 176) must equal it.</item>
     ///   <item>Otherwise, if the offer has blinded paths (TLV 16),
     ///   <c>invoice_node_id</c> must equal the <c>blinded_node_id</c> of the
     ///   final hop in at least one of those paths.</item>
+    ///   <item>The BOLT 12 Merkle root of the offer-range TLV fields (types 2–22)
+    ///   in the invoice must equal the Merkle root computed from the same fields in
+    ///   the original offer — confirming the invoice was generated from this specific
+    ///   offer, not merely by the same key.</item>
     /// </list>
-    /// When the offer provides neither an issuer key nor blinded paths, the
-    /// method returns without error (the offer is unusually permissive; nothing
-    /// can be checked without a full BOLT 12 Merkle-root implementation).
     /// </summary>
     /// <param name="bolt12Invoice">The fetched BOLT 12 invoice (<c>lni1…</c>).</param>
     /// <param name="bolt12Offer">The original BOLT 12 offer (<c>lno1…</c>) the invoice was requested for.</param>
@@ -194,37 +201,61 @@ internal static class Bolt12InvoiceParser
     /// Either string is not valid BOLT 12, or the invoice is missing <c>invoice_node_id</c>.
     /// </exception>
     /// <exception cref="InvalidOperationException">
-    /// The invoice's signing key does not match the offer — the invoice was not
-    /// issued by the offer's owner.
+    /// The invoice's signing key does not match the offer, or the offer-range Merkle root
+    /// is inconsistent — the invoice was not generated from this offer.
     /// </exception>
     public static void VerifyInvoiceMatchesOffer(string bolt12Invoice, string bolt12Offer)
     {
-        var offerIssuerId = ExtractOfferIssuerId(bolt12Offer);
+        var offerTlv = DecodeBolt12Bech32(bolt12Offer.ToLowerInvariant());
+        var invoiceTlv = DecodeBolt12Bech32(bolt12Invoice.ToLowerInvariant());
+
+        var offerIssuerId = FindTlvRecord(offerTlv, OfferIssuerIdType);
         if (offerIssuerId is not null)
         {
             // Check 1: explicit issuer_id pubkey match.
-            var invoiceNodeId = ExtractNodeId(bolt12Invoice);
+            var invoiceNodeId = FindTlvRecord(invoiceTlv, InvoiceNodeIdType);
+            if (invoiceNodeId is null || invoiceNodeId.Length != 33)
+                throw new FormatException(
+                    $"invoice_node_id (TLV type {InvoiceNodeIdType}) not found or has wrong length in BOLT 12 invoice.");
             if (!invoiceNodeId.AsSpan().SequenceEqual(offerIssuerId))
                 throw new InvalidOperationException(
                     "BOLT 12 invoice_node_id does not match offer_issuer_id — " +
                     "the invoice was not issued by the offer's owner.");
-            return;
+        }
+        else
+        {
+            // Check 2: blinded-path offer — invoice_node_id must equal the
+            // blinded_node_id of the final hop in at least one of the offer's paths.
+            var pathsValue = FindTlvRecord(offerTlv, OfferPathsType);
+            if (pathsValue is not null && pathsValue.Length > 0)
+            {
+                var lastHops = ParseBlindedPathLastHops(pathsValue);
+                if (lastHops.Count > 0)
+                {
+                    var invoiceNodeIdBlinded = FindTlvRecord(invoiceTlv, InvoiceNodeIdType);
+                    if (invoiceNodeIdBlinded is null)
+                        throw new FormatException(
+                            $"invoice_node_id (TLV type {InvoiceNodeIdType}) not found in BOLT 12 invoice.");
+                    if (!lastHops.Any(hop => invoiceNodeIdBlinded.AsSpan().SequenceEqual(hop)))
+                        throw new InvalidOperationException(
+                            "BOLT 12 invoice_node_id does not match the final hop of any " +
+                            "blinded path in the offer — the invoice was not issued by the offer's owner.");
+                }
+            }
         }
 
-        // Check 2: blinded-path offer — invoice_node_id must equal the
-        // blinded_node_id of the final hop in at least one of the offer's paths.
-        var offerTlv = DecodeBolt12Bech32(bolt12Offer.ToLowerInvariant());
-        var pathsValue = FindTlvRecord(offerTlv, OfferPathsType);
-        if (pathsValue is null || pathsValue.Length == 0) return; // cannot verify
-
-        var lastHops = ParseBlindedPathLastHops(pathsValue);
-        if (lastHops.Count == 0) return; // cannot verify
-
-        var invoiceNodeIdBlinded = ExtractNodeId(bolt12Invoice);
-        if (!lastHops.Any(hop => invoiceNodeIdBlinded.AsSpan().SequenceEqual(hop)))
-            throw new InvalidOperationException(
-                "BOLT 12 invoice_node_id does not match the final hop of any " +
-                "blinded path in the offer — the invoice was not issued by the offer's owner.");
+        // Check 3: the Merkle root of offer-range TLV fields (types 2–22) must be
+        // identical in both the offer and the invoice, confirming the invoice was
+        // generated from this specific offer.
+        var offerRoot = ComputeOfferIdMerkleRoot(offerTlv);
+        if (offerRoot is not null)
+        {
+            var invoiceRoot = ComputeOfferIdMerkleRoot(invoiceTlv);
+            if (invoiceRoot is null || !offerRoot.AsSpan().SequenceEqual(invoiceRoot))
+                throw new InvalidOperationException(
+                    "BOLT 12 invoice offer_id (Merkle root of offer-range TLVs 2–22) does not match " +
+                    "the original offer — the invoice was not generated from this offer.");
+        }
     }
 
     /// <summary>
@@ -418,6 +449,27 @@ internal static class Bolt12InvoiceParser
     }
 
     /// <summary>
+    /// Enumerates all TLV records in <paramref name="tlv"/>, yielding the type
+    /// and the full raw wire bytes (type BigSize + length BigSize + value) for
+    /// each record.
+    /// </summary>
+    internal static IEnumerable<(ulong Type, byte[] Raw)> EnumerateTlvRecordsRaw(byte[] tlv)
+    {
+        var pos = 0;
+        while (pos < tlv.Length)
+        {
+            var start = pos;
+            var type = ReadBigSize(tlv, ref pos);
+            if (pos >= tlv.Length) yield break;
+            var length = (int)ReadBigSize(tlv, ref pos);
+            if (pos + length > tlv.Length) yield break;
+            var raw = tlv[start..(pos + length)];
+            pos += length;
+            yield return (type, raw);
+        }
+    }
+
+    /// <summary>
     /// Reads one Lightning BigSize-encoded <c>ulong</c> from <paramref name="data"/>
     /// at <paramref name="pos"/> and advances <paramref name="pos"/> past it.
     /// </summary>
@@ -435,5 +487,112 @@ internal static class Bolt12InvoiceParser
                  | (ulong)data[pos++] << 24 | (ulong)data[pos++] << 16
                  | (ulong)data[pos++] << 8 | data[pos++]
         };
+    }
+
+    // ─── BOLT 12 Merkle hashing ───────────────────────────────────────────────
+
+    /// <summary>
+    /// Computes the BOLT 12 tagged hash:
+    /// <c>H(tag, msg) = SHA256(SHA256(tag) || SHA256(tag) || msg)</c>.
+    /// </summary>
+    private static byte[] TaggedHash(ReadOnlySpan<byte> tag, ReadOnlySpan<byte> msg)
+    {
+        var tagHash = SHA256.HashData(tag);
+        var input = new byte[64 + msg.Length];
+        tagHash.CopyTo(input.AsSpan(0));
+        tagHash.CopyTo(input.AsSpan(32));
+        msg.CopyTo(input.AsSpan(64));
+        return SHA256.HashData(input);
+    }
+
+    /// <summary>
+    /// Encodes <paramref name="val"/> as a Lightning BigSize byte sequence.
+    /// Used to produce the type bytes fed into the BOLT 12 Merkle nonce hash.
+    /// </summary>
+    private static byte[] BigSizeEncode(ulong val)
+    {
+        if (val <= 0xFC) return [(byte)val];
+        if (val <= 0xFFFF) return [0xFD, (byte)(val >> 8), (byte)val];
+        if (val <= 0xFFFF_FFFF)
+            return [0xFE, (byte)(val >> 24), (byte)(val >> 16), (byte)(val >> 8), (byte)val];
+        return
+        [
+            0xFF,
+            (byte)(val >> 56), (byte)(val >> 48), (byte)(val >> 40), (byte)(val >> 32),
+            (byte)(val >> 24), (byte)(val >> 16), (byte)(val >> 8), (byte)val,
+        ];
+    }
+
+    /// <summary>
+    /// Computes <c>H("LnBranch", min(a,b) || max(a,b))</c> — the branch node
+    /// hash used in BOLT 12 Merkle tree construction.
+    /// </summary>
+    private static byte[] BranchHash(byte[] a, byte[] b)
+    {
+        var cmp = a.AsSpan().SequenceCompareTo(b.AsSpan());
+        var (lo, hi) = cmp <= 0 ? (a, b) : (b, a);
+        var input = new byte[64];
+        lo.CopyTo(input.AsSpan(0));
+        hi.CopyTo(input.AsSpan(32));
+        return TaggedHash("LnBranch"u8, input);
+    }
+
+    /// <summary>
+    /// Computes the BOLT 12 Merkle root over an ordered list of TLV records
+    /// using the tagged-hash tree algorithm from BOLT 12 Appendix A.
+    /// </summary>
+    /// <remarks>
+    /// For each record <c>r</c>:
+    /// <list type="bullet">
+    ///   <item><c>leaf = H("LnLeaf", r_raw)</c></item>
+    ///   <item><c>nonce = H("LnNonce" || first_raw, BigSize(r.Type))</c></item>
+    ///   <item><c>pair = H("LnBranch", sort(leaf, nonce))</c></item>
+    /// </list>
+    /// The pair nodes are then combined bottom-up: adjacent pairs are merged with
+    /// <c>H("LnBranch", sort(…))</c>; an odd last node is promoted unchanged.
+    /// </remarks>
+    internal static byte[] ComputeMerkleRoot(IReadOnlyList<(ulong Type, byte[] Raw)> records)
+    {
+        if (records.Count == 0)
+            throw new ArgumentException("Record list must not be empty.", nameof(records));
+
+        var firstRaw = records[0].Raw;
+        var nonceTagPrefix = new byte[7 + firstRaw.Length];
+        "LnNonce"u8.CopyTo(nonceTagPrefix.AsSpan(0));
+        firstRaw.CopyTo(nonceTagPrefix.AsSpan(7));
+
+        // Compute per-record pair nodes.
+        var nodes = new List<byte[]>(records.Count);
+        foreach (var (type, raw) in records)
+        {
+            var leaf = TaggedHash("LnLeaf"u8, raw);
+            var nonce = TaggedHash(nonceTagPrefix, BigSizeEncode(type));
+            nodes.Add(BranchHash(leaf, nonce));
+        }
+
+        // Build tree: combine adjacent pairs; promote last unpaired node.
+        while (nodes.Count > 1)
+        {
+            var next = new List<byte[]>((nodes.Count + 1) / 2);
+            for (var i = 0; i + 1 < nodes.Count; i += 2)
+                next.Add(BranchHash(nodes[i], nodes[i + 1]));
+            if (nodes.Count % 2 == 1) next.Add(nodes[^1]);
+            nodes = next;
+        }
+
+        return nodes[0];
+    }
+
+    /// <summary>
+    /// Computes the BOLT 12 offer_id: the Merkle root of TLV records with types
+    /// in the offer range (2–22) from <paramref name="tlvStream"/>.
+    /// Returns <c>null</c> when no offer-range records are present.
+    /// </summary>
+    internal static byte[]? ComputeOfferIdMerkleRoot(byte[] tlvStream)
+    {
+        var offerRecords = EnumerateTlvRecordsRaw(tlvStream)
+            .Where(r => r.Type >= OfferRangeMin && r.Type <= OfferRangeMax)
+            .ToList();
+        return offerRecords.Count == 0 ? null : ComputeMerkleRoot(offerRecords);
     }
 }

--- a/NArk.Swaps/Bolt12/Bolt12InvoiceParser.cs
+++ b/NArk.Swaps/Bolt12/Bolt12InvoiceParser.cs
@@ -22,6 +22,7 @@ internal static class Bolt12InvoiceParser
     private const ulong InvoicePaymentHashType = 168; // 0xA8 — invoice_payment_hash
     private const ulong InvoiceNodeIdType       = 176; // 0xB0 — invoice_node_id
     private const ulong OfferIssuerIdType       =  22; // 0x16 — offer_issuer_id
+    private const ulong OfferPathsType          =  16; // 0x10 — offer_paths
 
     private const string InvoiceHrpPrefix = "lni";
     private const string OfferHrpPrefix = "lno";
@@ -175,39 +176,127 @@ internal static class Bolt12InvoiceParser
 
     /// <summary>
     /// Verifies that <paramref name="bolt12Invoice"/> was issued for
-    /// <paramref name="bolt12Offer"/> by asserting that
-    /// <c>invoice_node_id</c> (TLV 176) equals <c>offer_issuer_id</c> (TLV 22).
+    /// <paramref name="bolt12Offer"/> using two checks per BOLT 12 §Invoice:
+    /// <list type="number">
+    ///   <item>If the offer has an explicit <c>offer_issuer_id</c> (TLV 22),
+    ///   <c>invoice_node_id</c> (TLV 176) must equal it.</item>
+    ///   <item>Otherwise, if the offer has blinded paths (TLV 16),
+    ///   <c>invoice_node_id</c> must equal the <c>blinded_node_id</c> of the
+    ///   final hop in at least one of those paths.</item>
+    /// </list>
+    /// When the offer provides neither an issuer key nor blinded paths, the
+    /// method returns without error (the offer is unusually permissive; nothing
+    /// can be checked without a full BOLT 12 Merkle-root implementation).
     /// </summary>
-    /// <remarks>
-    /// Per BOLT 12 §Invoice: "if <c>offer_issuer_id</c> is present, MUST set
-    /// <c>invoice_node_id</c> to <c>offer_issuer_id</c>." Callers MUST reject the
-    /// invoice when this check fails — the invoice may have been substituted by
-    /// a man-in-the-middle (e.g. Boltz acting as the offer resolver).
-    ///
-    /// When the offer carries no explicit <c>offer_issuer_id</c> (blinded-path-only
-    /// offers), this method returns without error; full Merkle-root verification
-    /// would be needed to authenticate such invoices.
-    /// </remarks>
     /// <param name="bolt12Invoice">The fetched BOLT 12 invoice (<c>lni1…</c>).</param>
     /// <param name="bolt12Offer">The original BOLT 12 offer (<c>lno1…</c>) the invoice was requested for.</param>
     /// <exception cref="FormatException">
     /// Either string is not valid BOLT 12, or the invoice is missing <c>invoice_node_id</c>.
     /// </exception>
     /// <exception cref="InvalidOperationException">
-    /// <c>invoice_node_id</c> does not match <c>offer_issuer_id</c> — the invoice
-    /// was not issued by the offer's owner.
+    /// The invoice's signing key does not match the offer — the invoice was not
+    /// issued by the offer's owner.
     /// </exception>
     public static void VerifyInvoiceMatchesOffer(string bolt12Invoice, string bolt12Offer)
     {
         var offerIssuerId = ExtractOfferIssuerId(bolt12Offer);
-        if (offerIssuerId is null) return; // blinded-path-only offer, cannot verify
+        if (offerIssuerId is not null)
+        {
+            // Check 1: explicit issuer_id pubkey match.
+            var invoiceNodeId = ExtractNodeId(bolt12Invoice);
+            if (!invoiceNodeId.AsSpan().SequenceEqual(offerIssuerId))
+                throw new InvalidOperationException(
+                    "BOLT 12 invoice_node_id does not match offer_issuer_id — " +
+                    "the invoice was not issued by the offer's owner.");
+            return;
+        }
 
-        var invoiceNodeId = ExtractNodeId(bolt12Invoice);
+        // Check 2: blinded-path offer — invoice_node_id must equal the
+        // blinded_node_id of the final hop in at least one of the offer's paths.
+        var offerTlv = DecodeBolt12Bech32(bolt12Offer.ToLowerInvariant());
+        var pathsValue = FindTlvRecord(offerTlv, OfferPathsType);
+        if (pathsValue is null || pathsValue.Length == 0) return; // cannot verify
 
-        if (!invoiceNodeId.AsSpan().SequenceEqual(offerIssuerId))
+        var lastHops = ParseBlindedPathLastHops(pathsValue);
+        if (lastHops.Count == 0) return; // cannot verify
+
+        var invoiceNodeIdBlinded = ExtractNodeId(bolt12Invoice);
+        if (!lastHops.Any(hop => invoiceNodeIdBlinded.AsSpan().SequenceEqual(hop)))
             throw new InvalidOperationException(
-                "BOLT 12 invoice_node_id does not match offer_issuer_id — " +
-                "the invoice was not issued by the offer's owner.");
+                "BOLT 12 invoice_node_id does not match the final hop of any " +
+                "blinded path in the offer — the invoice was not issued by the offer's owner.");
+    }
+
+    /// <summary>
+    /// Parses the raw value of an <c>offer_paths</c> TLV record (type 16) and
+    /// returns the <c>blinded_node_id</c> of the final hop in each blinded path.
+    /// </summary>
+    /// <remarks>
+    /// Blinded path wire format (BOLT 4 §Route Blinding):
+    /// <code>
+    /// introduction_node  33 bytes (02/03 prefix) | 9 bytes sciddir
+    /// blinding_point     33 bytes
+    /// num_hops           u8
+    /// per hop:
+    ///   blinded_node_id  33 bytes
+    ///   enc_data_len     u16 big-endian
+    ///   enc_data         enc_data_len bytes
+    /// </code>
+    /// Multiple paths are concatenated in the TLV value.
+    /// </remarks>
+    internal static IReadOnlyList<byte[]> ParseBlindedPathLastHops(byte[] pathsValue)
+    {
+        var result = new List<byte[]>();
+        var pos = 0;
+        while (pos < pathsValue.Length)
+        {
+            var before = pos;
+            if (!TryReadBlindedPathLastHop(pathsValue, ref pos, out var lastHop) || lastHop is null)
+                break;
+            if (pos <= before) break; // guard against infinite loop on malformed data
+            result.Add(lastHop);
+        }
+        return result;
+    }
+
+    private static bool TryReadBlindedPathLastHop(byte[] data, ref int pos, out byte[]? lastHop)
+    {
+        lastHop = null;
+        var start = pos;
+
+        // introduction_node: 33 bytes when compressed pubkey (0x02/0x03 prefix),
+        // 9 bytes when sciddir (short_channel_id || direction).
+        if (pos >= data.Length) return false;
+        var introLen = data[pos] is 0x02 or 0x03 ? 33 : 9;
+        if (pos + introLen > data.Length) { pos = start; return false; }
+        pos += introLen;
+
+        // blinding_point: 33 bytes
+        if (pos + 33 > data.Length) { pos = start; return false; }
+        pos += 33;
+
+        // num_hops: u8
+        if (pos >= data.Length) { pos = start; return false; }
+        var numHops = data[pos++];
+
+        for (var hop = 0; hop < numHops; hop++)
+        {
+            if (pos + 33 > data.Length) { pos = start; return false; }
+            var nodeId = data[pos..(pos + 33)];
+            pos += 33;
+
+            // encrypted_recipient_data: u16 big-endian length prefix
+            if (pos + 2 > data.Length) { pos = start; return false; }
+            var encLen = (data[pos] << 8) | data[pos + 1];
+            pos += 2;
+
+            if (pos + encLen > data.Length) { pos = start; return false; }
+            pos += encLen;
+
+            lastHop = nodeId; // keep updating — last assignment is the final hop
+        }
+
+        return lastHop is not null;
     }
 
     // ─── Bech32 without-checksum codec ────────────────────────────────────────

--- a/NArk.Swaps/Bolt12/Bolt12InvoiceParser.cs
+++ b/NArk.Swaps/Bolt12/Bolt12InvoiceParser.cs
@@ -97,8 +97,7 @@ internal static class Bolt12InvoiceParser
         {
             tlv = DecodeBolt12Bech32(lower);
         }
-        catch (FormatException) { throw; }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not FormatException)
         {
             throw new FormatException("Failed to decode BOLT 12 invoice envelope.", ex);
         }
@@ -208,10 +207,12 @@ internal static class Bolt12InvoiceParser
     {
         var offerTlv = DecodeBolt12Bech32(bolt12Offer.ToLowerInvariant());
         var invoiceTlv = DecodeBolt12Bech32(bolt12Invoice.ToLowerInvariant());
+        var anyCheckPerformed = false;
 
         var offerIssuerId = FindTlvRecord(offerTlv, OfferIssuerIdType);
         if (offerIssuerId is not null)
         {
+            anyCheckPerformed = true;
             // Check 1: explicit issuer_id pubkey match.
             var invoiceNodeId = FindTlvRecord(invoiceTlv, InvoiceNodeIdType);
             if (invoiceNodeId is null || invoiceNodeId.Length != 33)
@@ -232,10 +233,15 @@ internal static class Bolt12InvoiceParser
                 var lastHops = ParseBlindedPathLastHops(pathsValue);
                 if (lastHops.Count > 0)
                 {
+                    anyCheckPerformed = true;
                     var invoiceNodeIdBlinded = FindTlvRecord(invoiceTlv, InvoiceNodeIdType);
                     if (invoiceNodeIdBlinded is null)
                         throw new FormatException(
                             $"invoice_node_id (TLV type {InvoiceNodeIdType}) not found in BOLT 12 invoice.");
+                    if (invoiceNodeIdBlinded.Length != 33)
+                        throw new FormatException(
+                            $"invoice_node_id (TLV type {InvoiceNodeIdType}) has wrong length " +
+                            $"{invoiceNodeIdBlinded.Length} (expected 33) in BOLT 12 invoice.");
                     if (!lastHops.Any(hop => invoiceNodeIdBlinded.AsSpan().SequenceEqual(hop)))
                         throw new InvalidOperationException(
                             "BOLT 12 invoice_node_id does not match the final hop of any " +
@@ -250,12 +256,18 @@ internal static class Bolt12InvoiceParser
         var offerRoot = ComputeOfferIdMerkleRoot(offerTlv);
         if (offerRoot is not null)
         {
+            anyCheckPerformed = true;
             var invoiceRoot = ComputeOfferIdMerkleRoot(invoiceTlv);
             if (invoiceRoot is null || !offerRoot.AsSpan().SequenceEqual(invoiceRoot))
                 throw new InvalidOperationException(
                     "BOLT 12 invoice offer_id (Merkle root of offer-range TLVs 2–22) does not match " +
                     "the original offer — the invoice was not generated from this offer.");
         }
+
+        if (!anyCheckPerformed)
+            throw new InvalidOperationException(
+                "BOLT 12 offer has no verifiable fields (no issuer_id, no blinded paths, " +
+                "no offer-range TLVs) — cannot confirm invoice authenticity.");
     }
 
     /// <summary>
@@ -475,17 +487,25 @@ internal static class Bolt12InvoiceParser
     /// </summary>
     internal static ulong ReadBigSize(byte[] data, ref int pos)
     {
+        if (pos >= data.Length)
+            throw new FormatException("Truncated BigSize: no bytes remaining.");
         var b = data[pos++];
         return b switch
         {
             <= 0xFC => b,
-            0xFD => (ulong)data[pos++] << 8 | data[pos++],
-            0xFE => (ulong)data[pos++] << 24 | (ulong)data[pos++] << 16
-                    | (ulong)data[pos++] << 8 | data[pos++],
-            _ => (ulong)data[pos++] << 56 | (ulong)data[pos++] << 48
-                 | (ulong)data[pos++] << 40 | (ulong)data[pos++] << 32
-                 | (ulong)data[pos++] << 24 | (ulong)data[pos++] << 16
-                 | (ulong)data[pos++] << 8 | data[pos++]
+            0xFD => pos + 2 <= data.Length
+                ? (ulong)data[pos++] << 8 | data[pos++]
+                : throw new FormatException("Truncated BigSize (expected 2 more bytes)."),
+            0xFE => pos + 4 <= data.Length
+                ? (ulong)data[pos++] << 24 | (ulong)data[pos++] << 16
+                  | (ulong)data[pos++] << 8 | data[pos++]
+                : throw new FormatException("Truncated BigSize (expected 4 more bytes)."),
+            _ => pos + 8 <= data.Length
+                ? (ulong)data[pos++] << 56 | (ulong)data[pos++] << 48
+                  | (ulong)data[pos++] << 40 | (ulong)data[pos++] << 32
+                  | (ulong)data[pos++] << 24 | (ulong)data[pos++] << 16
+                  | (ulong)data[pos++] << 8 | data[pos++]
+                : throw new FormatException("Truncated BigSize (expected 8 more bytes).")
         };
     }
 

--- a/NArk.Swaps/Boltz/BoltzSwapsService.cs
+++ b/NArk.Swaps/Boltz/BoltzSwapsService.cs
@@ -67,7 +67,7 @@ internal class BoltzSwapService(BoltzClient boltzClient, IClientTransport client
             throw new Exception(
                 $"Address mismatch! Expected {address.ToString(operatorTerms.Network.ChainName == ChainName.Mainnet)} got {response.Address}");
 
-        return new SubmarineSwapResult(vhtlcContract, response, address);
+        return new SubmarineSwapResult(vhtlcContract, response, address, invoice.ToString());
     }
 
     /// <summary>
@@ -149,7 +149,7 @@ internal class BoltzSwapService(BoltzClient boltzClient, IClientTransport client
                 $"Address mismatch — expected {address.ToString(operatorTerms.Network.ChainName == ChainName.Mainnet)}, " +
                 $"Boltz returned {response.Address}");
 
-        return new SubmarineSwapResult(vhtlcContract, response, address);
+        return new SubmarineSwapResult(vhtlcContract, response, address, fetchResponse.Invoice);
     }
 
     // Reverse Swaps

--- a/NArk.Swaps/Boltz/BoltzSwapsService.cs
+++ b/NArk.Swaps/Boltz/BoltzSwapsService.cs
@@ -103,6 +103,8 @@ internal class BoltzSwapService(BoltzClient boltzClient, IClientTransport client
         string currency = "BTC",
         CancellationToken cancellationToken = default)
     {
+        if (amountSats <= 0)
+            throw new ArgumentOutOfRangeException(nameof(amountSats), amountSats, "Amount must be positive.");
         if (!Bolt12InvoiceParser.IsBolt12Offer(offer))
             throw new ArgumentException(
                 $"Expected a BOLT 12 offer (lno1…), got: '{offer[..Math.Min(8, offer.Length)]}…'",
@@ -149,7 +151,8 @@ internal class BoltzSwapService(BoltzClient boltzClient, IClientTransport client
                 $"Address mismatch — expected {address.ToString(operatorTerms.Network.ChainName == ChainName.Mainnet)}, " +
                 $"Boltz returned {response.Address}");
 
-        return new SubmarineSwapResult(vhtlcContract, response, address, fetchResponse.Invoice);
+        var paymentHashHex = Convert.ToHexString(paymentHashBytes).ToLowerInvariant();
+        return new SubmarineSwapResult(vhtlcContract, response, address, fetchResponse.Invoice, paymentHashHex);
     }
 
     // Reverse Swaps

--- a/NArk.Swaps/Boltz/BoltzSwapsService.cs
+++ b/NArk.Swaps/Boltz/BoltzSwapsService.cs
@@ -3,8 +3,10 @@ using BTCPayServer.Lightning;
 using NArk.Abstractions.Extensions;
 using NArk.Core.Contracts;
 using NArk.Core.Extensions;
+using NArk.Swaps.Bolt12;
 using NArk.Swaps.Boltz.Client;
 using NArk.Swaps.Boltz.Models;
+using NArk.Swaps.Boltz.Models.Bolt12;
 using NArk.Swaps.Boltz.Models.Swaps.Chain;
 using NArk.Swaps.Boltz.Models.Swaps.Reverse;
 using NArk.Swaps.Boltz.Models.Swaps.Submarine;
@@ -25,7 +27,6 @@ internal class BoltzSwapService(BoltzClient boltzClient, IClientTransport client
     }
 
     // Submarine Swaps
-
     public async Task<SubmarineSwapResult> CreateSubmarineSwap(BOLT11PaymentRequest invoice, OutputDescriptor sender,
         CancellationToken cancellationToken = default)
     {
@@ -65,6 +66,88 @@ internal class BoltzSwapService(BoltzClient boltzClient, IClientTransport client
         if (response.Address != address.ToString(operatorTerms.Network.ChainName == ChainName.Mainnet))
             throw new Exception(
                 $"Address mismatch! Expected {address.ToString(operatorTerms.Network.ChainName == ChainName.Mainnet)} got {response.Address}");
+
+        return new SubmarineSwapResult(vhtlcContract, response, address);
+    }
+
+    /// <summary>
+    /// Creates a submarine swap (Arkade → Lightning) where the destination is a
+    /// BOLT 12 offer rather than a BOLT 11 invoice.
+    /// </summary>
+    /// <remarks>
+    /// The method first calls Boltz's
+    /// <c>POST /v2/lightning/{currency}/bolt12/fetch</c> to exchange the offer
+    /// for a BOLT 12 invoice, then extracts the payment hash from that invoice
+    /// and continues with the same VHTLC construction as the BOLT 11 path.
+    /// The returned <see cref="SubmarineSwapResult"/> is identical in structure
+    /// to the one produced by <see cref="CreateSubmarineSwap"/> — all downstream
+    /// monitoring and refund logic applies without modification.
+    /// </remarks>
+    /// <param name="offer">A BOLT 12 offer string (<c>lno1…</c>).</param>
+    /// <param name="amountSats">Amount to pay in satoshis.</param>
+    /// <param name="sender">
+    /// Output descriptor of the sender's key, used as the VHTLC refund key.
+    /// </param>
+    /// <param name="currency">
+    /// Lightning currency symbol passed to Boltz, defaults to <c>"BTC"</c>.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// A <see cref="SubmarineSwapResult"/> with the VHTLC contract, Boltz swap
+    /// details, and the Arkade lockup address.
+    /// </returns>
+    public async Task<SubmarineSwapResult> CreateSubmarineSwapBolt12(
+        string offer,
+        long amountSats,
+        OutputDescriptor sender,
+        string currency = "BTC",
+        CancellationToken cancellationToken = default)
+    {
+        if (!Bolt12InvoiceParser.IsBolt12Offer(offer))
+            throw new ArgumentException(
+                $"Expected a BOLT 12 offer (lno1…), got: '{offer[..Math.Min(8, offer.Length)]}…'",
+                nameof(offer));
+
+        var fetchResponse = await boltzClient.FetchBolt12InvoiceAsync(
+            currency,
+            new Bolt12FetchRequest { Offer = offer, Amount = amountSats },
+            cancellationToken);
+
+        Bolt12InvoiceParser.VerifyInvoiceMatchesOffer(fetchResponse.Invoice, offer);
+
+        var paymentHashBytes = Bolt12InvoiceParser.ExtractPaymentHash(fetchResponse.Invoice);
+        var hash = new uint160(Hashes.RIPEMD160(paymentHashBytes), false);
+
+        var extractedSender = OutputDescriptorHelpers.Extract(sender);
+        var operatorTerms = await clientTransport.GetServerInfoAsync(cancellationToken);
+
+        var response = await boltzClient.CreateSubmarineSwapAsync(new SubmarineRequest
+        {
+            Invoice = fetchResponse.Invoice,
+            RefundPublicKey =
+                (extractedSender.PubKey?.ToBytes() ?? extractedSender.XOnlyPubKey.ToBytes()).ToHexStringLower(),
+            From = "ARK",
+            To = "BTC",
+            ReferralId = boltzClient.ReferralId,
+        }, cancellationToken);
+
+        var vhtlcContract = new VHTLCContract(
+            server: operatorTerms.SignerKey,
+            sender: sender,
+            receiver: KeyExtensions.ParseOutputDescriptor(response.ClaimPublicKey, operatorTerms.Network),
+            hash: hash,
+            refundLocktime: new LockTime(response.TimeoutBlockHeights.Refund),
+            unilateralClaimDelay: ParseSequence(response.TimeoutBlockHeights.UnilateralClaim),
+            unilateralRefundDelay: ParseSequence(response.TimeoutBlockHeights.UnilateralRefund),
+            unilateralRefundWithoutReceiverDelay: ParseSequence(
+                response.TimeoutBlockHeights.UnilateralRefundWithoutReceiver)
+        );
+
+        var address = vhtlcContract.GetArkAddress();
+        if (response.Address != address.ToString(operatorTerms.Network.ChainName == ChainName.Mainnet))
+            throw new InvalidOperationException(
+                $"Address mismatch — expected {address.ToString(operatorTerms.Network.ChainName == ChainName.Mainnet)}, " +
+                $"Boltz returned {response.Address}");
 
         return new SubmarineSwapResult(vhtlcContract, response, address);
     }

--- a/NArk.Swaps/Boltz/Client/BoltzClient.Bolt12.cs
+++ b/NArk.Swaps/Boltz/Client/BoltzClient.Bolt12.cs
@@ -1,0 +1,30 @@
+using NArk.Swaps.Boltz.Models.Bolt12;
+
+namespace NArk.Swaps.Boltz.Client;
+
+public partial class BoltzClient
+{
+    /// <summary>
+    /// Fetches a BOLT 12 invoice from the given offer via
+    /// <c>POST /v2/lightning/{currency}/bolt12/fetch</c>.
+    /// </summary>
+    /// <param name="currency">
+    /// The Lightning currency symbol, e.g. <c>"BTC"</c>.
+    /// </param>
+    /// <param name="request">Offer string, amount in satoshis, and optional note.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// A <see cref="Bolt12FetchResponse"/> containing the BOLT 12 invoice
+    /// (<c>lni1…</c>) and an optional magic routing hint.
+    /// </returns>
+    /// <exception cref="HttpRequestException">
+    /// Thrown when the currency has no BOLT 12 support (HTTP 404) or when
+    /// Boltz could not reach the offer's node to obtain an invoice (HTTP 500).
+    /// </exception>
+    public virtual Task<Bolt12FetchResponse> FetchBolt12InvoiceAsync(
+        string currency,
+        Bolt12FetchRequest request,
+        CancellationToken ct = default)
+        => PostAsJsonAsync<Bolt12FetchRequest, Bolt12FetchResponse>(
+            $"v2/lightning/{currency}/bolt12/fetch", request, ct);
+}

--- a/NArk.Swaps/Boltz/Client/BoltzClient.Bolt12.cs
+++ b/NArk.Swaps/Boltz/Client/BoltzClient.Bolt12.cs
@@ -1,16 +1,125 @@
+using System.Net.Http.Json;
 using NArk.Swaps.Boltz.Models.Bolt12;
 
 namespace NArk.Swaps.Boltz.Client;
 
 public partial class BoltzClient
 {
+    // ─── Bolt12 offer bridge ───────────────────────────────────────────────────
+    // These endpoints are for operators who run a BOLT 12-capable Lightning node
+    // (CLN, LDK) and want incoming offer payments converted to Arkade VTXOs by
+    // Boltz. They are distinct from the submarine-swap fetch flow below.
+
+    /// <summary>
+    /// Retrieves the parameters needed to construct a BOLT 12 offer that routes
+    /// payments through Boltz to the specified receiving chain via
+    /// <c>GET /v2/lightning/{currency}/bolt12/{receiving}</c>.
+    /// </summary>
+    /// <param name="currency">Lightning currency, e.g. <c>"BTC"</c>.</param>
+    /// <param name="receiving">
+    /// Symbol of the chain that should receive the swapped funds, e.g. <c>"ARK"</c>.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>
+    /// <see cref="Bolt12OfferParams"/> containing the minimum CLTV delta.
+    /// </returns>
+    /// <exception cref="HttpRequestException">
+    /// Thrown when the currency has no BOLT 12 support (HTTP 404) or the
+    /// receiving symbol is not supported (HTTP 400).
+    /// </exception>
+    public virtual async Task<Bolt12OfferParams> GetBolt12OfferParamsAsync(
+        string currency,
+        string receiving,
+        CancellationToken ct = default)
+    {
+        var resp = await _httpClient.GetAsync($"v2/lightning/{currency}/bolt12/{receiving}", ct);
+        resp.EnsureSuccessStatusCode();
+        return (await resp.Content.ReadFromJsonAsync<Bolt12OfferParams>(ct))!;
+    }
+
+    /// <summary>
+    /// Registers a BOLT 12 offer with Boltz via
+    /// <c>POST /v2/lightning/{currency}/bolt12</c> so that payments to the offer
+    /// are converted to Arkade VTXOs.
+    /// </summary>
+    /// <param name="currency">Lightning currency, e.g. <c>"BTC"</c>.</param>
+    /// <param name="request">Offer string and optional webhook URL.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <exception cref="HttpRequestException">
+    /// Thrown on HTTP 400 (invalid request) or 404 (currency has no BOLT 12 support).
+    /// </exception>
+    public virtual async Task RegisterBolt12OfferAsync(
+        string currency,
+        Bolt12RegisterOfferRequest request,
+        CancellationToken ct = default)
+    {
+        var resp = await _httpClient.PostAsJsonAsync(
+            $"v2/lightning/{currency}/bolt12", request, JsonOptions, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            throw new HttpRequestException(body, null, resp.StatusCode);
+        }
+    }
+
+    /// <summary>
+    /// Updates the webhook URL of a registered BOLT 12 offer via
+    /// <c>PATCH /v2/lightning/{currency}/bolt12</c>.
+    /// </summary>
+    /// <param name="currency">Lightning currency, e.g. <c>"BTC"</c>.</param>
+    /// <param name="request">
+    /// Offer string, new webhook URL (or <c>null</c> to remove), and a Schnorr
+    /// signature authorising the change.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <exception cref="HttpRequestException">
+    /// Thrown on HTTP 400, 404, or 422 (invalid signature).
+    /// </exception>
+    public virtual async Task UpdateBolt12OfferAsync(
+        string currency,
+        Bolt12UpdateOfferRequest request,
+        CancellationToken ct = default)
+    {
+        var resp = await _httpClient.PatchAsJsonAsync(
+            $"v2/lightning/{currency}/bolt12", request, JsonOptions, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            throw new HttpRequestException(body, null, resp.StatusCode);
+        }
+    }
+
+    /// <summary>
+    /// Deletes a registered BOLT 12 offer via
+    /// <c>POST /v2/lightning/{currency}/bolt12/delete</c>.
+    /// </summary>
+    /// <param name="currency">Lightning currency, e.g. <c>"BTC"</c>.</param>
+    /// <param name="request">Offer string and a Schnorr signature authorising deletion.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <exception cref="HttpRequestException">
+    /// Thrown on HTTP 404 (offer not found or currency unsupported).
+    /// </exception>
+    public virtual async Task DeleteBolt12OfferAsync(
+        string currency,
+        Bolt12DeleteOfferRequest request,
+        CancellationToken ct = default)
+    {
+        var resp = await _httpClient.PostAsJsonAsync(
+            $"v2/lightning/{currency}/bolt12/delete", request, JsonOptions, ct);
+        if (!resp.IsSuccessStatusCode)
+        {
+            var body = await resp.Content.ReadAsStringAsync(ct);
+            throw new HttpRequestException(body, null, resp.StatusCode);
+        }
+    }
+
+    // ─── Bolt12 submarine (paying an offer) ───────────────────────────────────
+
     /// <summary>
     /// Fetches a BOLT 12 invoice from the given offer via
     /// <c>POST /v2/lightning/{currency}/bolt12/fetch</c>.
     /// </summary>
-    /// <param name="currency">
-    /// The Lightning currency symbol, e.g. <c>"BTC"</c>.
-    /// </param>
+    /// <param name="currency">Lightning currency, e.g. <c>"BTC"</c>.</param>
     /// <param name="request">Offer string, amount in satoshis, and optional note.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>

--- a/NArk.Swaps/Boltz/Models/Bolt12/Bolt12DeleteOfferRequest.cs
+++ b/NArk.Swaps/Boltz/Models/Bolt12/Bolt12DeleteOfferRequest.cs
@@ -1,0 +1,25 @@
+using System.Text.Json.Serialization;
+
+namespace NArk.Swaps.Boltz.Models.Bolt12;
+
+/// <summary>
+/// Request body for <c>POST /v2/lightning/{currency}/bolt12/delete</c>.
+/// Removes a previously registered BOLT 12 offer from Boltz.
+/// </summary>
+/// <remarks>
+/// <see cref="Signature"/> must be a Schnorr signature of the SHA-256 hash of
+/// the literal string <c>"DELETE"</c>, produced by the private key whose public
+/// key is embedded in <see cref="Offer"/>.
+/// </remarks>
+public class Bolt12DeleteOfferRequest
+{
+    /// <summary>The BOLT 12 offer to delete (<c>lno1…</c>).</summary>
+    [JsonPropertyName("offer")]
+    public required string Offer { get; set; }
+
+    /// <summary>
+    /// Schnorr signature authorising the deletion, as described in the remarks.
+    /// </summary>
+    [JsonPropertyName("signature")]
+    public required string Signature { get; set; }
+}

--- a/NArk.Swaps/Boltz/Models/Bolt12/Bolt12FetchRequest.cs
+++ b/NArk.Swaps/Boltz/Models/Bolt12/Bolt12FetchRequest.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace NArk.Swaps.Boltz.Models.Bolt12;
+
+/// <summary>
+/// Request body for <c>POST /v2/lightning/{currency}/bolt12/fetch</c>.
+/// Asks Boltz to fetch a BOLT 12 invoice from the given offer so the caller
+/// can use it in a submarine swap without needing a direct connection to the
+/// payee's Lightning node.
+/// </summary>
+public class Bolt12FetchRequest
+{
+    /// <summary>The BOLT 12 offer to fetch an invoice from (<c>lno1…</c>).</summary>
+    [JsonPropertyName("offer")]
+    public required string Offer { get; set; }
+
+    /// <summary>Amount in satoshis for the invoice that should be fetched.</summary>
+    [JsonPropertyName("amount")]
+    public required long Amount { get; set; }
+
+    /// <summary>Optional note to include in the invoice request.</summary>
+    [JsonPropertyName("note")]
+    public string? Note { get; set; }
+}

--- a/NArk.Swaps/Boltz/Models/Bolt12/Bolt12FetchRequest.cs
+++ b/NArk.Swaps/Boltz/Models/Bolt12/Bolt12FetchRequest.cs
@@ -14,9 +14,14 @@ public class Bolt12FetchRequest
     [JsonPropertyName("offer")]
     public required string Offer { get; set; }
 
-    /// <summary>Amount in satoshis for the invoice that should be fetched.</summary>
+    /// <summary>
+    /// Amount in satoshis for the invoice that should be fetched.
+    /// <c>null</c> when the offer already encodes a fixed amount — Boltz will
+    /// use the amount embedded in the offer.
+    /// </summary>
     [JsonPropertyName("amount")]
-    public required long Amount { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? Amount { get; set; }
 
     /// <summary>Optional note to include in the invoice request.</summary>
     [JsonPropertyName("note")]

--- a/NArk.Swaps/Boltz/Models/Bolt12/Bolt12FetchResponse.cs
+++ b/NArk.Swaps/Boltz/Models/Bolt12/Bolt12FetchResponse.cs
@@ -1,0 +1,25 @@
+using System.Text.Json.Serialization;
+
+namespace NArk.Swaps.Boltz.Models.Bolt12;
+
+/// <summary>
+/// Response from <c>POST /v2/lightning/{currency}/bolt12/fetch</c>.
+/// </summary>
+public class Bolt12FetchResponse
+{
+    /// <summary>
+    /// The fetched BOLT 12 invoice string (<c>lni1…</c>).
+    /// Pass this directly to <c>POST /v2/swap/submarine</c> as the
+    /// <c>invoice</c> field to initiate a submarine swap.
+    /// </summary>
+    [JsonPropertyName("invoice")]
+    public required string Invoice { get; set; }
+
+    /// <summary>
+    /// Optional magic routing hint returned by Boltz for BOLT 12 reverse swaps.
+    /// Contains a BIP-21 URI and a Schnorr signature for the embedded address.
+    /// May be <c>null</c> when the offer does not require a routing hint.
+    /// </summary>
+    [JsonPropertyName("magicRoutingHint")]
+    public Bolt12MagicRoutingHint? MagicRoutingHint { get; set; }
+}

--- a/NArk.Swaps/Boltz/Models/Bolt12/Bolt12MagicRoutingHint.cs
+++ b/NArk.Swaps/Boltz/Models/Bolt12/Bolt12MagicRoutingHint.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace NArk.Swaps.Boltz.Models.Bolt12;
+
+/// <summary>
+/// Magic routing hint included in a <see cref="Bolt12FetchResponse"/>.
+/// Corresponds to the <c>ReverseBip21</c> schema in the Boltz OpenAPI spec.
+/// </summary>
+public class Bolt12MagicRoutingHint
+{
+    /// <summary>BIP-21 URI for the reverse swap lockup address.</summary>
+    [JsonPropertyName("bip21")]
+    public string? Bip21 { get; set; }
+
+    /// <summary>
+    /// Schnorr signature of the address in the BIP-21, signed by the public
+    /// key embedded in the routing hint. Used by the payer to verify the hint.
+    /// </summary>
+    [JsonPropertyName("signature")]
+    public string? Signature { get; set; }
+}

--- a/NArk.Swaps/Boltz/Models/Bolt12/Bolt12OfferParams.cs
+++ b/NArk.Swaps/Boltz/Models/Bolt12/Bolt12OfferParams.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace NArk.Swaps.Boltz.Models.Bolt12;
+
+/// <summary>
+/// Response from <c>GET /v2/lightning/{currency}/bolt12/{receiving}</c>.
+/// Contains the parameters required when constructing a BOLT 12 offer that
+/// routes payments through Boltz to the specified receiving chain.
+/// </summary>
+public class Bolt12OfferParams
+{
+    /// <summary>
+    /// Minimum CLTV (CheckLockTimeVerify) delta that the offer must encode.
+    /// Payers use this to ensure the payment route has sufficient time to settle.
+    /// </summary>
+    [JsonPropertyName("minCltv")]
+    public int MinCltv { get; set; }
+}

--- a/NArk.Swaps/Boltz/Models/Bolt12/Bolt12RegisterOfferRequest.cs
+++ b/NArk.Swaps/Boltz/Models/Bolt12/Bolt12RegisterOfferRequest.cs
@@ -1,0 +1,29 @@
+using System.Text.Json.Serialization;
+
+namespace NArk.Swaps.Boltz.Models.Bolt12;
+
+/// <summary>
+/// Request body for <c>POST /v2/lightning/{currency}/bolt12</c>.
+/// Registers a BOLT 12 offer with Boltz so that incoming Lightning payments
+/// to that offer are converted to Arkade VTXOs for the offer's owner.
+/// </summary>
+/// <remarks>
+/// The caller must already hold a BOLT 12-capable Lightning node (e.g. CLN or
+/// LDK) that generated <see cref="Offer"/>. Boltz calls the optional
+/// <see cref="WebhookUrl"/> to retrieve a fresh invoice each time a payer
+/// tries to pay the offer. If <see cref="WebhookUrl"/> is omitted, Boltz uses
+/// its own invoice-fetching mechanism.
+/// </remarks>
+public class Bolt12RegisterOfferRequest
+{
+    /// <summary>The BOLT 12 offer to register (<c>lno1…</c>).</summary>
+    [JsonPropertyName("offer")]
+    public required string Offer { get; set; }
+
+    /// <summary>
+    /// Optional webhook URL that Boltz calls to fetch invoices for the offer.
+    /// Must be reachable by the Boltz server.
+    /// </summary>
+    [JsonPropertyName("url")]
+    public string? WebhookUrl { get; set; }
+}

--- a/NArk.Swaps/Boltz/Models/Bolt12/Bolt12UpdateOfferRequest.cs
+++ b/NArk.Swaps/Boltz/Models/Bolt12/Bolt12UpdateOfferRequest.cs
@@ -1,0 +1,34 @@
+using System.Text.Json.Serialization;
+
+namespace NArk.Swaps.Boltz.Models.Bolt12;
+
+/// <summary>
+/// Request body for <c>PATCH /v2/lightning/{currency}/bolt12</c>.
+/// Updates the webhook URL associated with a previously registered BOLT 12 offer.
+/// </summary>
+/// <remarks>
+/// <see cref="Signature"/> must be a Schnorr signature of the SHA-256 hash of
+/// the new <see cref="WebhookUrl"/>, or the literal string <c>"UPDATE"</c> when
+/// <see cref="WebhookUrl"/> is omitted (i.e. removing the webhook). The signature
+/// must be produced by the private key whose public key is embedded in the offer.
+/// </remarks>
+public class Bolt12UpdateOfferRequest
+{
+    /// <summary>The BOLT 12 offer to update (<c>lno1…</c>).</summary>
+    [JsonPropertyName("offer")]
+    public required string Offer { get; set; }
+
+    /// <summary>
+    /// New webhook URL, or <c>null</c> to remove the existing webhook.
+    /// </summary>
+    [JsonPropertyName("url")]
+    public string? WebhookUrl { get; set; }
+
+    /// <summary>
+    /// Schnorr signature authorising the update. Must be the signature of the
+    /// SHA-256 hash of <see cref="WebhookUrl"/>, or <c>"UPDATE"</c> when no
+    /// URL is provided.
+    /// </summary>
+    [JsonPropertyName("signature")]
+    public required string Signature { get; set; }
+}

--- a/NArk.Swaps/Boltz/Models/SubmarineSwapResult.cs
+++ b/NArk.Swaps/Boltz/Models/SubmarineSwapResult.cs
@@ -4,4 +4,20 @@ using NArk.Swaps.Boltz.Models.Swaps.Submarine;
 
 namespace NArk.Swaps.Boltz.Models;
 
-public record SubmarineSwapResult(VHTLCContract Contract, SubmarineResponse Swap, ArkAddress Address);
+/// <summary>
+/// Result of creating an Arkade submarine swap (Arkade → Lightning) via Boltz.
+/// </summary>
+/// <param name="Contract">VHTLC contract that the sender must fund.</param>
+/// <param name="Swap">Raw response from the Boltz API.</param>
+/// <param name="Address">Arkade lockup address derived from the VHTLC contract.</param>
+/// <param name="Invoice">
+/// The Lightning invoice string to be paid by Boltz once the VHTLC is funded.
+/// For BOLT 11 swaps this echoes the invoice supplied by the caller.
+/// For BOLT 12 swaps this is the invoice fetched from the offer by Boltz.
+/// <c>null</c> when not applicable (e.g. older call sites that predate BOLT 12 support).
+/// </param>
+public record SubmarineSwapResult(
+    VHTLCContract Contract,
+    SubmarineResponse Swap,
+    ArkAddress Address,
+    string? Invoice = null);

--- a/NArk.Swaps/Boltz/Models/SubmarineSwapResult.cs
+++ b/NArk.Swaps/Boltz/Models/SubmarineSwapResult.cs
@@ -20,4 +20,5 @@ public record SubmarineSwapResult(
     VHTLCContract Contract,
     SubmarineResponse Swap,
     ArkAddress Address,
-    string? Invoice = null);
+    string? Invoice = null,
+    string? PaymentHashHex = null);

--- a/NArk.Swaps/Services/SwapsManagementService.cs
+++ b/NArk.Swaps/Services/SwapsManagementService.cs
@@ -12,9 +12,8 @@ using NArk.Core.Contracts;
 using NArk.Core.Extensions;
 using NArk.Core.Services;
 using NArk.Swaps.Abstractions;
+using NArk.Swaps.Bolt12;
 using NArk.Swaps.Boltz;
-using NArk.Swaps.Boltz.Client;
-using NArk.Swaps.Boltz.Models;
 using NArk.Swaps.Boltz.Models.Restore;
 using NArk.Swaps.Models;
 using NArk.Core.Transport;
@@ -225,6 +224,127 @@ public class SwapsManagementService : IAsyncDisposable
                     DateTimeOffset.UtcNow,
                     DateTimeOffset.UtcNow,
                     invoice.Hash.ToString()
+                )
+                {
+                    ProviderId = BoltzSwapProvider.Id,
+                    Route = new SwapRoute(SwapAsset.ArkBtc, SwapAsset.BtcLightning)
+                }, cancellationToken);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Initiates an Arkade → Lightning submarine swap where the destination is a
+    /// BOLT 12 offer (<c>lno1…</c>) rather than a BOLT 11 invoice.
+    /// </summary>
+    /// <remarks>
+    /// Boltz is asked to fetch a BOLT 12 invoice from the offer first; the resulting
+    /// invoice is then used to create the submarine swap in the same way as the
+    /// standard BOLT 11 path (<see cref="InitiateSubmarineSwap"/>).
+    ///
+    /// The swap is stored with <see cref="ArkSwapType.Submarine"/> and the fetched
+    /// BOLT 12 invoice string in the <c>Invoice</c> field.
+    ///
+    /// When <paramref name="autoPay"/> is <c>true</c> (default) the method funds the
+    /// VHTLC immediately and returns the Arkade batch transaction ID.
+    /// When <c>false</c> it saves the swap and returns the Boltz swap ID so the caller
+    /// can fund it later via <see cref="PayExistingSubmarineSwap"/>.
+    /// </remarks>
+    /// <param name="walletId">Identifier of the Arkade wallet that will pay.</param>
+    /// <param name="bolt12Offer">A BOLT 12 offer string (<c>lno1…</c>).</param>
+    /// <param name="amountSats">Amount to pay in satoshis.</param>
+    /// <param name="autoPay">
+    /// When <c>true</c> the VHTLC is funded immediately; returns the batch tx ID.
+    /// When <c>false</c> returns the Boltz swap ID for deferred payment.
+    /// </param>
+    /// <param name="currency">Lightning currency forwarded to Boltz, defaults to <c>"BTC"</c>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The Arkade batch transaction ID (when <paramref name="autoPay"/> is <c>true</c>)
+    /// or the Boltz swap ID (when <c>false</c>).
+    /// </returns>
+    public async Task<string> InitiateSubmarineSwapBolt12(
+        string walletId,
+        string bolt12Offer,
+        long amountSats,
+        bool autoPay = true,
+        string currency = "BTC",
+        CancellationToken cancellationToken = default)
+    {
+        using var _walletScope = _logger?.BeginScope(("WalletId", walletId));
+        var boltz = GetBoltzProvider();
+
+        _logger?.LogInformation(
+            "Initiating BOLT 12 submarine swap for wallet {WalletId}, amount={Amount}, autoPay={AutoPay}",
+            walletId, amountSats, autoPay);
+
+        var serverInfo = await _clientTransport.GetServerInfoAsync(cancellationToken);
+        var addressProvider = await _walletProvider.GetAddressProviderAsync(walletId, cancellationToken);
+        var swap = await boltz.BoltzService.CreateSubmarineSwapBolt12(
+            bolt12Offer,
+            amountSats,
+            await addressProvider!.GetNextSigningDescriptor(cancellationToken),
+            currency,
+            cancellationToken);
+
+        var invoiceStr = swap.Invoice
+            ?? throw new InvalidOperationException("BOLT 12 submarine swap did not return an invoice string");
+
+        var paymentHashBytes = Bolt12InvoiceParser.ExtractPaymentHash(invoiceStr);
+        var paymentHashHex = Convert.ToHexString(paymentHashBytes).ToLowerInvariant();
+
+        await _contractService.ImportContract(walletId, swap.Contract,
+            ContractActivityState.AwaitingFundsBeforeDeactivate,
+            metadata: new Dictionary<string, string> { ["Source"] = $"swap:{swap.Swap.Id}" },
+            cancellationToken: cancellationToken);
+
+        var isMainnet = serverInfo.Network.ChainName == ChainName.Mainnet;
+        await _swapsStorage.SaveSwap(
+            walletId,
+            new ArkSwap(
+                swap.Swap.Id,
+                walletId,
+                ArkSwapType.Submarine,
+                invoiceStr,
+                swap.Swap.ExpectedAmount,
+                swap.Contract.GetArkAddress().ScriptPubKey.ToHex(),
+                swap.Address.ToString(isMainnet),
+                ArkSwapStatus.Pending,
+                null,
+                DateTimeOffset.UtcNow,
+                DateTimeOffset.UtcNow,
+                paymentHashHex
+            )
+            {
+                ProviderId = BoltzSwapProvider.Id,
+                Route = new SwapRoute(SwapAsset.ArkBtc, SwapAsset.BtcLightning)
+            }, cancellationToken);
+
+        try
+        {
+            return autoPay
+                ? (await _spendingService.Spend(walletId,
+                    [new ArkTxOut(ArkTxOutType.Vtxo, swap.Swap.ExpectedAmount, swap.Address)],
+                    cancellationToken)).ToString()
+                : swap.Swap.Id;
+        }
+        catch (Exception e)
+        {
+            await _swapsStorage.SaveSwap(
+                walletId,
+                new ArkSwap(
+                    swap.Swap.Id,
+                    walletId,
+                    ArkSwapType.Submarine,
+                    invoiceStr,
+                    swap.Swap.ExpectedAmount,
+                    swap.Contract.GetArkAddress().ScriptPubKey.ToHex(),
+                    swap.Address.ToString(isMainnet),
+                    ArkSwapStatus.Failed,
+                    e.ToString(),
+                    DateTimeOffset.UtcNow,
+                    DateTimeOffset.UtcNow,
+                    paymentHashHex
                 )
                 {
                     ProviderId = BoltzSwapProvider.Id,

--- a/NArk.Swaps/Services/SwapsManagementService.cs
+++ b/NArk.Swaps/Services/SwapsManagementService.cs
@@ -175,62 +175,12 @@ public class SwapsManagementService : IAsyncDisposable
         var swap = await boltz.BoltzService.CreateSubmarineSwap(invoice,
             await addressProvider!.GetNextSigningDescriptor(cancellationToken),
             cancellationToken);
-        await _contractService.ImportContract(walletId, swap.Contract,
-            ContractActivityState.AwaitingFundsBeforeDeactivate,
-            metadata: new Dictionary<string, string> { ["Source"] = $"swap:{swap.Swap.Id}" },
-            cancellationToken: cancellationToken);
-        await _swapsStorage.SaveSwap(
-            walletId,
-            new ArkSwap(
-                swap.Swap.Id,
-                walletId,
-                ArkSwapType.Submarine,
-                invoice.ToString(),
-                swap.Swap.ExpectedAmount,
-                swap.Contract.GetArkAddress().ScriptPubKey.ToHex(),
-                swap.Address.ToString(serverInfo.Network.ChainName == ChainName.Mainnet),
-                ArkSwapStatus.Pending,
-                null,
-                DateTimeOffset.UtcNow,
-                DateTimeOffset.UtcNow,
-                invoice.Hash.ToString()
-            )
-            {
-                ProviderId = BoltzSwapProvider.Id,
-                Route = new SwapRoute(SwapAsset.ArkBtc, SwapAsset.BtcLightning)
-            }, cancellationToken);
-        try
-        {
-            return autoPay
-                ? (await _spendingService.Spend(walletId,
-                    [new ArkTxOut(ArkTxOutType.Vtxo, swap.Swap.ExpectedAmount, swap.Address)], cancellationToken))
-                .ToString()
-                : swap.Swap.Id;
-        }
-        catch (Exception e)
-        {
-            await _swapsStorage.SaveSwap(
-                walletId,
-                new ArkSwap(
-                    swap.Swap.Id,
-                    walletId,
-                    ArkSwapType.Submarine,
-                    invoice.ToString(),
-                    swap.Swap.ExpectedAmount,
-                    swap.Contract.GetArkAddress().ScriptPubKey.ToHex(),
-                    swap.Address.ToString(serverInfo.Network.ChainName == ChainName.Mainnet),
-                    ArkSwapStatus.Failed,
-                    e.ToString(),
-                    DateTimeOffset.UtcNow,
-                    DateTimeOffset.UtcNow,
-                    invoice.Hash.ToString()
-                )
-                {
-                    ProviderId = BoltzSwapProvider.Id,
-                    Route = new SwapRoute(SwapAsset.ArkBtc, SwapAsset.BtcLightning)
-                }, cancellationToken);
-            throw;
-        }
+        return await SaveAndFundSubmarineSwap(
+            walletId, swap.Contract, swap.Swap.Id, invoice.ToString(),
+            swap.Swap.ExpectedAmount, swap.Address,
+            invoice.Hash.ToString(),
+            serverInfo.Network.ChainName == ChainName.Mainnet,
+            autoPay, cancellationToken);
     }
 
     /// <summary>
@@ -289,67 +239,60 @@ public class SwapsManagementService : IAsyncDisposable
 
         var invoiceStr = swap.Invoice
             ?? throw new InvalidOperationException("BOLT 12 submarine swap did not return an invoice string");
+        var paymentHashHex = swap.PaymentHashHex
+            ?? throw new InvalidOperationException("BOLT 12 submarine swap did not return a payment hash");
 
-        var paymentHashBytes = Bolt12InvoiceParser.ExtractPaymentHash(invoiceStr);
-        var paymentHashHex = Convert.ToHexString(paymentHashBytes).ToLowerInvariant();
+        return await SaveAndFundSubmarineSwap(
+            walletId, swap.Contract, swap.Swap.Id, invoiceStr,
+            swap.Swap.ExpectedAmount, swap.Address,
+            paymentHashHex,
+            serverInfo.Network.ChainName == ChainName.Mainnet,
+            autoPay, cancellationToken);
+    }
 
-        await _contractService.ImportContract(walletId, swap.Contract,
+    private async Task<string> SaveAndFundSubmarineSwap(
+        string walletId,
+        VHTLCContract contract,
+        string swapId,
+        string invoiceStr,
+        long expectedAmount,
+        ArkAddress lockupAddress,
+        string paymentHashHex,
+        bool isMainnet,
+        bool autoPay,
+        CancellationToken cancellationToken)
+    {
+        await _contractService.ImportContract(walletId, contract,
             ContractActivityState.AwaitingFundsBeforeDeactivate,
-            metadata: new Dictionary<string, string> { ["Source"] = $"swap:{swap.Swap.Id}" },
+            metadata: new Dictionary<string, string> { ["Source"] = $"swap:{swapId}" },
             cancellationToken: cancellationToken);
 
-        var isMainnet = serverInfo.Network.ChainName == ChainName.Mainnet;
-        await _swapsStorage.SaveSwap(
-            walletId,
+        ArkSwap BuildSwap(ArkSwapStatus status, string? failReason = null) =>
             new ArkSwap(
-                swap.Swap.Id,
-                walletId,
-                ArkSwapType.Submarine,
-                invoiceStr,
-                swap.Swap.ExpectedAmount,
-                swap.Contract.GetArkAddress().ScriptPubKey.ToHex(),
-                swap.Address.ToString(isMainnet),
-                ArkSwapStatus.Pending,
-                null,
-                DateTimeOffset.UtcNow,
-                DateTimeOffset.UtcNow,
-                paymentHashHex
-            )
+                swapId, walletId, ArkSwapType.Submarine, invoiceStr, expectedAmount,
+                contract.GetArkAddress().ScriptPubKey.ToHex(),
+                lockupAddress.ToString(isMainnet),
+                status, failReason,
+                DateTimeOffset.UtcNow, DateTimeOffset.UtcNow,
+                paymentHashHex)
             {
                 ProviderId = BoltzSwapProvider.Id,
                 Route = new SwapRoute(SwapAsset.ArkBtc, SwapAsset.BtcLightning)
-            }, cancellationToken);
+            };
+
+        await _swapsStorage.SaveSwap(walletId, BuildSwap(ArkSwapStatus.Pending), cancellationToken);
 
         try
         {
             return autoPay
                 ? (await _spendingService.Spend(walletId,
-                    [new ArkTxOut(ArkTxOutType.Vtxo, swap.Swap.ExpectedAmount, swap.Address)],
+                    [new ArkTxOut(ArkTxOutType.Vtxo, expectedAmount, lockupAddress)],
                     cancellationToken)).ToString()
-                : swap.Swap.Id;
+                : swapId;
         }
         catch (Exception e)
         {
-            await _swapsStorage.SaveSwap(
-                walletId,
-                new ArkSwap(
-                    swap.Swap.Id,
-                    walletId,
-                    ArkSwapType.Submarine,
-                    invoiceStr,
-                    swap.Swap.ExpectedAmount,
-                    swap.Contract.GetArkAddress().ScriptPubKey.ToHex(),
-                    swap.Address.ToString(isMainnet),
-                    ArkSwapStatus.Failed,
-                    e.ToString(),
-                    DateTimeOffset.UtcNow,
-                    DateTimeOffset.UtcNow,
-                    paymentHashHex
-                )
-                {
-                    ProviderId = BoltzSwapProvider.Id,
-                    Route = new SwapRoute(SwapAsset.ArkBtc, SwapAsset.BtcLightning)
-                }, cancellationToken);
+            await _swapsStorage.SaveSwap(walletId, BuildSwap(ArkSwapStatus.Failed, e.ToString()), cancellationToken);
             throw;
         }
     }

--- a/NArk.Tests.End2End/Common/DockerHelper.cs
+++ b/NArk.Tests.End2End/Common/DockerHelper.cs
@@ -169,4 +169,37 @@ public static class DockerHelper
                 $"bitcoin-cli getnewaddress failed (exit={result.ExitCode}): {result.StandardError.Trim()}");
         return result.StandardOutput.Trim();
     }
+
+    /// <summary>
+    /// Creates a BOLT 12 offer on the Core Lightning (<c>cln</c>) regtest container.
+    /// Returns the <c>lno1…</c> offer string.
+    /// </summary>
+    /// <remarks>
+    /// Requires a <c>cln</c> Docker container running Core Lightning with
+    /// <c>lightning-cli</c> available at <c>/usr/local/bin/lightning-cli</c>.
+    /// The regtest docker-compose stack must include CLN alongside LND for
+    /// BOLT 12 end-to-end tests to pass.
+    /// </remarks>
+    /// <param name="amountSats">Amount in satoshis embedded in the offer; use <c>0</c> for an any-amount offer.</param>
+    /// <param name="description">Short human-readable description included in the offer.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The BOLT 12 offer string (<c>lno1…</c>).</returns>
+    public static async Task<string> CreateClnBolt12Offer(
+        long amountSats = 10000,
+        string description = "test offer",
+        CancellationToken ct = default)
+    {
+        var amountArg = amountSats > 0
+            ? $"{amountSats * 1000}msat"  // CLN uses millisatoshis
+            : "any";
+
+        var output = await Exec("cln",
+            ["lightning-cli", "--network=regtest", "offer", amountArg, description], ct);
+
+        var offer = JsonSerializer.Deserialize<JsonObject>(output)?["bolt12"]
+                        ?.GetValue<string>()
+                    ?? throw new InvalidOperationException(
+                        $"BOLT 12 offer creation on CLN failed. Output: {output}");
+        return offer.Trim();
+    }
 }

--- a/NArk.Tests.End2End/SwapManagementServiceTests.cs
+++ b/NArk.Tests.End2End/SwapManagementServiceTests.cs
@@ -752,4 +752,110 @@ public class SwapManagementServiceTests
         var swapsAfterRestore = await swapStorage.GetSwaps(walletIds: [testingPrerequisite.walletIdentifier]);
         Assert.That(swapsAfterRestore, Has.Count.GreaterThanOrEqualTo(1));
     }
+
+    // BOLT 12 submarine swap test.
+    //
+    // Nigiri ships a CLN container so the offer can be generated with:
+    //   docker exec cln lightning-cli --network=regtest offer any "nark bolt12 e2e"
+    //
+    // Pass the returned `bolt12` value via BOLT12_OFFER when running this test:
+    //   BOLT12_OFFER=lno1... dotnet test --filter CanPayBolt12OfferWithArkadeUsingBoltz
+    //
+    // The test is [Explicit] because Boltz must also be configured to use a BOLT12-capable
+    // Lightning backend (CLN or LDK). The default regtest stack connects Boltz only to LND,
+    // which does not support BOLT12.
+    private const string Bolt12OfferEnv = "BOLT12_OFFER";
+    private const long Bolt12TestAmountSats = 2_000;
+
+    [Test]
+    [Explicit("Requires BOLT12_OFFER env var and Boltz configured with a BOLT12-capable Lightning backend (CLN/LDK)")]
+    [Category("Bolt12")]
+    public async Task CanPayBolt12OfferWithArkadeUsingBoltz()
+    {
+        var offer = Environment.GetEnvironmentVariable(Bolt12OfferEnv)
+            ?? await DockerHelper.CreateClnBolt12Offer(amountSats: 0, description: "nark bolt12 e2e");
+
+        var testingPrerequisite = await FundedWalletHelper.GetFundedWallet();
+        var swapStorage = TestStorage.CreateSwapStorage();
+        var boltzClient = new BoltzClient(new HttpClient(),
+            new OptionsWrapper<BoltzClientOptions>(new BoltzClientOptions
+            {
+                BoltzUrl = SharedSwapInfrastructure.BoltzEndpoint.ToString(),
+                WebsocketUrl = SharedSwapInfrastructure.BoltzWsEndpoint.ToString()
+            }));
+        var intentStorage = TestStorage.CreateIntentStorage();
+        var chainTimeProvider = new NBXplorerBlockchain(Network.RegTest, SharedArkInfrastructure.NbxplorerEndpoint);
+        var coinService = new CoinService(
+            testingPrerequisite.clientTransport,
+            testingPrerequisite.contracts,
+            [
+                new PaymentContractTransformer(testingPrerequisite.walletProvider),
+                new HashLockedContractTransformer(testingPrerequisite.walletProvider)
+            ]);
+        var spendingService = new SpendingService(
+            testingPrerequisite.vtxoStorage,
+            testingPrerequisite.contracts,
+            testingPrerequisite.walletProvider,
+            coinService,
+            testingPrerequisite.contractService,
+            testingPrerequisite.clientTransport,
+            new DefaultCoinSelector(),
+            testingPrerequisite.safetyService,
+            intentStorage);
+        var boltzProvider = new BoltzSwapProvider(
+            boltzClient,
+            new BoltzLimitsValidator(new CachedBoltzClient(
+                new HttpClient(),
+                new OptionsWrapper<BoltzClientOptions>(new BoltzClientOptions
+                {
+                    BoltzUrl = SharedSwapInfrastructure.BoltzEndpoint.ToString(),
+                    WebsocketUrl = SharedSwapInfrastructure.BoltzWsEndpoint.ToString()
+                }))),
+            testingPrerequisite.clientTransport,
+            testingPrerequisite.vtxoStorage,
+            testingPrerequisite.walletProvider,
+            swapStorage,
+            testingPrerequisite.contractService,
+            testingPrerequisite.contracts,
+            testingPrerequisite.safetyService,
+            spendingService,
+            intentStorage,
+            chainTimeProvider);
+
+        await using var swapMgr = new SwapsManagementService(
+            new ISwapProvider[] { boltzProvider },
+            spendingService,
+            testingPrerequisite.clientTransport,
+            testingPrerequisite.vtxoStorage,
+            testingPrerequisite.walletProvider,
+            swapStorage,
+            testingPrerequisite.contractService,
+            testingPrerequisite.contracts,
+            testingPrerequisite.safetyService,
+            intentStorage,
+            chainTimeProvider);
+
+        var settledSwapTcs = new TaskCompletionSource();
+        swapStorage.SwapsChanged += (_, swap) =>
+        {
+            if (swap.Status == ArkSwapStatus.Settled)
+                settledSwapTcs.TrySetResult();
+        };
+
+        await swapMgr.StartAsync(CancellationToken.None);
+
+        await swapMgr.InitiateSubmarineSwapBolt12(
+            testingPrerequisite.walletIdentifier,
+            offer,
+            amountSats: Bolt12TestAmountSats,
+            autoPay: true,
+            cancellationToken: CancellationToken.None);
+
+        await settledSwapTcs.Task.WaitAsync(TimeSpan.FromMinutes(2));
+
+        var swaps = (await swapStorage.GetSwaps(walletIds: [testingPrerequisite.walletIdentifier])).ToList();
+        Assert.That(swaps, Has.Count.EqualTo(1));
+        Assert.That(swaps[0].Status, Is.EqualTo(ArkSwapStatus.Settled));
+        Assert.That(swaps[0].Invoice, Does.StartWith("lni"));
+    }
 }

--- a/NArk.Tests/Bolt12InvoiceParserTests.cs
+++ b/NArk.Tests/Bolt12InvoiceParserTests.cs
@@ -1,0 +1,268 @@
+using NArk.Swaps.Bolt12;
+using NBitcoin.DataEncoders;
+
+namespace NArk.Tests;
+
+[TestFixture]
+public class Bolt12InvoiceParserTests
+{
+    // A known 32-byte payment hash used across round-trip tests.
+    private static readonly byte[] KnownPaymentHash =
+        Convert.FromHexString("a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
+
+    // Builds a minimal bech32m-encoded BOLT 12 invoice that contains exactly
+    // one TLV record: invoice_payment_hash (type 168, length 32).
+    private static string BuildMinimalInvoice(byte[] paymentHash, string hrp = "lni")
+    {
+        // TLV: [0xA8][0x20][32 bytes]
+        var tlv = new byte[1 + 1 + 32];
+        tlv[0] = 0xA8; // type 168
+        tlv[1] = 0x20; // length 32
+        Array.Copy(paymentHash, 0, tlv, 2, 32);
+
+        var encoder = Encoders.Bech32(hrp);
+        encoder.StrictLength = false;
+        encoder.SquashBytes = true;
+        return encoder.EncodeData(tlv, Bech32EncodingType.BECH32M);
+    }
+
+    // Builds a multi-record TLV stream: offer_chains (type 0, 2 bytes),
+    // invoice_created_at (type 164, 4 bytes), invoice_payment_hash (type 168, 32 bytes).
+    private static string BuildMultiRecordInvoice(byte[] paymentHash)
+    {
+        // type 0, length 2, value 0xAB 0xCD
+        // type 164, length 4, value 0x01 0x02 0x03 0x04
+        // type 168, length 32, value = paymentHash
+        byte[] tlv =
+        [
+            0x00, 0x02, 0xAB, 0xCD,
+            0xA4, 0x04, 0x01, 0x02, 0x03, 0x04,
+            0xA8, 0x20, .. paymentHash
+        ];
+
+        var encoder = Encoders.Bech32("lni");
+        encoder.StrictLength = false;
+        encoder.SquashBytes = true;
+        return encoder.EncodeData(tlv, Bech32EncodingType.BECH32M);
+    }
+
+    // BOLT 12 does NOT use different HRP prefixes per network (unlike BOLT 11's
+    // lnbc/lntb/lnbcrt). Both mainnet and testnet invoices start with lni1; the
+    // chain is identified inside the TLV stream via offer_chains (type 2) which
+    // contains the genesis block hash. This helper builds a realistic testnet
+    // invoice TLV that includes the testnet3 genesis hash so the parser is
+    // tested against data that mirrors what a real CLN/LDK testnet node emits.
+    private static string BuildTestnetStyleInvoice(byte[] paymentHash)
+    {
+        // Testnet3 genesis hash in internal byte order (reversed from display form
+        // 000000000933ea01…d77f4943).
+        byte[] testnetGenesisHash = Convert.FromHexString(
+            "43497fd7f826957108f4a30fd9cec3aeba79972084e90ead01ea330900000000");
+
+        // type  2 (offer_chains):        length 32, value = testnet genesis hash
+        // type 164 (invoice_created_at): length 4,  value = arbitrary timestamp
+        // type 168 (invoice_payment_hash): length 32, value = paymentHash
+        // type 170 (invoice_amount):     length 3,  value = 100_000 msats (tu64)
+        byte[] tlv =
+        [
+            0x02, 0x20, .. testnetGenesisHash,
+            0xA4, 0x04, 0x66, 0x48, 0xFE, 0x00,
+            0xA8, 0x20, .. paymentHash,
+            0xAA, 0x03, 0x01, 0x86, 0xA0,
+        ];
+
+        var encoder = Encoders.Bech32("lni");
+        encoder.StrictLength = false;
+        encoder.SquashBytes = true;
+        return encoder.EncodeData(tlv, Bech32EncodingType.BECH32M);
+    }
+
+    [Test]
+    public void ExtractPaymentHash_MinimalInvoice_RoundTrips()
+    {
+        var invoice = BuildMinimalInvoice(KnownPaymentHash);
+
+        var result = Bolt12InvoiceParser.ExtractPaymentHash(invoice);
+
+        Assert.That(result, Is.EqualTo(KnownPaymentHash));
+    }
+
+    [Test]
+    public void ExtractPaymentHash_UpperCaseInput_Succeeds()
+    {
+        var invoice = BuildMinimalInvoice(KnownPaymentHash).ToUpperInvariant();
+
+        var result = Bolt12InvoiceParser.ExtractPaymentHash(invoice);
+
+        Assert.That(result, Is.EqualTo(KnownPaymentHash));
+    }
+
+    [Test]
+    public void ExtractPaymentHash_MultipleRecords_FindsPaymentHashAmongOthers()
+    {
+        var invoice = BuildMultiRecordInvoice(KnownPaymentHash);
+
+        var result = Bolt12InvoiceParser.ExtractPaymentHash(invoice);
+
+        Assert.That(result, Is.EqualTo(KnownPaymentHash));
+    }
+
+    // ─── Network-agnostic (testnet) ───────────────────────────────────
+
+    [Test]
+    public void ExtractPaymentHash_TestnetStyleInvoice_SameHrpAsMainnet()
+    {
+        // Verifies that a BOLT 12 invoice carrying the testnet3 genesis hash in
+        // offer_chains still uses the lni1 prefix (no lntb1 equivalent in BOLT 12).
+        var invoice = BuildTestnetStyleInvoice(KnownPaymentHash);
+
+        Assert.That(invoice, Does.StartWith("lni1"),
+            "BOLT 12 invoices use lni1 regardless of network");
+    }
+
+    [Test]
+    public void ExtractPaymentHash_TestnetStyleInvoice_ExtractsCorrectHash()
+    {
+        var invoice = BuildTestnetStyleInvoice(KnownPaymentHash);
+
+        var result = Bolt12InvoiceParser.ExtractPaymentHash(invoice);
+
+        Assert.That(result, Is.EqualTo(KnownPaymentHash));
+    }
+
+    [Test]
+    public void IsBolt12Offer_TestnetOffer_SameHrpAsMainnet()
+    {
+        // Testnet BOLT 12 offers also start with lno1 — there is no lnotb1 or
+        // similar variant. The chain is embedded in TLV, not the HRP.
+        const string testnetOffer = "lno1qgsyxjtl6luzd9t3pr62xr7eemp6awnejusgd6gk";
+
+        Assert.That(Bolt12InvoiceParser.IsBolt12Offer(testnetOffer), Is.True);
+    }
+
+    [Test]
+    public void ExtractPaymentHash_DifferentHashes_AreDistinct()
+    {
+        var hash1 = new byte[32];
+        var hash2 = new byte[32];
+        hash2[0] = 0xFF;
+
+        var invoice1 = BuildMinimalInvoice(hash1);
+        var invoice2 = BuildMinimalInvoice(hash2);
+
+        Assert.That(
+            Bolt12InvoiceParser.ExtractPaymentHash(invoice1),
+            Is.Not.EqualTo(Bolt12InvoiceParser.ExtractPaymentHash(invoice2)));
+    }
+
+    [Test]
+    public void ExtractPaymentHash_Bolt11Invoice_ThrowsFormatException()
+    {
+        const string bolt11 = "lnbc1500n1...";
+
+        Assert.Throws<FormatException>(() => Bolt12InvoiceParser.ExtractPaymentHash(bolt11));
+    }
+
+    [Test]
+    public void ExtractPaymentHash_Bolt12Offer_ThrowsFormatException()
+    {
+        const string offer = "lno1qgsyxjtl6luzd9t3pr62xr7eemp6awnejusgd6gk...";
+
+        Assert.Throws<FormatException>(() => Bolt12InvoiceParser.ExtractPaymentHash(offer));
+    }
+
+    [Test]
+    public void ExtractPaymentHash_EmptyString_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => Bolt12InvoiceParser.ExtractPaymentHash(""));
+    }
+
+    [Test]
+    public void ExtractPaymentHash_NullString_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => Bolt12InvoiceParser.ExtractPaymentHash(null!));
+    }
+
+    [Test]
+    public void IsBolt12Invoice_Lni1Prefix_ReturnsTrue()
+    {
+        Assert.That(Bolt12InvoiceParser.IsBolt12Invoice("lni1abc"), Is.True);
+        Assert.That(Bolt12InvoiceParser.IsBolt12Invoice("LNI1ABC"), Is.True);
+    }
+
+    [Test]
+    public void IsBolt12Invoice_OtherPrefixes_ReturnsFalse()
+    {
+        Assert.That(Bolt12InvoiceParser.IsBolt12Invoice("lno1abc"), Is.False);
+        Assert.That(Bolt12InvoiceParser.IsBolt12Invoice("lnbc1abc"), Is.False);
+        Assert.That(Bolt12InvoiceParser.IsBolt12Invoice(""), Is.False);
+        Assert.That(Bolt12InvoiceParser.IsBolt12Invoice(null!), Is.False);
+    }
+
+    [Test]
+    public void IsBolt12Offer_Lno1Prefix_ReturnsTrue()
+    {
+        Assert.That(Bolt12InvoiceParser.IsBolt12Offer("lno1abc"), Is.True);
+        Assert.That(Bolt12InvoiceParser.IsBolt12Offer("LNO1ABC"), Is.True);
+    }
+
+    [Test]
+    public void IsBolt12Offer_OtherPrefixes_ReturnsFalse()
+    {
+        Assert.That(Bolt12InvoiceParser.IsBolt12Offer("lni1abc"), Is.False);
+        Assert.That(Bolt12InvoiceParser.IsBolt12Offer("lnbc1abc"), Is.False);
+    }
+
+    // ─── ReadBigSize unit tests ───────────────────────────────────────
+
+    private static IEnumerable<object[]> BigSizeCases()
+    {
+        yield return [new byte[] { 0x00 },                   0UL,    1];
+        yield return [new byte[] { 0xFC },                   252UL,  1];
+        yield return [new byte[] { 0xFD, 0x00, 0xFD },       253UL,  3];
+        yield return [new byte[] { 0xFD, 0xFF, 0xFF },       65535UL, 3];
+        yield return [new byte[] { 0xFE, 0x00, 0x01, 0x00, 0x00 }, 65536UL, 5];
+    }
+
+    [TestCaseSource(nameof(BigSizeCases))]
+    public void ReadBigSize_KnownEncodings(byte[] data, ulong expected, int expectedPos)
+    {
+        var pos = 0;
+        var value = Bolt12InvoiceParser.ReadBigSize(data, ref pos);
+
+        Assert.That(value, Is.EqualTo(expected));
+        Assert.That(pos, Is.EqualTo(expectedPos));
+    }
+
+    [Test]
+    public void FindTlvRecord_RecordPresent_ReturnsValue()
+    {
+        // [type=5, length=3, value=0x01 0x02 0x03]
+        byte[] tlv = [0x05, 0x03, 0x01, 0x02, 0x03];
+
+        var result = Bolt12InvoiceParser.FindTlvRecord(tlv, 5);
+
+        Assert.That(result, Is.EqualTo(new byte[] { 0x01, 0x02, 0x03 }));
+    }
+
+    [Test]
+    public void FindTlvRecord_RecordAbsent_ReturnsNull()
+    {
+        byte[] tlv = [0x05, 0x01, 0xFF];
+
+        var result = Bolt12InvoiceParser.FindTlvRecord(tlv, 99);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void FindTlvRecord_SkipsEarlierRecords_FindsTarget()
+    {
+        // [type=1, length=1, 0xAA] [type=2, length=2, 0xBB 0xCC]
+        byte[] tlv = [0x01, 0x01, 0xAA, 0x02, 0x02, 0xBB, 0xCC];
+
+        var result = Bolt12InvoiceParser.FindTlvRecord(tlv, 2);
+
+        Assert.That(result, Is.EqualTo(new byte[] { 0xBB, 0xCC }));
+    }
+}

--- a/NArk.Tests/Bolt12InvoiceParserTests.cs
+++ b/NArk.Tests/Bolt12InvoiceParserTests.cs
@@ -1,5 +1,4 @@
 using NArk.Swaps.Bolt12;
-using NBitcoin.DataEncoders;
 
 namespace NArk.Tests;
 
@@ -10,7 +9,7 @@ public class Bolt12InvoiceParserTests
     private static readonly byte[] KnownPaymentHash =
         Convert.FromHexString("a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
 
-    // Builds a minimal bech32m-encoded BOLT 12 invoice that contains exactly
+    // Builds a bech32-without-checksum BOLT 12 invoice that contains exactly
     // one TLV record: invoice_payment_hash (type 168, length 32).
     private static string BuildMinimalInvoice(byte[] paymentHash, string hrp = "lni")
     {
@@ -19,11 +18,7 @@ public class Bolt12InvoiceParserTests
         tlv[0] = 0xA8; // type 168
         tlv[1] = 0x20; // length 32
         Array.Copy(paymentHash, 0, tlv, 2, 32);
-
-        var encoder = Encoders.Bech32(hrp);
-        encoder.StrictLength = false;
-        encoder.SquashBytes = true;
-        return encoder.EncodeData(tlv, Bech32EncodingType.BECH32M);
+        return Bolt12InvoiceParser.EncodeBolt12Bech32(hrp, tlv);
     }
 
     // Builds a multi-record TLV stream: offer_chains (type 0, 2 bytes),
@@ -40,10 +35,7 @@ public class Bolt12InvoiceParserTests
             0xA8, 0x20, .. paymentHash
         ];
 
-        var encoder = Encoders.Bech32("lni");
-        encoder.StrictLength = false;
-        encoder.SquashBytes = true;
-        return encoder.EncodeData(tlv, Bech32EncodingType.BECH32M);
+        return Bolt12InvoiceParser.EncodeBolt12Bech32("lni", tlv);
     }
 
     // BOLT 12 does NOT use different HRP prefixes per network (unlike BOLT 11's
@@ -71,10 +63,7 @@ public class Bolt12InvoiceParserTests
             0xAA, 0x03, 0x01, 0x86, 0xA0,
         ];
 
-        var encoder = Encoders.Bech32("lni");
-        encoder.StrictLength = false;
-        encoder.SquashBytes = true;
-        return encoder.EncodeData(tlv, Bech32EncodingType.BECH32M);
+        return Bolt12InvoiceParser.EncodeBolt12Bech32("lni", tlv);
     }
 
     [Test]
@@ -265,4 +254,268 @@ public class Bolt12InvoiceParserTests
 
         Assert.That(result, Is.EqualTo(new byte[] { 0xBB, 0xCC }));
     }
+
+    // ─── ExtractNodeId / ExtractOfferIssuerId / VerifyInvoiceMatchesOffer ────
+
+    // Builds a lni1 invoice with both invoice_payment_hash (type 168) and
+    // invoice_node_id (type 176). TLV records must be in ascending type order.
+    private static string BuildInvoiceWithNodeId(byte[] paymentHash, byte[] nodeId)
+    {
+        byte[] tlv =
+        [
+            0xA8, 0x20, .. paymentHash, // type 168, length 32
+            0xB0, 0x21, .. nodeId,      // type 176, length 33
+        ];
+        return Bolt12InvoiceParser.EncodeBolt12Bech32("lni", tlv);
+    }
+
+    private static readonly byte[] KnownNodeId =
+        Convert.FromHexString("02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619");
+
+    private static readonly byte[] OtherNodeId =
+        Convert.FromHexString("0303030303030303030303030303030303030303030303030303030303030303ab");
+
+    [Test]
+    public void ExtractNodeId_InvoiceWithNodeId_ReturnsCorrectKey()
+    {
+        var invoice = BuildInvoiceWithNodeId(KnownPaymentHash, KnownNodeId);
+
+        var result = Bolt12InvoiceParser.ExtractNodeId(invoice);
+
+        Assert.That(result, Is.EqualTo(KnownNodeId));
+    }
+
+    [Test]
+    public void ExtractNodeId_InvoiceWithoutNodeId_ThrowsFormatException()
+    {
+        var invoice = BuildMinimalInvoice(KnownPaymentHash); // only type 168, no type 176
+
+        Assert.Throws<FormatException>(() => Bolt12InvoiceParser.ExtractNodeId(invoice));
+    }
+
+    [Test]
+    public void ExtractOfferIssuerId_MinimalOffer_ReturnsKnownKey()
+    {
+        var result = Bolt12InvoiceParser.ExtractOfferIssuerId(MinimalOffer);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(Convert.ToHexString(result!).ToLowerInvariant(),
+            Is.EqualTo(MinimalOfferIssuerIdHex));
+    }
+
+    [Test]
+    public void ExtractOfferIssuerId_BlindedPathOnlyOffer_ReturnsNull()
+    {
+        // "no issuer_id and blinded path" from offers-test.json — no TLV type 22.
+        const string blindedPathOffer =
+            "lno1pgx9getnwss8vetrw3hhyucs5ypjgef743p5fzqq9nqxh0ah7y87rzv3ud0eleps9kl2d5348hq2k8qzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgqpqqqqqqqqqqqqqqqqqqqqqqqqqqqzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqqzq3zyg3zyg3zygszqqqqyqqqqsqqvpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsq";
+
+        var result = Bolt12InvoiceParser.ExtractOfferIssuerId(blindedPathOffer);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void VerifyInvoiceMatchesOffer_MatchingKeys_DoesNotThrow()
+    {
+        // invoice_node_id == offer_issuer_id (both = KnownNodeId / MinimalOffer key).
+        var invoice = BuildInvoiceWithNodeId(KnownPaymentHash, KnownNodeId);
+
+        Assert.DoesNotThrow(() =>
+            Bolt12InvoiceParser.VerifyInvoiceMatchesOffer(invoice, MinimalOffer));
+    }
+
+    [Test]
+    public void VerifyInvoiceMatchesOffer_MismatchedKeys_ThrowsInvalidOperationException()
+    {
+        var invoice = BuildInvoiceWithNodeId(KnownPaymentHash, OtherNodeId);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            Bolt12InvoiceParser.VerifyInvoiceMatchesOffer(invoice, MinimalOffer));
+    }
+
+    [Test]
+    public void VerifyInvoiceMatchesOffer_BlindedPathOnlyOffer_SkipsVerification()
+    {
+        // Offer has no offer_issuer_id — verification is skipped, any invoice passes.
+        const string blindedPathOffer =
+            "lno1pgx9getnwss8vetrw3hhyucs5ypjgef743p5fzqq9nqxh0ah7y87rzv3ud0eleps9kl2d5348hq2k8qzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgqpqqqqqqqqqqqqqqqqqqqqqqqqqqqzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqqzq3zyg3zyg3zygszqqqqyqqqqsqqvpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsq";
+        var invoice = BuildInvoiceWithNodeId(KnownPaymentHash, OtherNodeId);
+
+        Assert.DoesNotThrow(() =>
+            Bolt12InvoiceParser.VerifyInvoiceMatchesOffer(invoice, blindedPathOffer));
+    }
+
+    // ─── Official BOLT 12 test vectors (lightning/bolts bolt12/) ─────────────
+    // Source: https://github.com/lightning/bolts/blob/master/bolt12/offers-test.json
+    // Offer strings are bech32-without-checksum encoded; field values are confirmed
+    // by the spec test vector JSON (type, length, hex).
+
+    // Minimal offer: single TLV type=22 (offer_issuer_id), length=33.
+    private const string MinimalOffer =
+        "lno1zcss9mk8y3wkklfvevcrszlmu23kfrxh49px20665dqwmn4p72pksese";
+
+    private const string MinimalOfferIssuerIdHex =
+        "02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619";
+
+    // Testnet offer: TLV type=2 (offer_chains) with testnet3 genesis hash, then
+    // type=10 (offer_description), then type=22 (offer_issuer_id).
+    private const string TestnetOffer =
+        "lno1qgsyxjtl6luzd9t3pr62xr7eemp6awnejusgf6gw45q75vcfqqqqqqq2p32x2um5ypmx2cm5dae8x93pqthvwfzadd7jejes8q9lhc4rvjxd022zv5l44g6qah82ru5rdpnpj";
+
+    private const string Testnet3GenesisHashHex =
+        "43497fd7f826957108f4a30fd9cec3aeba79972084e90ead01ea330900000000";
+
+    // Offer with description ("Test vectors") and issuer_id.
+    private const string OfferWithDescription =
+        "lno1pgx9getnwss8vetrw3hhyuckyypwa3eyt44h6txtxquqh7lz5djge4afgfjn7k4rgrkuag0jsd5xvxg";
+
+    // Invalid: bech32 padding exceeds 4-bit limit — decoder must reject this.
+    private const string InvalidPaddingOffer =
+        "lno1zcss9mk8y3wkklfvevcrszlmu23kfrxh49px20665dqwmn4p72pkseseq";
+
+    [Test]
+    public void DecodeBolt12Bech32_MinimalOffer_FindsIssuerIdTlv()
+    {
+        var tlv = Bolt12InvoiceParser.DecodeBolt12Bech32(MinimalOffer);
+
+        var issuerId = Bolt12InvoiceParser.FindTlvRecord(tlv, 22); // offer_issuer_id
+
+        Assert.That(issuerId, Is.Not.Null);
+        Assert.That(Convert.ToHexString(issuerId!).ToLowerInvariant(),
+            Is.EqualTo(MinimalOfferIssuerIdHex));
+    }
+
+    [Test]
+    public void DecodeBolt12Bech32_TestnetOffer_FindsChainsTlv()
+    {
+        var tlv = Bolt12InvoiceParser.DecodeBolt12Bech32(TestnetOffer.ToLowerInvariant());
+
+        var chains = Bolt12InvoiceParser.FindTlvRecord(tlv, 2); // offer_chains
+
+        Assert.That(chains, Is.Not.Null);
+        Assert.That(Convert.ToHexString(chains!).ToLowerInvariant(),
+            Is.EqualTo(Testnet3GenesisHashHex));
+    }
+
+    [Test]
+    public void DecodeBolt12Bech32_OfferWithDescription_FindsDescriptionTlv()
+    {
+        var tlv = Bolt12InvoiceParser.DecodeBolt12Bech32(OfferWithDescription);
+
+        var description = Bolt12InvoiceParser.FindTlvRecord(tlv, 10); // offer_description
+
+        Assert.That(description, Is.Not.Null);
+        // "Test vectors" in UTF-8
+        Assert.That(System.Text.Encoding.UTF8.GetString(description!), Is.EqualTo("Test vectors"));
+    }
+
+    // All 20 valid offers from offers-test.json (SetName matches the "description" field).
+    private static IEnumerable<TestCaseData> ValidOffers()
+    {
+        yield return new TestCaseData(
+            "lno1zcss9mk8y3wkklfvevcrszlmu23kfrxh49px20665dqwmn4p72pksese")
+            .SetName("minimal");
+        yield return new TestCaseData(
+            "lno1pgx9getnwss8vetrw3hhyuckyypwa3eyt44h6txtxquqh7lz5djge4afgfjn7k4rgrkuag0jsd5xvxg")
+            .SetName("with_description");
+        yield return new TestCaseData(
+            "lno1qgsyxjtl6luzd9t3pr62xr7eemp6awnejusgf6gw45q75vcfqqqqqqq2p32x2um5ypmx2cm5dae8x93pqthvwfzadd7jejes8q9lhc4rvjxd022zv5l44g6qah82ru5rdpnpj")
+            .SetName("for_testnet");
+        yield return new TestCaseData(
+            "lno1qgsxlc5vp2m0rvmjcxn2y34wv0m5lyc7sdj7zksgn35dvxgqqqqqqqq2p32x2um5ypmx2cm5dae8x93pqthvwfzadd7jejes8q9lhc4rvjxd022zv5l44g6qah82ru5rdpnpj")
+            .SetName("for_bitcoin_redundant");
+        yield return new TestCaseData(
+            "lno1qfqpge38tqmzyrdjj3x2qkdr5y80dlfw56ztq6yd9sme995g3gsxqqm0u2xq4dh3kdevrf4zg6hx8a60jv0gxe0ptgyfc6xkryqqqqqqqq9qc4r9wd6zqan9vd6x7unnzcss9mk8y3wkklfvevcrszlmu23kfrxh49px20665dqwmn4p72pksese")
+            .SetName("for_bitcoin_or_liquidv1");
+        yield return new TestCaseData(
+            "lno1qsgqqqqqqqqqqqqqqqqqqqqqqqqqqzsv23jhxapqwejkxar0wfe3vggzamrjghtt05kvkvpcp0a79gmy3nt6jsn98ad2xs8de6sl9qmgvcvs")
+            .SetName("with_metadata");
+        yield return new TestCaseData(
+            "lno1pqpzwyq2p32x2um5ypmx2cm5dae8x93pqthvwfzadd7jejes8q9lhc4rvjxd022zv5l44g6qah82ru5rdpnpj")
+            .SetName("with_amount");
+        yield return new TestCaseData(
+            "lno1qcp4256ypqpzwyq2p32x2um5ypmx2cm5dae8x93pqthvwfzadd7jejes8q9lhc4rvjxd022zv5l44g6qah82ru5rdpnpj")
+            .SetName("with_currency");
+        yield return new TestCaseData(
+            "lno1pgx9getnwss8vetrw3hhyucwq3ay997czcss9mk8y3wkklfvevcrszlmu23kfrxh49px20665dqwmn4p72pksese")
+            .SetName("with_expiry");
+        yield return new TestCaseData(
+            "lno1pgx9getnwss8vetrw3hhyucjy358garswvaz7tmzdak8gvfj9ehhyeeqgf85c4p3xgsxjmnyw4ehgunfv4e3vggzamrjghtt05kvkvpcp0a79gmy3nt6jsn98ad2xs8de6sl9qmgvcvs")
+            .SetName("with_issuer");
+        yield return new TestCaseData(
+            "lno1pgx9getnwss8vetrw3hhyuc5qyz3vggzamrjghtt05kvkvpcp0a79gmy3nt6jsn98ad2xs8de6sl9qmgvcvs")
+            .SetName("with_quantity");
+        yield return new TestCaseData(
+            "lno1pgx9getnwss8vetrw3hhyuc5qqtzzqhwcuj966ma9n9nqwqtl032xeyv6755yeflt235pmww58egx6rxry")
+            .SetName("unlimited_quantity");
+        yield return new TestCaseData(
+            "lno1pgx9getnwss8vetrw3hhyuc5qyq3vggzamrjghtt05kvkvpcp0a79gmy3nt6jsn98ad2xs8de6sl9qmgvcvs")
+            .SetName("single_quantity");
+        yield return new TestCaseData(
+            "lno1pgx9getnwss8vetrw3hhyucvp5yqqqqqqqqqqqqqqqqqqqqkyypwa3eyt44h6txtxquqh7lz5djge4afgfjn7k4rgrkuag0jsd5xvxg")
+            .SetName("with_feature_bit_99");
+        yield return new TestCaseData(
+            "lno1pgx9getnwss8vetrw3hhyucs5ypjgef743p5fzqq9nqxh0ah7y87rzv3ud0eleps9kl2d5348hq2k8qzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgqpqqqqqqqqqqqqqqqqqqqqqqqqqqqzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqqzq3zyg3zyg3zyg3vggzamrjghtt05kvkvpcp0a79gmy3nt6jsn98ad2xs8de6sl9qmgvcvs")
+            .SetName("blinded_path_via_bob");
+        yield return new TestCaseData(
+            "lno1pgx9getnwss8vetrw3hhyucs3yqqqqqqqqqqqqp2qgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqqyqqqqqqqqqqqqqqqqqqqqqqqqqqqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqqgzyg3zyg3zyg3z93pqthvwfzadd7jejes8q9lhc4rvjxd022zv5l44g6qah82ru5rdpnpj")
+            .SetName("blinded_path_sciddir");
+        yield return new TestCaseData(
+            "lno1pgx9getnwss8vetrw3hhyucs5ypjgef743p5fzqq9nqxh0ah7y87rzv3ud0eleps9kl2d5348hq2k8qzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgqpqqqqqqqqqqqqqqqqqqqqqqqqqqqzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqqzq3zyg3zyg3zygszqqqqyqqqqsqqvpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsq")
+            .SetName("no_issuer_id_blinded_path");
+        yield return new TestCaseData(
+            "lno1pgx9getnwss8vetrw3hhyucsl5qj5qeyv5l2cs6y3qqzesrth7mlzrlp3xg7xhulusczm04x6g6nms9trspqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqqsqqqqqqqqqqqqqqqqqqqqqqqqqqpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsqpqg3zyg3zyg3zygpqqqqzqqqqgqqxqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqqgqqqqqqqqqqqqqqqqqqqqqqqqqqqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgqqsg3zyg3zyg3zygtzzqhwcuj966ma9n9nqwqtl032xeyv6755yeflt235pmww58egx6rxry")
+            .SetName("two_blinded_paths");
+        yield return new TestCaseData(
+            "lno1pgx9getnwss8vetrw3hhyuckyypwa3eyt44h6txtxquqh7lz5djge4afgfjn7k4rgrkuag0jsd5xvxfppf5x2mrvdamk7unvvs")
+            .SetName("unknown_odd_field");
+        yield return new TestCaseData(
+            "lno1pgx9getnwss8vetrw3hhyuckyypwa3eyt44h6txtxquqh7lz5djge4afgfjn7k4rgrkuag0jsd5xvx078wdv5gg2dpjkcmr0wahhymry")
+            .SetName("unknown_odd_experimental_field");
+    }
+
+    [TestCaseSource(nameof(ValidOffers))]
+    public void IsBolt12Offer_ValidOfferTestVectors_ReturnsTrue(string offer)
+    {
+        Assert.That(Bolt12InvoiceParser.IsBolt12Offer(offer), Is.True);
+    }
+
+    [TestCaseSource(nameof(ValidOffers))]
+    public void DecodeBolt12Bech32_ValidOfferTestVectors_DoesNotThrow(string offer)
+    {
+        Assert.DoesNotThrow(() => Bolt12InvoiceParser.DecodeBolt12Bech32(offer));
+    }
+
+    // Invalid offers from offers-test.json where the bech32 encoding itself is wrong
+    // (not just semantic BOLT 12 violations, which our minimal parser doesn't enforce).
+    private static IEnumerable<TestCaseData> InvalidEncodingOffers()
+    {
+        yield return new TestCaseData(
+            "lno1zcss9mk8y3wkklfvevcrszlmu23kfrxh49px20665dqwmn4p72pkseseq")
+            .SetName("padding_exceeds_4bit_limit");
+        yield return new TestCaseData("lno1")
+            .SetName("empty_data_part");
+    }
+
+    [TestCaseSource(nameof(InvalidEncodingOffers))]
+    public void DecodeBolt12Bech32_InvalidEncoding_ThrowsFormatException(string offer)
+    {
+        Assert.Throws<FormatException>(
+            () => Bolt12InvoiceParser.DecodeBolt12Bech32(offer));
+    }
+
+    // format-string-test.json: uppercase variants must decode to the same bytes.
+    [Test]
+    public void DecodeBolt12Bech32_UppercaseFormatString_DecodesIdentically()
+    {
+        const string lower = "lno1pqps7sjqpgtyzm3qv4uxzmtsd3jjqer9wd3hy6tsw35k7msjzfpy7nz5yqcnygrfdej82um5wf5k2uckyypwa3eyt44h6txtxquqh7lz5djge4afgfjn7k4rgrkuag0jsd5xvxg";
+        const string upper = "LNO1PQPS7SJQPGTYZM3QV4UXZMTSD3JJQER9WD3HY6TSW35K7MSJZFPY7NZ5YQCNYGRFDEJ82UM5WF5K2UCKYYPWA3EYT44H6TXTXQUQH7LZ5DJGE4AFGFJN7K4RGRKUAG0JSD5XVXG";
+
+        var fromLower = Bolt12InvoiceParser.DecodeBolt12Bech32(lower);
+        var fromUpper = Bolt12InvoiceParser.DecodeBolt12Bech32(upper.ToLowerInvariant());
+
+        Assert.That(fromLower, Is.EqualTo(fromUpper));
+    }
+
 }

--- a/NArk.Tests/Bolt12InvoiceParserTests.cs
+++ b/NArk.Tests/Bolt12InvoiceParserTests.cs
@@ -334,16 +334,65 @@ public class Bolt12InvoiceParserTests
             Bolt12InvoiceParser.VerifyInvoiceMatchesOffer(invoice, MinimalOffer));
     }
 
+    // "with no issuer_id and blinded path via Bob" from offers-test.json.
+    // TLV 16 structure: intro_node=0324653e... (33B), blinding_point=0202...02 (33B),
+    // num_hops=2, hop1={blinded_node_id=0202...02, enc=0x00×16},
+    //             hop2={blinded_node_id=0202...02, enc=0x11×8}.
+    // → last hop blinded_node_id = 33 bytes of 0x02.
+    private const string BlindedPathOnlyOffer =
+        "lno1pgx9getnwss8vetrw3hhyucs5ypjgef743p5fzqq9nqxh0ah7y87rzv3ud0eleps9kl2d5348hq2k8qzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgqpqqqqqqqqqqqqqqqqqqqqqqqqqqqzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqqzq3zyg3zyg3zygszqqqqyqqqqsqqvpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsq";
+
+    // blinded_node_id of the last hop in BlindedPathOnlyOffer (33 × 0x02).
+    private static readonly byte[] BlindedLastHopNodeId =
+        Convert.FromHexString("020202020202020202020202020202020202020202020202020202020202020202");
+
     [Test]
-    public void VerifyInvoiceMatchesOffer_BlindedPathOnlyOffer_SkipsVerification()
+    public void ParseBlindedPathLastHops_NoIssuerIdOffer_ReturnsLastHopNodeId()
     {
-        // Offer has no offer_issuer_id — verification is skipped, any invoice passes.
-        const string blindedPathOffer =
-            "lno1pgx9getnwss8vetrw3hhyucs5ypjgef743p5fzqq9nqxh0ah7y87rzv3ud0eleps9kl2d5348hq2k8qzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgqpqqqqqqqqqqqqqqqqqqqqqqqqqqqzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqqzq3zyg3zyg3zygszqqqqyqqqqsqqvpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsq";
-        var invoice = BuildInvoiceWithNodeId(KnownPaymentHash, OtherNodeId);
+        var tlv = Bolt12InvoiceParser.DecodeBolt12Bech32(BlindedPathOnlyOffer);
+        var pathsValue = Bolt12InvoiceParser.FindTlvRecord(tlv, 16)!;
+
+        var lastHops = Bolt12InvoiceParser.ParseBlindedPathLastHops(pathsValue);
+
+        Assert.That(lastHops, Has.Count.EqualTo(1));
+        Assert.That(lastHops[0], Is.EqualTo(BlindedLastHopNodeId));
+    }
+
+    [Test]
+    public void VerifyInvoiceMatchesOffer_BlindedPathMatch_DoesNotThrow()
+    {
+        var invoice = BuildInvoiceWithNodeId(KnownPaymentHash, BlindedLastHopNodeId);
 
         Assert.DoesNotThrow(() =>
-            Bolt12InvoiceParser.VerifyInvoiceMatchesOffer(invoice, blindedPathOffer));
+            Bolt12InvoiceParser.VerifyInvoiceMatchesOffer(invoice, BlindedPathOnlyOffer));
+    }
+
+    [Test]
+    public void VerifyInvoiceMatchesOffer_BlindedPathMismatch_ThrowsInvalidOperationException()
+    {
+        var invoice = BuildInvoiceWithNodeId(KnownPaymentHash, OtherNodeId);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            Bolt12InvoiceParser.VerifyInvoiceMatchesOffer(invoice, BlindedPathOnlyOffer));
+    }
+
+    [Test]
+    public void ParseBlindedPathLastHops_TwoBlindedPaths_ReturnsTwoLastHops()
+    {
+        // "... and with second blinded path via 1x2x3 (direction 1)" from offers-test.json.
+        // TLV 16, length 298 — two concatenated blinded paths, each with 2 hops.
+        // Both paths have blinded_node_id = 0202...02 for their last hop.
+        const string twoPathOffer =
+            "lno1pgx9getnwss8vetrw3hhyucsl5qj5qeyv5l2cs6y3qqzesrth7mlzrlp3xg7xhulusczm04x6g6nms9trspqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqqsqqqqqqqqqqqqqqqqqqqqqqqqqqpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsqpqg3zyg3zyg3zygpqqqqzqqqqgqqxqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqqgqqqqqqqqqqqqqqqqqqqqqqqqqqqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgqqsg3zyg3zyg3zygtzzqhwcuj966ma9n9nqwqtl032xeyv6755yeflt235pmww58egx6rxry";
+
+        var tlv = Bolt12InvoiceParser.DecodeBolt12Bech32(twoPathOffer);
+        var pathsValue = Bolt12InvoiceParser.FindTlvRecord(tlv, 16)!;
+
+        var lastHops = Bolt12InvoiceParser.ParseBlindedPathLastHops(pathsValue);
+
+        Assert.That(lastHops, Has.Count.EqualTo(2));
+        Assert.That(lastHops[0], Is.EqualTo(BlindedLastHopNodeId));
+        Assert.That(lastHops[1], Is.EqualTo(BlindedLastHopNodeId));
     }
 
     // ─── Official BOLT 12 test vectors (lightning/bolts bolt12/) ─────────────

--- a/NArk.Tests/Bolt12InvoiceParserTests.cs
+++ b/NArk.Tests/Bolt12InvoiceParserTests.cs
@@ -315,11 +315,27 @@ public class Bolt12InvoiceParserTests
         Assert.That(result, Is.Null);
     }
 
+    // Builds a lni1 invoice whose offer-range TLVs (types 2–22) are taken verbatim
+    // from the given offer, followed by invoice_payment_hash (168) and invoice_node_id (176).
+    // This mirrors what a real BOLT 12 payee returns: all offer fields echoed back.
+    private static string BuildInvoiceWithOfferTlvsAndNodeId(string offer, byte[] paymentHash, byte[] nodeId)
+    {
+        var offerTlv = Bolt12InvoiceParser.DecodeBolt12Bech32(offer.ToLowerInvariant());
+        var offerRangeBytes = Bolt12InvoiceParser.EnumerateTlvRecordsRaw(offerTlv)
+            .Where(r => r.Type >= 2 && r.Type <= 22)
+            .SelectMany(r => r.Raw)
+            .ToArray();
+        // offer-range types (2–22) < invoice_payment_hash (168) < invoice_node_id (176)
+        byte[] tlv = [.. offerRangeBytes, 0xA8, 0x20, .. paymentHash, 0xB0, 0x21, .. nodeId];
+        return Bolt12InvoiceParser.EncodeBolt12Bech32("lni", tlv);
+    }
+
     [Test]
     public void VerifyInvoiceMatchesOffer_MatchingKeys_DoesNotThrow()
     {
         // invoice_node_id == offer_issuer_id (both = KnownNodeId / MinimalOffer key).
-        var invoice = BuildInvoiceWithNodeId(KnownPaymentHash, KnownNodeId);
+        // Invoice also echoes the offer's TLV fields so Check 3 (Merkle root) passes.
+        var invoice = BuildInvoiceWithOfferTlvsAndNodeId(MinimalOffer, KnownPaymentHash, KnownNodeId);
 
         Assert.DoesNotThrow(() =>
             Bolt12InvoiceParser.VerifyInvoiceMatchesOffer(invoice, MinimalOffer));
@@ -361,7 +377,8 @@ public class Bolt12InvoiceParserTests
     [Test]
     public void VerifyInvoiceMatchesOffer_BlindedPathMatch_DoesNotThrow()
     {
-        var invoice = BuildInvoiceWithNodeId(KnownPaymentHash, BlindedLastHopNodeId);
+        // Invoice echoes the offer's TLV fields so Check 3 (Merkle root) passes.
+        var invoice = BuildInvoiceWithOfferTlvsAndNodeId(BlindedPathOnlyOffer, KnownPaymentHash, BlindedLastHopNodeId);
 
         Assert.DoesNotThrow(() =>
             Bolt12InvoiceParser.VerifyInvoiceMatchesOffer(invoice, BlindedPathOnlyOffer));
@@ -565,6 +582,142 @@ public class Bolt12InvoiceParserTests
         var fromUpper = Bolt12InvoiceParser.DecodeBolt12Bech32(upper.ToLowerInvariant());
 
         Assert.That(fromLower, Is.EqualTo(fromUpper));
+    }
+
+    // ─── BOLT 12 Merkle hashing (signature-test.json vectors) ────────────────
+    // Source: https://github.com/lightning/bolts/blob/master/bolt12/signature-test.json
+    // Each test case passes raw TLV records (type + full wire bytes) and the
+    // expected Merkle root as a lowercase hex string.
+
+    private static IEnumerable<TestCaseData> MerkleSignatureTestCases()
+    {
+        // Vector 1: n1 — tlv1 type=1 value=1000
+        yield return new TestCaseData(
+            new List<(ulong, byte[])>
+            {
+                (1UL, Convert.FromHexString("010203e8")),
+            },
+            "b013756c8fee86503a0b4abdab4cddeb1af5d344ca6fc2fa8b6c08938caa6f93"
+        ).SetName("one_tlv_1000");
+
+        // Vector 2: n1 — tlv1 type=1 value=1000, tlv2 type=2 value=1x2x3
+        yield return new TestCaseData(
+            new List<(ulong, byte[])>
+            {
+                (1UL, Convert.FromHexString("010203e8")),
+                (2UL, Convert.FromHexString("02080000010000020003")),
+            },
+            "c3774abbf4815aa54ccaa026bff6581f01f3be5fe814c620a252534f434bc0d1"
+        ).SetName("two_tlvs_1000_1x2x3");
+
+        // Vector 3: n1 — tlv1=1000, tlv2=1x2x3, tlv3=pubkey(0266e4…)+1+2
+        yield return new TestCaseData(
+            new List<(ulong, byte[])>
+            {
+                (1UL, Convert.FromHexString("010203e8")),
+                (2UL, Convert.FromHexString("02080000010000020003")),
+                (3UL, Convert.FromHexString(
+                    "03310266e4598d1d3c415f572a8488830b60f7e744ed9235eb0b1ba93283b315c03518" +
+                    "00000000000000010000000000000002")),
+            },
+            "ab2e79b1283b0b31e0b035258de23782df6b89a38cfa7237bde69aed1a658c5d"
+        ).SetName("three_tlvs_1000_1x2x3_pubkey");
+
+        // Vector 4: invoice_request — offer_issuer_id=Alice, offer_description="A Mathematical
+        // Treatise", offer_amount=100 USD, invreq_metadata=0, invreq_payer_id=Bob.
+        // TLV types: 0 (invreq_metadata), 6 (offer_currency), 8 (offer_amount),
+        //            10 (offer_description), 22 (offer_issuer_id), 88 (invreq_payer_id).
+        yield return new TestCaseData(
+            new List<(ulong, byte[])>
+            {
+                ( 0UL, Convert.FromHexString("00080000000000000000")),
+                ( 6UL, Convert.FromHexString("0603555344")),
+                ( 8UL, Convert.FromHexString("080164")),
+                (10UL, Convert.FromHexString("0a1741204d617468656d61746963616c205472656174697365")),
+                (22UL, Convert.FromHexString("162102eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619")),
+                (88UL, Convert.FromHexString("58210324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c")),
+            },
+            "608407c18ad9a94d9ea2bcdbe170b6c20c462a7833a197621c916f78cf18e624"
+        ).SetName("invoice_request_alice_bob");
+    }
+
+    [TestCaseSource(nameof(MerkleSignatureTestCases))]
+    public void ComputeMerkleRoot_SignatureTestVector(
+        List<(ulong, byte[])> records, string expectedHex)
+    {
+        var root = Bolt12InvoiceParser.ComputeMerkleRoot(records);
+
+        Assert.That(Convert.ToHexString(root).ToLowerInvariant(), Is.EqualTo(expectedHex));
+    }
+
+    [Test]
+    public void ComputeMerkleRoot_EmptyList_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            Bolt12InvoiceParser.ComputeMerkleRoot([]));
+    }
+
+    [Test]
+    public void ComputeOfferIdMerkleRoot_MinimalOffer_ReturnsNonNull()
+    {
+        // MinimalOffer has exactly one TLV: type 22 (offer_issuer_id) which is in range 2–22.
+        var tlv = Bolt12InvoiceParser.DecodeBolt12Bech32(MinimalOffer);
+
+        var root = Bolt12InvoiceParser.ComputeOfferIdMerkleRoot(tlv);
+
+        Assert.That(root, Is.Not.Null);
+        Assert.That(root!.Length, Is.EqualTo(32));
+    }
+
+    [Test]
+    public void ComputeOfferIdMerkleRoot_EmptyStream_ReturnsNull()
+    {
+        var root = Bolt12InvoiceParser.ComputeOfferIdMerkleRoot([]);
+
+        Assert.That(root, Is.Null);
+    }
+
+    [Test]
+    public void ComputeOfferIdMerkleRoot_StreamWithNoOfferRangeTlvs_ReturnsNull()
+    {
+        // Invoice with only type 168 and 176 — outside the 2–22 offer range.
+        var tlv = Bolt12InvoiceParser.DecodeBolt12Bech32(
+            BuildInvoiceWithNodeId(KnownPaymentHash, KnownNodeId));
+
+        var root = Bolt12InvoiceParser.ComputeOfferIdMerkleRoot(tlv);
+
+        Assert.That(root, Is.Null);
+    }
+
+    [Test]
+    public void ComputeOfferIdMerkleRoot_OfferAndMatchingInvoice_RootsAreEqual()
+    {
+        // Verify that extracting offer-range TLVs from the offer and from a
+        // properly constructed invoice yields the same Merkle root.
+        var offerTlv = Bolt12InvoiceParser.DecodeBolt12Bech32(MinimalOffer);
+        var invoice = BuildInvoiceWithOfferTlvsAndNodeId(MinimalOffer, KnownPaymentHash, KnownNodeId);
+        var invoiceTlv = Bolt12InvoiceParser.DecodeBolt12Bech32(invoice);
+
+        var offerRoot = Bolt12InvoiceParser.ComputeOfferIdMerkleRoot(offerTlv);
+        var invoiceRoot = Bolt12InvoiceParser.ComputeOfferIdMerkleRoot(invoiceTlv);
+
+        Assert.That(offerRoot, Is.Not.Null);
+        Assert.That(invoiceRoot, Is.Not.Null);
+        Assert.That(offerRoot, Is.EqualTo(invoiceRoot));
+    }
+
+    [Test]
+    public void VerifyInvoiceMatchesOffer_OfferMerkleRootMismatch_ThrowsInvalidOperationException()
+    {
+        // Invoice has invoice_node_id = KnownNodeId (passes Check 1 against MinimalOffer),
+        // but its offer_issuer_id TLV (type 22) carries OtherNodeId instead of KnownNodeId,
+        // so the Merkle root of offer-range TLVs will not match. Check 3 must reject it.
+        byte[] type22WithWrongKey = [0x16, 0x21, .. OtherNodeId]; // type 22, wrong key
+        byte[] tlv = [.. type22WithWrongKey, 0xA8, 0x20, .. KnownPaymentHash, 0xB0, 0x21, .. KnownNodeId];
+        var invoice = Bolt12InvoiceParser.EncodeBolt12Bech32("lni", tlv);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            Bolt12InvoiceParser.VerifyInvoiceMatchesOffer(invoice, MinimalOffer));
     }
 
 }


### PR DESCRIPTION
## Summary

- Adds a minimal BOLT 12 TLV parser (`Bolt12InvoiceParser`) that decodes
  `lni1…` invoices and `lno1…` offers without an external BOLT 12 library.
  Three-check verification confirms an invoice was generated from the given
  offer: (1) `invoice_node_id` / `offer_issuer_id` key match, (2) blinded
  path final-hop key match, (3) Merkle root of offer-range TLV fields
  (types 2–22) must be identical — all four official `signature-test.json`
  test vectors pass.

- Extends Boltz client with the BOLT 12 offer-bridge endpoints
  (`GET /bolt12/{receiving}`, `POST /bolt12`, `PATCH /bolt12`,
  `POST /bolt12/delete`) and the fetch endpoint
  (`POST /bolt12/fetch`) used by the submarine flow.

- Adds `BoltzSwapService.CreateSubmarineSwapBolt12` (internal): fetches a
  BOLT 12 invoice from the offer via Boltz, verifies it matches the offer,
  then constructs the VHTLC contract identical to the BOLT 11 path.

- Adds `SwapsManagementService.InitiateSubmarineSwapBolt12` (public): the
  top-level entry point — resolves a wallet descriptor, calls the service
  above, stores the swap with `ArkSwapType.Submarine` and the fetched
  `lni1…` invoice, and optionally funds the VHTLC immediately via
  `SpendingService.Spend`.

- Extends `SubmarineSwapResult` with an optional `Invoice` string so both
  the BOLT 11 and BOLT 12 paths can carry the invoice through to storage.

- Adds `DockerHelper.CreateClnBolt12Offer` using `docker exec cln
  lightning-cli offer` (Nigiri ships CLN).

- Adds E2E test `CanPayBolt12OfferWithArkadeUsingBoltz` (`[Explicit]`,
  `[Category("Bolt12")]`): reads the offer from `BOLT12_OFFER` env var or
  generates one from the Nigiri CLN container. Skipped in CI until Boltz is
  configured with a BOLT 12-capable Lightning backend (CLN/LDK).

## Test plan

- [ ] `dotnet test NArk.Tests` — 493 unit tests pass (Merkle vectors,
  parser, blinded-path checks)
- [ ] Manual E2E: generate offer with
  `docker exec cln lightning-cli --network=regtest offer any "nark bolt12 e2e"`,
  then run
  `BOLT12_OFFER=lno1... dotnet test --filter CanPayBolt12OfferWithArkadeUsingBoltz`
  against a regtest stack with Boltz configured for CLN