### PR TITLE
feat(payments): lift LnurlHelper from samples into NArk.Core.Payments

### DIFF
--- a/NArk.Core/Payments/LnurlHelper.cs
+++ b/NArk.Core/Payments/LnurlHelper.cs
@@ -1,23 +1,28 @@
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 
-namespace NArk.Wallet.Client.Services;
+namespace NArk.Core.Payments;
 
 /// <summary>
-/// Client-side LNURL-pay decoder and callback handler.
-/// Handles lnurl1... bech32 strings and Lightning Addresses (user@domain).
+/// Client-side LNURL-pay decoder and callback handler. Resolves both bech32 <c>lnurl1…</c>
+/// strings and Lightning Addresses (<c>user@domain</c>) into pay-params, and fetches a BOLT11
+/// invoice from a callback URL.
+/// <para>Pure consumer helper — no Ark-specific state. Lifted into the SDK so wallet hosts
+/// don't each reinvent the same well-known-URL + bech32 + JSON decode dance.</para>
 /// </summary>
 public class LnurlHelper(HttpClient http)
 {
+    /// <summary>
+    /// Pay-params returned by an LNURL-pay endpoint. Amounts are normalised to satoshis
+    /// (the wire format is millisats).
+    /// </summary>
     public record LnurlPayParams(
         string Callback,
         long MinSendable,
         long MaxSendable,
         string? Description);
 
-    /// <summary>
-    /// Detects if the input is an LNURL or Lightning Address.
-    /// </summary>
+    /// <summary>True if <paramref name="input"/> looks like an LNURL or Lightning Address.</summary>
     public static bool IsLnurl(string input)
     {
         input = input.Trim();
@@ -25,16 +30,17 @@ public class LnurlHelper(HttpClient http)
             return true;
         if (input.StartsWith("lightning:", StringComparison.OrdinalIgnoreCase))
             return true;
-        // Lightning Address: user@domain
+        // Lightning Address: user@domain (no spaces, '@' not in first column).
         if (input.Contains('@') && !input.Contains(' ') && input.IndexOf('@') > 0)
             return true;
         return false;
     }
 
     /// <summary>
-    /// Resolves an LNURL or Lightning Address to its pay parameters.
+    /// Resolves an LNURL or Lightning Address to its pay parameters by fetching the
+    /// well-known URL (Lightning Address) or decoded bech32 URL (LNURL).
     /// </summary>
-    public async Task<LnurlPayParams> ResolveAsync(string input)
+    public async Task<LnurlPayParams> ResolveAsync(string input, CancellationToken cancellationToken = default)
     {
         input = input.Trim();
 
@@ -44,7 +50,7 @@ public class LnurlHelper(HttpClient http)
 
         if (input.Contains('@'))
         {
-            // Lightning Address → well-known URL
+            // Lightning Address → well-known URL.
             var parts = input.Split('@', 2);
             url = $"https://{parts[1]}/.well-known/lnurlp/{parts[0]}";
         }
@@ -54,32 +60,32 @@ public class LnurlHelper(HttpClient http)
         }
         else
         {
-            throw new ArgumentException("Not a valid LNURL or Lightning Address");
+            throw new ArgumentException("Not a valid LNURL or Lightning Address", nameof(input));
         }
 
-        var response = await http.GetFromJsonAsync<LnurlPayResponse>(url)
+        var response = await http.GetFromJsonAsync<LnurlPayResponse>(url, cancellationToken).ConfigureAwait(false)
             ?? throw new InvalidOperationException("Failed to fetch LNURL-pay params");
 
-        if (response.Tag?.ToLower() != "payrequest")
+        if (response.Tag?.ToLowerInvariant() != "payrequest")
             throw new InvalidOperationException($"Expected payRequest, got: {response.Tag}");
 
         return new LnurlPayParams(
             response.Callback,
-            response.MinSendable / 1000, // Convert millisats to sats
+            response.MinSendable / 1000, // millisats → sats
             response.MaxSendable / 1000,
             response.Metadata);
     }
 
     /// <summary>
-    /// Fetches a Lightning invoice from the LNURL-pay callback.
+    /// Fetches a BOLT11 invoice from an LNURL-pay <c>callback</c> URL for the given amount.
     /// </summary>
-    public async Task<string> FetchInvoiceAsync(string callback, long amountSats)
+    public async Task<string> FetchInvoiceAsync(string callback, long amountSats, CancellationToken cancellationToken = default)
     {
         var amountMsat = amountSats * 1000;
         var separator = callback.Contains('?') ? "&" : "?";
         var url = $"{callback}{separator}amount={amountMsat}";
 
-        var response = await http.GetFromJsonAsync<LnurlCallbackResponse>(url)
+        var response = await http.GetFromJsonAsync<LnurlCallbackResponse>(url, cancellationToken).ConfigureAwait(false)
             ?? throw new InvalidOperationException("Failed to fetch invoice from LNURL callback");
 
         if (!string.IsNullOrEmpty(response.Reason))
@@ -88,13 +94,13 @@ public class LnurlHelper(HttpClient http)
         return response.Pr ?? throw new InvalidOperationException("No invoice in LNURL response");
     }
 
-    private static string DecodeLnurl(string lnurl)
+    /// <summary>Decodes a bech32 <c>lnurl1…</c> string to its underlying callback URL.</summary>
+    public static string DecodeLnurl(string lnurl)
     {
-        // Decode bech32 LNURL to URL
         var encoder = NBitcoin.DataEncoders.Encoders.Bech32("lnurl");
         encoder.StrictLength = false;
         encoder.SquashBytes = true;
-        var data = encoder.DecodeDataRaw(lnurl.ToLower(), out _);
+        var data = encoder.DecodeDataRaw(lnurl.ToLowerInvariant(), out _);
         return System.Text.Encoding.UTF8.GetString(data);
     }
 

--- a/NArk.Tests/LnurlHelperTests.cs
+++ b/NArk.Tests/LnurlHelperTests.cs
@@ -1,0 +1,126 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using NArk.Core.Payments;
+
+namespace NArk.Tests;
+
+/// <summary>
+/// Pins the public surface of <see cref="LnurlHelper"/> after lifting it out of the WASM sample:
+/// detection rules for LNURL / Lightning Address, bech32 decode of <c>lnurl1…</c>, and the
+/// callback-fetch wire format (millisat amount, separator handling, error surfacing).
+/// </summary>
+[TestFixture]
+public class LnurlHelperTests
+{
+    [Test]
+    public void IsLnurl_Lightning1Prefix_True()
+    {
+        Assert.That(LnurlHelper.IsLnurl("LNURL1DP68GURN8GHJ7MRWWPSHJTNRDUH"), Is.True);
+    }
+
+    [Test]
+    public void IsLnurl_LightningScheme_True()
+    {
+        Assert.That(LnurlHelper.IsLnurl("lightning:LNURL1DP68GURN8GHJ7"), Is.True);
+    }
+
+    [Test]
+    public void IsLnurl_LightningAddress_True()
+    {
+        Assert.That(LnurlHelper.IsLnurl("alice@walletofsatoshi.com"), Is.True);
+    }
+
+    [Test]
+    public void IsLnurl_BareEmail_True()
+    {
+        // The test mirrors arkade-os/wallet's lenient detection: anything user@host shaped
+        // is treated as a candidate (the well-known fetch is what actually validates it).
+        Assert.That(LnurlHelper.IsLnurl("user@example.com"), Is.True);
+    }
+
+    [Test]
+    public void IsLnurl_OnchainAddress_False()
+    {
+        Assert.That(LnurlHelper.IsLnurl("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"), Is.False);
+    }
+
+    [Test]
+    public void IsLnurl_AtSignAtStart_False()
+    {
+        Assert.That(LnurlHelper.IsLnurl("@bad"), Is.False);
+    }
+
+    [Test]
+    public void DecodeLnurl_RoundTrip_ProducesUrl()
+    {
+        // Canonical example from the LNURL spec / bech32 LUD-01.
+        const string Encoded = "LNURL1DP68GURN8GHJ7UM9WFMXJCM99E3K7MF0V9CXJ0M385EKVCENXC6R2C35XVUKXEFCV5MKVV34X5EKZD3EV56NYD3HXQURZEPEXEJXXEPNXSCRVWFNV9NXZCN9XQ6XYEFHVGCXXCMYXYMNSERXFQ5FNS";
+        string url = LnurlHelper.DecodeLnurl(Encoded);
+        Assert.That(url, Does.StartWith("https://"));
+        Assert.That(Uri.TryCreate(url, UriKind.Absolute, out _), Is.True);
+    }
+
+    [Test]
+    public async Task FetchInvoiceAsync_AppendsAmount_AndReturnsPr()
+    {
+        var stub = new StubMessageHandler((req, _) =>
+        {
+            Assert.That(req.RequestUri!.ToString(), Does.Contain("amount=100000")); // 100 sats → 100_000 msat
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent("{\"pr\":\"lnbc100stub\"}"),
+            };
+        });
+        var helper = new LnurlHelper(new HttpClient(stub));
+
+        string invoice = await helper.FetchInvoiceAsync("https://lnurl.example/cb", amountSats: 100);
+
+        Assert.That(invoice, Is.EqualTo("lnbc100stub"));
+    }
+
+    [Test]
+    public async Task FetchInvoiceAsync_CallbackAlreadyHasQuery_UsesAmpersand()
+    {
+        var stub = new StubMessageHandler((req, _) =>
+        {
+            // ?session=abc preserved + & separator + amount appended.
+            Assert.That(req.RequestUri!.Query, Does.Contain("session=abc"));
+            Assert.That(req.RequestUri!.Query, Does.Contain("&amount=1000"));
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = JsonContent("{\"pr\":\"lnbc1stub\"}"),
+            };
+        });
+        var helper = new LnurlHelper(new HttpClient(stub));
+
+        await helper.FetchInvoiceAsync("https://lnurl.example/cb?session=abc", amountSats: 1);
+    }
+
+    [Test]
+    public void FetchInvoiceAsync_ServerReasonField_Throws()
+    {
+        var stub = new StubMessageHandler((_, _) => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = JsonContent("{\"reason\":\"amount too small\"}"),
+        });
+        var helper = new LnurlHelper(new HttpClient(stub));
+
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(
+            () => helper.FetchInvoiceAsync("https://lnurl.example/cb", 1));
+        Assert.That(ex!.Message, Does.Contain("amount too small"));
+    }
+
+    private static StringContent JsonContent(string json)
+    {
+        var c = new StringContent(json);
+        c.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        return c;
+    }
+
+    private sealed class StubMessageHandler(Func<HttpRequestMessage, CancellationToken, HttpResponseMessage> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(handler(request, cancellationToken));
+    }
+}

--- a/samples/NArk.Wallet/NArk.Wallet.Client/Pages/Send.razor
+++ b/samples/NArk.Wallet/NArk.Wallet.Client/Pages/Send.razor
@@ -6,6 +6,7 @@
 @inject LnurlHelper Lnurl
 @using NArk.Wallet.Client.Services
 @using NArk.Abstractions.Payments
+@using NArk.Core.Payments
 @using NArk.Swaps.Boltz
 
 <div class="page-header">

--- a/samples/NArk.Wallet/NArk.Wallet.Client/Program.cs
+++ b/samples/NArk.Wallet/NArk.Wallet.Client/Program.cs
@@ -9,6 +9,7 @@ using NArk.Blockchain;
 using NArk.Abstractions.Intents;
 using NArk.Core.Services;
 using NArk.Core.Wallet;
+using NArk.Core.Payments;
 using NArk.Hosting;
 using NArk.Storage.EfCore.Hosting;
 using NArk.Swaps.Hosting;


### PR DESCRIPTION
## Summary

\`LnurlHelper\` — the LNURL-pay decode / Lightning Address resolve / callback-fetch logic — was trapped in the WASM sample. Lift it into \`NArk.Core/Payments/\` so downstream wallet hosts don't each reinvent it (or maintain a parallel copy, which is what motivated this PR — WalletWasabi's Arkade integration needs the same logic for its universal-send box).

## Why

The SDK already ships everything else a payments box needs in \`NArk.Abstractions.Payments\`:

- \`ArkBip21\` (build BIP21 URIs)
- \`Bip21PaymentInfo\` (parse BIP21 / raw Ark / raw BOLT11 / raw onchain) with \`PreferredMethod\` + \`Recipient\` for routing
- \`ArkPaymentMethod\` enum

LNURL was the one gap — wallets that wanted Lightning Address / \`lnurl1…\` support either copied the sample or wrote it from scratch. With this PR, \`NArk.Core.Payments.LnurlHelper\` fills the gap and the SDK is a complete payment-handling toolkit.

## Approach

- New file \`NArk.Core/Payments/LnurlHelper.cs\`. Public API unchanged from the sample: \`IsLnurl\`, \`ResolveAsync\`, \`FetchInvoiceAsync\`, \`DecodeLnurl\`, \`LnurlPayParams\`. Added \`CancellationToken\` parameters for SDK-style consistency.
- No new dependencies — already uses NBitcoin's bech32 encoder and built-in \`System.Net.Http.Json\`.
- Sample (\`samples/NArk.Wallet\`): private copy deleted; \`Program.cs\` + \`Send.razor\` switch to \`using NArk.Core.Payments;\` so \`new LnurlHelper(new HttpClient())\` resolves through the SDK type. Public API identical → zero call-site changes beyond the namespace.
- \`NArk.Tests/LnurlHelperTests.cs\` pins:
  - Detection rules (\`lnurl1\` / \`lightning:\` scheme / \`user@host\` / rejection of bare onchain + leading \`@\`)
  - \`DecodeLnurl\` round-trips a canonical LUD-01 example to a valid URI
  - \`FetchInvoiceAsync\` wire format: sats → msat conversion, \`?\` vs \`&\` separator handling, \`reason\` error field surfaced as \`InvalidOperationException\`

## Test plan

- [x] \`dotnet build NArk.Core\` — 0 errors
- [x] \`dotnet build samples/NArk.Wallet/NArk.Wallet.Client\` — 0 errors (consumer side proves the rename is clean)
- [x] \`dotnet test NArk.Tests\` — **414 / 414** (404 existing + 10 new)