### PR TITLE
feat(wallets): watch-only + remote-signing as signer-provider capabilities (not WalletType cases)

### DIFF
--- a/NArk.Abstractions/Wallets/ArkWalletInfo.cs
+++ b/NArk.Abstractions/Wallets/ArkWalletInfo.cs
@@ -4,9 +4,18 @@ namespace NArk.Abstractions.Wallets;
 /// Wallet information record used at the abstraction/interface boundary.
 /// </summary>
 /// <param name="Id">Wallet identifier.</param>
-/// <param name="Secret">For nsec wallets: the nsec private key. For HD wallets: the BIP-39 mnemonic.</param>
+/// <param name="Secret">
+/// Signing material for the wallet, interpreted according to
+/// <paramref name="WalletType"/>:
+/// <list type="bullet">
+///   <item><description><see cref="Wallets.WalletType.SingleKey"/>: the nsec private key — MUST be non-null and non-empty.</description></item>
+///   <item><description><see cref="Wallets.WalletType.HD"/>: the BIP-39 mnemonic — MUST be non-null and non-empty.</description></item>
+///   <item><description><see cref="Wallets.WalletType.WatchOnly"/>: MUST be null or empty — the wallet holds no signing material.</description></item>
+///   <item><description><see cref="Wallets.WalletType.Remote"/>: MUST be null or empty — signing is proxied via <see cref="IRemoteSignerTransport"/>.</description></item>
+/// </list>
+/// </param>
 /// <param name="Destination">Destination address for swept funds.</param>
-/// <param name="WalletType">Wallet flavour (legacy nsec or HD mnemonic).</param>
+/// <param name="WalletType">Wallet flavour — see <see cref="Wallets.WalletType"/>.</param>
 /// <param name="AccountDescriptor">For HD wallets: the account descriptor. For legacy: <c>tr(pubkey)</c>.</param>
 /// <param name="LastUsedIndex">For HD wallets: last used derivation index.</param>
 /// <param name="Metadata">
@@ -18,7 +27,7 @@ namespace NArk.Abstractions.Wallets;
 /// </param>
 public record ArkWalletInfo(
     string Id,
-    string Secret,
+    string? Secret,
     string? Destination,
     WalletType WalletType,
     string? AccountDescriptor,

--- a/NArk.Abstractions/Wallets/ArkWalletInfo.cs
+++ b/NArk.Abstractions/Wallets/ArkWalletInfo.cs
@@ -5,17 +5,16 @@ namespace NArk.Abstractions.Wallets;
 /// </summary>
 /// <param name="Id">Wallet identifier.</param>
 /// <param name="Secret">
-/// Signing material for the wallet, interpreted according to
-/// <paramref name="WalletType"/>:
-/// <list type="bullet">
-///   <item><description><see cref="Wallets.WalletType.SingleKey"/>: the nsec private key — MUST be non-null and non-empty.</description></item>
-///   <item><description><see cref="Wallets.WalletType.HD"/>: the BIP-39 mnemonic — MUST be non-null and non-empty.</description></item>
-///   <item><description><see cref="Wallets.WalletType.WatchOnly"/>: MUST be null or empty — the wallet holds no signing material.</description></item>
-///   <item><description><see cref="Wallets.WalletType.Remote"/>: MUST be null or empty — signing is proxied via <see cref="IRemoteSignerTransport"/>.</description></item>
-/// </list>
+/// Local signing material, when present, interpreted according to <paramref name="WalletType"/>:
+/// the nsec private key for <see cref="Wallets.WalletType.SingleKey"/>, the BIP-39 mnemonic for
+/// <see cref="Wallets.WalletType.HD"/>.
+/// <para>Null/empty means the wallet has no local key — it is either watch-only or remote-signed,
+/// distinguished at runtime by whether <see cref="IWalletProvider.GetSignerAsync"/> can produce
+/// a signer (e.g. via a registered <see cref="IRemoteSignerTransport"/>). Capability lives on
+/// the signer-provider boundary; it is not encoded in the data type.</para>
 /// </param>
 /// <param name="Destination">Destination address for swept funds.</param>
-/// <param name="WalletType">Wallet flavour — see <see cref="Wallets.WalletType"/>.</param>
+/// <param name="WalletType">Key-derivation flavour — see <see cref="Wallets.WalletType"/>.</param>
 /// <param name="AccountDescriptor">For HD wallets: the account descriptor. For legacy: <c>tr(pubkey)</c>.</param>
 /// <param name="LastUsedIndex">For HD wallets: last used derivation index.</param>
 /// <param name="Metadata">

--- a/NArk.Abstractions/Wallets/IRemoteSignerTransport.cs
+++ b/NArk.Abstractions/Wallets/IRemoteSignerTransport.cs
@@ -1,0 +1,80 @@
+using NBitcoin;
+using NBitcoin.Scripting;
+using NBitcoin.Secp256k1;
+using NBitcoin.Secp256k1.Musig;
+
+namespace NArk.Abstractions.Wallets;
+
+/// <summary>
+/// Transport abstraction over a remote signer. Mirrors
+/// <see cref="IArkadeWalletSigner"/> but adds a <c>walletId</c> argument to
+/// every call so a single transport instance can serve multiple wallets
+/// (e.g. a multi-user server-side signing service, an HWI bridge, or a
+/// browser-extension wallet shared across tabs).
+/// </summary>
+/// <remarks>
+/// Register an implementation in DI alongside a wallet of type
+/// <see cref="WalletType.Remote"/>. The default
+/// <see cref="IWalletProvider"/> implementation will wrap the transport in
+/// an <c>IArkadeWalletSigner</c> proxy when <see cref="IWalletProvider.GetSignerAsync"/>
+/// is called for a Remote wallet.
+/// </remarks>
+public interface IRemoteSignerTransport
+{
+    /// <summary>
+    /// Gets the compressed public key for the given descriptor, preserving parity.
+    /// </summary>
+    /// <param name="walletId">The wallet whose key is being requested.</param>
+    /// <param name="descriptor">The descriptor identifying the key to return.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<ECPubKey> GetPubKeyAsync(
+        string walletId,
+        OutputDescriptor descriptor,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Produces a MuSig2 partial signature for the given context and nonce
+    /// using the descriptor's private key.
+    /// </summary>
+    /// <param name="walletId">The wallet whose key signs.</param>
+    /// <param name="descriptor">The descriptor identifying the signing key.</param>
+    /// <param name="context">The MuSig2 context (cosigner set + sighash).</param>
+    /// <param name="nonce">The secret nonce produced earlier by <see cref="GenerateNoncesAsync"/>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<MusigPartialSignature> SignMusigAsync(
+        string walletId,
+        OutputDescriptor descriptor,
+        MusigContext context,
+        MusigPrivNonce nonce,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Produces a BIP-340 Schnorr signature over <paramref name="hash"/> using
+    /// the descriptor's private key, returning the x-only pubkey alongside the
+    /// signature.
+    /// </summary>
+    /// <param name="walletId">The wallet whose key signs.</param>
+    /// <param name="descriptor">The descriptor identifying the signing key.</param>
+    /// <param name="hash">The 32-byte hash to sign.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<(ECXOnlyPubKey, SecpSchnorrSignature)> SignAsync(
+        string walletId,
+        OutputDescriptor descriptor,
+        uint256 hash,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Generates the secret nonce for the supplied MuSig2 context. The returned
+    /// nonce is bound to <paramref name="context"/> and must be passed back
+    /// into <see cref="SignMusigAsync"/> on the same context.
+    /// </summary>
+    /// <param name="walletId">The wallet whose key contributes the nonce.</param>
+    /// <param name="descriptor">The descriptor identifying the signing key.</param>
+    /// <param name="context">The MuSig2 context the nonce is generated for.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<MusigPrivNonce> GenerateNoncesAsync(
+        string walletId,
+        OutputDescriptor descriptor,
+        MusigContext context,
+        CancellationToken cancellationToken = default);
+}

--- a/NArk.Abstractions/Wallets/IRemoteSignerTransport.cs
+++ b/NArk.Abstractions/Wallets/IRemoteSignerTransport.cs
@@ -6,21 +6,30 @@ using NBitcoin.Secp256k1.Musig;
 namespace NArk.Abstractions.Wallets;
 
 /// <summary>
-/// Transport abstraction over a remote signer. Mirrors
-/// <see cref="IArkadeWalletSigner"/> but adds a <c>walletId</c> argument to
-/// every call so a single transport instance can serve multiple wallets
-/// (e.g. a multi-user server-side signing service, an HWI bridge, or a
+/// Transport abstraction over a remote signer. Mirrors <see cref="IArkadeWalletSigner"/> but
+/// adds a <c>walletId</c> argument to every call so a single transport instance can serve
+/// multiple wallets (e.g. a multi-user server-side signing service, an HWI bridge, or a
 /// browser-extension wallet shared across tabs).
 /// </summary>
 /// <remarks>
-/// Register an implementation in DI alongside a wallet of type
-/// <see cref="WalletType.Remote"/>. The default
-/// <see cref="IWalletProvider"/> implementation will wrap the transport in
-/// an <c>IArkadeWalletSigner</c> proxy when <see cref="IWalletProvider.GetSignerAsync"/>
-/// is called for a Remote wallet.
+/// Register an implementation in DI alongside any wallet whose <see cref="ArkWalletInfo.Secret"/>
+/// is null/empty (i.e. no local signing material). The default <see cref="IWalletProvider"/>
+/// implementation probes <see cref="KnowsWalletAsync"/> to decide whether such a wallet is
+/// remote-signed (signer is a <see cref="IArkadeWalletSigner"/> proxy over this transport) or
+/// watch-only (<see cref="IWalletProvider.GetSignerAsync"/> returns <c>null</c>). Capability is
+/// answered by this interface, not by a flag on the wallet record.
 /// </remarks>
 public interface IRemoteSignerTransport
 {
+    /// <summary>
+    /// Indicates whether this transport can sign for the given wallet. Used by the wallet
+    /// provider to distinguish remote-signed wallets from watch-only ones when the wallet has
+    /// no local <see cref="ArkWalletInfo.Secret"/>: <c>true</c> → produce a remote-signer proxy;
+    /// <c>false</c> → fall through to watch-only (signer = null).
+    /// </summary>
+    Task<bool> KnowsWalletAsync(string walletId, CancellationToken cancellationToken = default);
+
+
     /// <summary>
     /// Gets the compressed public key for the given descriptor, preserving parity.
     /// </summary>

--- a/NArk.Abstractions/Wallets/IRemoteSignerTransport.cs
+++ b/NArk.Abstractions/Wallets/IRemoteSignerTransport.cs
@@ -18,6 +18,17 @@ namespace NArk.Abstractions.Wallets;
 /// remote-signed (signer is a <see cref="IArkadeWalletSigner"/> proxy over this transport) or
 /// watch-only (<see cref="IWalletProvider.GetSignerAsync"/> returns <c>null</c>). Capability is
 /// answered by this interface, not by a flag on the wallet record.
+/// <para>
+/// <b>SECURITY LIMITATION (phase 1):</b> <see cref="GenerateNoncesAsync"/> currently returns
+/// the MuSig2 secret nonce to the SDK and <see cref="SignMusigAsync"/> accepts it back across
+/// the transport. The cryptographic argument for remote signing — that private material never
+/// leaves the signer — does <i>not</i> hold under this interface. The intended phase-2 shape
+/// has <see cref="GenerateNoncesAsync"/> returning only the public nonce and
+/// <see cref="SignMusigAsync"/> taking no nonce parameter (the signer remembers it indexed by
+/// context). Tracked in <see href="https://github.com/arkade-os/dotnet-sdk/issues/111">#111</see>;
+/// do not rely on nonce confidentiality of an <see cref="IRemoteSignerTransport"/>
+/// implementation until that is fixed.
+/// </para>
 /// </remarks>
 public interface IRemoteSignerTransport
 {
@@ -50,6 +61,9 @@ public interface IRemoteSignerTransport
     /// <param name="context">The MuSig2 context (cosigner set + sighash).</param>
     /// <param name="nonce">The secret nonce produced earlier by <see cref="GenerateNoncesAsync"/>.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    // TODO: SECURITY — drop the `nonce` parameter and have the signer dereference
+    // the private nonce it kept after GenerateNoncesAsync via a context key. Phase-2,
+    // tracked at https://github.com/arkade-os/dotnet-sdk/issues/111.
     Task<MusigPartialSignature> SignMusigAsync(
         string walletId,
         OutputDescriptor descriptor,
@@ -81,6 +95,10 @@ public interface IRemoteSignerTransport
     /// <param name="descriptor">The descriptor identifying the signing key.</param>
     /// <param name="context">The MuSig2 context the nonce is generated for.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    // TODO: SECURITY — return MusigPubNonce instead and keep the private nonce on
+    // the signer indexed by context. Today the SDK receives the secret half, which
+    // breaks the cryptographic argument for remote signing. Phase-2, tracked at
+    // https://github.com/arkade-os/dotnet-sdk/issues/111.
     Task<MusigPrivNonce> GenerateNoncesAsync(
         string walletId,
         OutputDescriptor descriptor,

--- a/NArk.Abstractions/Wallets/WalletType.cs
+++ b/NArk.Abstractions/Wallets/WalletType.cs
@@ -1,47 +1,27 @@
 namespace NArk.Abstractions.Wallets;
 
 /// <summary>
-/// The signing flavour of an <see cref="ArkWalletInfo"/>. Drives how
-/// <see cref="IWalletProvider.GetSignerAsync"/> materializes an
-/// <see cref="IArkadeWalletSigner"/> for the wallet — or whether it
-/// returns <c>null</c> because the wallet has no local signer.
+/// The key-derivation flavour of an <see cref="ArkWalletInfo"/>. This is strictly about
+/// <i>how scripts are derived</i> — a single tweaked key vs. an xpub-derived child set —
+/// and stays orthogonal to whether the wallet can sign locally, remote-sign, or only watch.
+/// <para>Signing capability is answered by <see cref="IWalletProvider.GetSignerAsync"/>: it
+/// returns a signer when one is available (local key in <see cref="ArkWalletInfo.Secret"/>,
+/// or a remote signer registered for this wallet) and <c>null</c> for watch-only.</para>
 /// </summary>
 public enum WalletType
 {
     /// <summary>
-    /// Legacy nsec-style wallet: a single Schnorr private key stored as the
-    /// wallet's <see cref="ArkWalletInfo.Secret"/>. The signer is produced
-    /// directly from that key. <see cref="ArkWalletInfo.Secret"/> MUST be
-    /// non-null/non-empty.
+    /// Legacy nsec-style wallet: a single Schnorr key pair. The script is a flat
+    /// <c>tr(pubkey)</c>; child derivation does not apply.
     /// </summary>
     SingleKey = 0,
 
     /// <summary>
-    /// BIP-39/BIP-32 hierarchical-deterministic wallet: the
-    /// <see cref="ArkWalletInfo.Secret"/> is a mnemonic, and individual
-    /// signing keys are derived from it on demand using the wallet's
-    /// <see cref="ArkWalletInfo.AccountDescriptor"/>.
-    /// <see cref="ArkWalletInfo.Secret"/> MUST be non-null/non-empty.
+    /// BIP-32/BIP-86 hierarchical-deterministic wallet: scripts are derived from the
+    /// wallet's account xpub (<see cref="ArkWalletInfo.AccountDescriptor"/>) at a
+    /// running child index. The mnemonic (when present in <see cref="ArkWalletInfo.Secret"/>)
+    /// allows local signing; absence means watch-only or remote-signed at the signer-provider
+    /// level — see <see cref="IWalletProvider.GetSignerAsync"/>.
     /// </summary>
     HD = 1,
-
-    /// <summary>
-    /// Watch-only wallet: the SDK can derive addresses and observe VTXOs
-    /// from the wallet's <see cref="ArkWalletInfo.AccountDescriptor"/>, but
-    /// holds no signing material. <see cref="IWalletProvider.GetSignerAsync"/>
-    /// returns <c>null</c> for this flavour, and signing-dependent operations
-    /// (batch participation, unilateral exits, etc.) will throw with a
-    /// descriptive error. <see cref="ArkWalletInfo.Secret"/> MUST be null
-    /// or empty.
-    /// </summary>
-    WatchOnly = 2,
-
-    /// <summary>
-    /// Remote-signing wallet: the signer is proxied to an external
-    /// <see cref="IRemoteSignerTransport"/> registered in DI. The SDK never
-    /// sees the private material; every signing call (pubkey, MuSig nonce,
-    /// MuSig partial signature, Schnorr signature) is forwarded to the
-    /// transport. <see cref="ArkWalletInfo.Secret"/> MUST be null or empty.
-    /// </summary>
-    Remote = 3
 }

--- a/NArk.Abstractions/Wallets/WalletType.cs
+++ b/NArk.Abstractions/Wallets/WalletType.cs
@@ -1,7 +1,47 @@
 namespace NArk.Abstractions.Wallets;
 
+/// <summary>
+/// The signing flavour of an <see cref="ArkWalletInfo"/>. Drives how
+/// <see cref="IWalletProvider.GetSignerAsync"/> materializes an
+/// <see cref="IArkadeWalletSigner"/> for the wallet — or whether it
+/// returns <c>null</c> because the wallet has no local signer.
+/// </summary>
 public enum WalletType
 {
+    /// <summary>
+    /// Legacy nsec-style wallet: a single Schnorr private key stored as the
+    /// wallet's <see cref="ArkWalletInfo.Secret"/>. The signer is produced
+    /// directly from that key. <see cref="ArkWalletInfo.Secret"/> MUST be
+    /// non-null/non-empty.
+    /// </summary>
     SingleKey = 0,
-    HD = 1
+
+    /// <summary>
+    /// BIP-39/BIP-32 hierarchical-deterministic wallet: the
+    /// <see cref="ArkWalletInfo.Secret"/> is a mnemonic, and individual
+    /// signing keys are derived from it on demand using the wallet's
+    /// <see cref="ArkWalletInfo.AccountDescriptor"/>.
+    /// <see cref="ArkWalletInfo.Secret"/> MUST be non-null/non-empty.
+    /// </summary>
+    HD = 1,
+
+    /// <summary>
+    /// Watch-only wallet: the SDK can derive addresses and observe VTXOs
+    /// from the wallet's <see cref="ArkWalletInfo.AccountDescriptor"/>, but
+    /// holds no signing material. <see cref="IWalletProvider.GetSignerAsync"/>
+    /// returns <c>null</c> for this flavour, and signing-dependent operations
+    /// (batch participation, unilateral exits, etc.) will throw with a
+    /// descriptive error. <see cref="ArkWalletInfo.Secret"/> MUST be null
+    /// or empty.
+    /// </summary>
+    WatchOnly = 2,
+
+    /// <summary>
+    /// Remote-signing wallet: the signer is proxied to an external
+    /// <see cref="IRemoteSignerTransport"/> registered in DI. The SDK never
+    /// sees the private material; every signing call (pubkey, MuSig nonce,
+    /// MuSig partial signature, Schnorr signature) is forwarded to the
+    /// transport. <see cref="ArkWalletInfo.Secret"/> MUST be null or empty.
+    /// </summary>
+    Remote = 3
 }

--- a/NArk.Core/Batches/TreeSignerSession.cs
+++ b/NArk.Core/Batches/TreeSignerSession.cs
@@ -48,7 +48,8 @@ public class TreeSignerSession
         // The cosigner keys in the PSBT were registered with the correct-parity key from
         // signer.GetPubKey() in IntentGenerationService, so we must match that here.
         var signer = await _walletProvider.GetSignerAsync(_walletId, cancellationToken)
-                     ?? throw new InvalidOperationException("Signer not found for wallet");
+                     ?? throw new InvalidOperationException(
+                         $"Wallet '{_walletId}' has no signer; watch-only wallets cannot participate in batch signing.");
         var myPubKey = await signer.GetPubKey(_descriptor, cancellationToken);
         var descriptorPubKey = _descriptor.ToPubKey();
 
@@ -158,13 +159,15 @@ public class TreeSignerSession
             throw new InvalidOperationException("nonces already generated");
 
         var walletIdentifier = _walletId;
-        var signer = await _walletProvider.GetSignerAsync(walletIdentifier, cancellationToken);
+        var signer = await _walletProvider.GetSignerAsync(walletIdentifier, cancellationToken)
+                     ?? throw new InvalidOperationException(
+                         $"Wallet '{_walletId}' has no signer; watch-only wallets cannot participate in batch signing.");
 
         var res = new Dictionary<uint256, (MusigPrivNonce secNonce, MusigPubNonce pubNonce)>();
         foreach (var (txid, musigContext) in _musigContexts!)
         {
             // Generate nonce tied to this specific context
-            var nonce = await signer!.GenerateNonces(_descriptor, musigContext, cancellationToken);
+            var nonce = await signer.GenerateNonces(_descriptor, musigContext, cancellationToken);
             res[txid] = (nonce, nonce.CreatePubNonce());
         }
 
@@ -189,11 +192,13 @@ public class TreeSignerSession
             throw new InvalidOperationException("missing aggregate nonce");
 
         var walletIdentifier = _walletId;
-        var signer = await _walletProvider.GetSignerAsync(walletIdentifier, cancellationToken);
+        var signer = await _walletProvider.GetSignerAsync(walletIdentifier, cancellationToken)
+                     ?? throw new InvalidOperationException(
+                         $"Wallet '{_walletId}' has no signer; watch-only wallets cannot participate in batch signing.");
 
         // Use the wallet signer to create a MUSIG2 partial signature
         // The context already has the correct sighash from nonce generation
-        var partialSig = await signer!.SignMusig(_descriptor, musigContext, myNonce.secNonce, cancellationToken);
+        var partialSig = await signer.SignMusig(_descriptor, musigContext, myNonce.secNonce, cancellationToken);
 
         return partialSig;
     }

--- a/NArk.Core/Helpers/TransactionHelpers.cs
+++ b/NArk.Core/Helpers/TransactionHelpers.cs
@@ -36,9 +36,12 @@ public static class TransactionHelpers
 
             receivedCheckpointTx.UpdateFrom(checkpointTx);
 
-            var signer = await walletProvider.GetSignerAsync(coin.WalletIdentifier, cancellationToken);
+            var signer = await walletProvider.GetSignerAsync(coin.WalletIdentifier, cancellationToken)
+                ?? throw new InvalidOperationException(
+                    $"Cannot sign checkpoint tx: wallet '{coin.WalletIdentifier}' has no signer " +
+                    "(watch-only wallet, or its remote signer transport is unavailable).");
 
-            await PsbtHelpers.SignAndFillPsbt(signer!, coin, receivedCheckpointTx, checkpointPrecomputedTransactionData,
+            await PsbtHelpers.SignAndFillPsbt(signer, coin, receivedCheckpointTx, checkpointPrecomputedTransactionData,
                 cancellationToken: cancellationToken);
 
             return receivedCheckpointTx;
@@ -230,8 +233,11 @@ public static class TransactionHelpers
 
             foreach (var (_, coin) in sortedCheckpointCoins)
             {
-                var signer = await walletProvider.GetSignerAsync(coin.WalletIdentifier, cancellationToken);
-                await PsbtHelpers.SignAndFillPsbt(signer!, coin, tx, precomputedTransactionData, cancellationToken: cancellationToken);
+                var signer = await walletProvider.GetSignerAsync(coin.WalletIdentifier, cancellationToken)
+                    ?? throw new InvalidOperationException(
+                        $"Cannot sign Arkade tx checkpoint input: wallet '{coin.WalletIdentifier}' has no signer " +
+                        "(watch-only wallet, or its remote signer transport is unavailable).");
+                await PsbtHelpers.SignAndFillPsbt(signer, coin, tx, precomputedTransactionData, cancellationToken: cancellationToken);
             }
 
             //reorder the checkpoints to match the order of the inputs of the Ark transaction
@@ -415,9 +421,13 @@ public static class TransactionHelpers
             var precomputedTransactionData =
                 gtx.PrecomputeTransactionData(sortedCheckpointCoins.OrderBy(x => x.Key).Select(x => x.Value).ToArray());
 
-            var signer = await walletProvider.GetSignerAsync(coin.WalletIdentifier, cancellationToken);
+            var signer = await walletProvider.GetSignerAsync(coin.WalletIdentifier, cancellationToken)
+                ?? throw new InvalidOperationException(
+                    $"Cannot sign forfeit tx: wallet '{coin.WalletIdentifier}' has no signer " +
+                    "(watch-only wallet, or its remote signer transport is unavailable). " +
+                    "Watch-only wallets cannot participate in batches that demand a forfeit.");
 
-            await PsbtHelpers.SignAndFillPsbt(signer!, coin, forfeitTx, precomputedTransactionData, sighash, cancellationToken);
+            await PsbtHelpers.SignAndFillPsbt(signer, coin, forfeitTx, precomputedTransactionData, sighash, cancellationToken);
 
             return forfeitTx;
         }

--- a/NArk.Core/Wallet/DefaultWalletProvider.cs
+++ b/NArk.Core/Wallet/DefaultWalletProvider.cs
@@ -4,6 +4,7 @@ using NArk.Abstractions.Contracts;
 using NArk.Abstractions.Safety;
 using NArk.Abstractions.Wallets;
 using NArk.Core.Transport;
+using NBitcoin;
 
 namespace NArk.Core.Wallet;
 
@@ -15,7 +16,8 @@ public class DefaultWalletProvider(
     ISafetyService safetyService,
     IWalletStorage walletStorage,
     IContractStorage contractStorage,
-    ILogger<DefaultWalletProvider>? logger = null)
+    ILogger<DefaultWalletProvider>? logger = null,
+    IRemoteSignerTransport? remoteSignerTransport = null)
     : IWalletProvider
 {
     public async Task<IArkadeWalletSigner?> GetSignerAsync(string identifier, CancellationToken cancellationToken = default)
@@ -31,7 +33,12 @@ public class DefaultWalletProvider(
             return wallet.WalletType switch
             {
                 WalletType.HD => new HierarchicalDeterministicWalletSigner(wallet),
-                WalletType.SingleKey => NSecWalletSigner.FromNsec(wallet.Secret, logger),
+                WalletType.SingleKey => NSecWalletSigner.FromNsec(
+                    wallet.Secret ?? throw new InvalidOperationException(
+                        $"SingleKey wallet '{wallet.Id}' has no Secret — nsec is required for SingleKey wallets."),
+                    logger),
+                WalletType.WatchOnly => null,
+                WalletType.Remote => CreateRemoteSigner(wallet),
                 _ => throw new ArgumentOutOfRangeException(nameof(wallet.WalletType))
             };
         }
@@ -40,6 +47,18 @@ public class DefaultWalletProvider(
             logger?.LogWarning("GetSignerAsync: wallet not found for identifier={Identifier}", identifier);
             return null;
         }
+    }
+
+    private IArkadeWalletSigner CreateRemoteSigner(ArkWalletInfo wallet)
+    {
+        if (remoteSignerTransport is null)
+        {
+            throw new InvalidOperationException(
+                $"Remote wallet '{wallet.Id}' selected but no IRemoteSignerTransport was registered. " +
+                "Register one in DI before using WalletType.Remote.");
+        }
+
+        return new RemoteArkadeWalletSigner(wallet.Id, remoteSignerTransport);
     }
 
     public async Task<IArkadeAddressProvider?> GetAddressProviderAsync(string identifier, CancellationToken cancellationToken = default)
@@ -61,7 +80,9 @@ public class DefaultWalletProvider(
             }
             if (wallet.WalletType == WalletType.SingleKey)
             {
-                var derivedDescriptor = WalletFactory.GetOutputDescriptorFromNsec(wallet.Secret);
+                var secret = wallet.Secret ?? throw new InvalidOperationException(
+                    $"SingleKey wallet '{wallet.Id}' has no Secret — nsec is required for SingleKey wallets.");
+                var derivedDescriptor = WalletFactory.GetOutputDescriptorFromNsec(secret);
                 if (wallet.AccountDescriptor != derivedDescriptor)
                 {
                     logger?.LogWarning(
@@ -75,6 +96,12 @@ public class DefaultWalletProvider(
             {
                 WalletType.HD => new HierarchicalDeterministicAddressProvider(clientTransport, safetyService, walletStorage, contractStorage, wallet, network, sweepDestination),
                 WalletType.SingleKey => new SingleKeyAddressProvider(clientTransport, wallet, network, sweepDestination, logger),
+                // WatchOnly and Remote wallets pick their address provider by descriptor shape:
+                // an HD-style account descriptor (tr([fp/path]xpub/0/*)) routes to the HD
+                // provider so new indices can be derived; a bare tr(pubkey) routes to the
+                // single-key provider so the one address is reused.
+                WalletType.WatchOnly => CreateWatchOnlyOrRemoteAddressProvider(wallet, network, sweepDestination),
+                WalletType.Remote => CreateWatchOnlyOrRemoteAddressProvider(wallet, network, sweepDestination),
                 _ => throw new ArgumentOutOfRangeException(nameof(wallet.WalletType))
             };
         }
@@ -82,5 +109,26 @@ public class DefaultWalletProvider(
         {
             return null;
         }
+    }
+
+    private IArkadeAddressProvider CreateWatchOnlyOrRemoteAddressProvider(
+        ArkWalletInfo wallet,
+        Network network,
+        ArkAddress? sweepDestination)
+    {
+        if (string.IsNullOrEmpty(wallet.AccountDescriptor))
+        {
+            throw new InvalidOperationException(
+                $"Wallet '{wallet.Id}' (type={wallet.WalletType}) has no AccountDescriptor. " +
+                "WatchOnly and Remote wallets require an AccountDescriptor — a tr(pubkey) for single-key style " +
+                "or a tr([fingerprint/path]xpub/0/*) for hierarchical-deterministic style.");
+        }
+
+        // HD account descriptors contain a derivation suffix ("/0/*"); single-key
+        // descriptors are bare tr(pubkey) with no '*'.
+        var isHd = wallet.AccountDescriptor.Contains('*');
+        return isHd
+            ? new HierarchicalDeterministicAddressProvider(clientTransport, safetyService, walletStorage, contractStorage, wallet, network, sweepDestination)
+            : new SingleKeyAddressProvider(clientTransport, wallet, network, sweepDestination, logger);
     }
 }

--- a/NArk.Core/Wallet/DefaultWalletProvider.cs
+++ b/NArk.Core/Wallet/DefaultWalletProvider.cs
@@ -9,7 +9,15 @@ using NBitcoin;
 namespace NArk.Core.Wallet;
 
 /// <summary>
-/// Default implementation of IWalletProvider using SDK wallet infrastructure.
+/// Default implementation of <see cref="IWalletProvider"/>.
+/// <para>
+/// Signing capability is answered by <em>asking</em> — never by tagging the wallet:
+/// <see cref="GetSignerAsync"/> returns a local signer when <see cref="ArkWalletInfo.Secret"/>
+/// is present, a remote-signer proxy when an <see cref="IRemoteSignerTransport"/> is registered
+/// and claims the wallet, and <c>null</c> otherwise (watch-only). Address derivation always
+/// works from <see cref="ArkWalletInfo.AccountDescriptor"/> alone, regardless of signer
+/// availability.
+/// </para>
 /// </summary>
 public class DefaultWalletProvider(
     IClientTransport clientTransport,
@@ -28,37 +36,37 @@ public class DefaultWalletProvider(
             var sw = System.Diagnostics.Stopwatch.StartNew();
             var wallet = await walletStorage.LoadWallet(identifier, cancellationToken);
             logger?.LogTrace("[wallet-probe] GetSigner LoadWallet: {Ms}ms", sw.ElapsedMilliseconds);
-            logger?.LogDebug("GetSignerAsync: identifier={Identifier}, walletId={WalletId}, walletType={WalletType}, accountDescriptor={AccountDescriptor}",
-                identifier, wallet.Id, wallet.WalletType, wallet.AccountDescriptor);
-            return wallet.WalletType switch
+            logger?.LogDebug("GetSignerAsync: identifier={Identifier}, walletId={WalletId}, walletType={WalletType}, hasSecret={HasSecret}",
+                identifier, wallet.Id, wallet.WalletType, !string.IsNullOrEmpty(wallet.Secret));
+
+            // Local signing material present → produce a local signer of the right shape.
+            if (!string.IsNullOrEmpty(wallet.Secret))
             {
-                WalletType.HD => new HierarchicalDeterministicWalletSigner(wallet),
-                WalletType.SingleKey => NSecWalletSigner.FromNsec(
-                    wallet.Secret ?? throw new InvalidOperationException(
-                        $"SingleKey wallet '{wallet.Id}' has no Secret — nsec is required for SingleKey wallets."),
-                    logger),
-                WalletType.WatchOnly => null,
-                WalletType.Remote => CreateRemoteSigner(wallet),
-                _ => throw new ArgumentOutOfRangeException(nameof(wallet.WalletType))
-            };
+                return wallet.WalletType switch
+                {
+                    WalletType.HD => new HierarchicalDeterministicWalletSigner(wallet),
+                    WalletType.SingleKey => NSecWalletSigner.FromNsec(wallet.Secret, logger),
+                    _ => throw new ArgumentOutOfRangeException(nameof(wallet.WalletType))
+                };
+            }
+
+            // No local secret → ask the remote-signer transport (if any) whether it can sign for
+            // this wallet. The transport is the source of truth for "remote vs watch-only" —
+            // no flag on ArkWalletInfo encodes it.
+            if (remoteSignerTransport is not null
+                && await remoteSignerTransport.KnowsWalletAsync(wallet.Id, cancellationToken).ConfigureAwait(false))
+            {
+                return new RemoteArkadeWalletSigner(wallet.Id, remoteSignerTransport);
+            }
+
+            // No local key, no remote signer claims it → watch-only.
+            return null;
         }
         catch (KeyNotFoundException)
         {
             logger?.LogWarning("GetSignerAsync: wallet not found for identifier={Identifier}", identifier);
             return null;
         }
-    }
-
-    private IArkadeWalletSigner CreateRemoteSigner(ArkWalletInfo wallet)
-    {
-        if (remoteSignerTransport is null)
-        {
-            throw new InvalidOperationException(
-                $"Remote wallet '{wallet.Id}' selected but no IRemoteSignerTransport was registered. " +
-                "Register one in DI before using WalletType.Remote.");
-        }
-
-        return new RemoteArkadeWalletSigner(wallet.Id, remoteSignerTransport);
     }
 
     public async Task<IArkadeAddressProvider?> GetAddressProviderAsync(string identifier, CancellationToken cancellationToken = default)
@@ -73,16 +81,19 @@ public class DefaultWalletProvider(
             var wallet = await walletStorage.LoadWallet(identifier, cancellationToken);
             logger?.LogTrace("[wallet-probe] GetAddressProvider: GetServerInfo={InfoMs}ms LoadWallet={LoadMs}ms",
                 infoMs, swLoad.ElapsedMilliseconds);
+
             ArkAddress? sweepDestination = null;
             if (!string.IsNullOrEmpty(wallet.Destination))
             {
                 sweepDestination = ArkAddress.Parse(wallet.Destination);
             }
-            if (wallet.WalletType == WalletType.SingleKey)
+
+            // Cross-check the stored descriptor against the one derived from the local nsec —
+            // only meaningful when we actually have the secret. Watch-only/remote single-key
+            // wallets keep the stored AccountDescriptor verbatim.
+            if (wallet.WalletType == WalletType.SingleKey && !string.IsNullOrEmpty(wallet.Secret))
             {
-                var secret = wallet.Secret ?? throw new InvalidOperationException(
-                    $"SingleKey wallet '{wallet.Id}' has no Secret — nsec is required for SingleKey wallets.");
-                var derivedDescriptor = WalletFactory.GetOutputDescriptorFromNsec(secret);
+                var derivedDescriptor = WalletFactory.GetOutputDescriptorFromNsec(wallet.Secret);
                 if (wallet.AccountDescriptor != derivedDescriptor)
                 {
                     logger?.LogWarning(
@@ -92,16 +103,12 @@ public class DefaultWalletProvider(
                 }
             }
 
+            // Address derivation is a function of the descriptor shape, which the WalletType
+            // already encodes — no string-sniff needed.
             return wallet.WalletType switch
             {
                 WalletType.HD => new HierarchicalDeterministicAddressProvider(clientTransport, safetyService, walletStorage, contractStorage, wallet, network, sweepDestination),
                 WalletType.SingleKey => new SingleKeyAddressProvider(clientTransport, wallet, network, sweepDestination, logger),
-                // WatchOnly and Remote wallets pick their address provider by descriptor shape:
-                // an HD-style account descriptor (tr([fp/path]xpub/0/*)) routes to the HD
-                // provider so new indices can be derived; a bare tr(pubkey) routes to the
-                // single-key provider so the one address is reused.
-                WalletType.WatchOnly => CreateWatchOnlyOrRemoteAddressProvider(wallet, network, sweepDestination),
-                WalletType.Remote => CreateWatchOnlyOrRemoteAddressProvider(wallet, network, sweepDestination),
                 _ => throw new ArgumentOutOfRangeException(nameof(wallet.WalletType))
             };
         }
@@ -109,26 +116,5 @@ public class DefaultWalletProvider(
         {
             return null;
         }
-    }
-
-    private IArkadeAddressProvider CreateWatchOnlyOrRemoteAddressProvider(
-        ArkWalletInfo wallet,
-        Network network,
-        ArkAddress? sweepDestination)
-    {
-        if (string.IsNullOrEmpty(wallet.AccountDescriptor))
-        {
-            throw new InvalidOperationException(
-                $"Wallet '{wallet.Id}' (type={wallet.WalletType}) has no AccountDescriptor. " +
-                "WatchOnly and Remote wallets require an AccountDescriptor — a tr(pubkey) for single-key style " +
-                "or a tr([fingerprint/path]xpub/0/*) for hierarchical-deterministic style.");
-        }
-
-        // HD account descriptors contain a derivation suffix ("/0/*"); single-key
-        // descriptors are bare tr(pubkey) with no '*'.
-        var isHd = wallet.AccountDescriptor.Contains('*');
-        return isHd
-            ? new HierarchicalDeterministicAddressProvider(clientTransport, safetyService, walletStorage, contractStorage, wallet, network, sweepDestination)
-            : new SingleKeyAddressProvider(clientTransport, wallet, network, sweepDestination, logger);
     }
 }

--- a/NArk.Core/Wallet/HierarchicalDeterministicWalletSigner.cs
+++ b/NArk.Core/Wallet/HierarchicalDeterministicWalletSigner.cs
@@ -24,7 +24,9 @@ public class HierarchicalDeterministicWalletSigner(ArkWalletInfo wallet) : IArka
     private Task<ECPrivKey> DerivePrivateKey(OutputDescriptor descriptor)
     {
         var fullPath = descriptor.Extract().FullPath ?? throw new InvalidOperationException();
-        var extKey = _extKeyCache.GetOrAdd(wallet.Secret, secret => new Mnemonic(secret).DeriveExtKey());
+        var mnemonic = wallet.Secret ?? throw new InvalidOperationException(
+            $"HD wallet '{wallet.Id}' has no Secret — a BIP-39 mnemonic is required for HD wallets.");
+        var extKey = _extKeyCache.GetOrAdd(mnemonic, secret => new Mnemonic(secret).DeriveExtKey());
         return Task.FromResult(ECPrivKey.Create(extKey.Derive(fullPath).PrivateKey.ToBytes()));
     }
 

--- a/NArk.Core/Wallet/RemoteArkadeWalletSigner.cs
+++ b/NArk.Core/Wallet/RemoteArkadeWalletSigner.cs
@@ -8,9 +8,13 @@ namespace NArk.Core.Wallet;
 
 /// <summary>
 /// Pure proxy implementation of <see cref="IArkadeWalletSigner"/> that
-/// forwards every call to an <see cref="IRemoteSignerTransport"/>. Used by
-/// <see cref="DefaultWalletProvider"/> for wallets of type
-/// <see cref="WalletType.Remote"/>.
+/// forwards every call to an <see cref="IRemoteSignerTransport"/>.
+/// <see cref="DefaultWalletProvider"/> instantiates this when the wallet
+/// has no local signing material (<see cref="ArkWalletInfo.Secret"/> is
+/// null/empty) <b>and</b> a registered transport's
+/// <see cref="IRemoteSignerTransport.KnowsWalletAsync"/> claims the wallet;
+/// when no transport claims it, the wallet is treated as watch-only and
+/// <see cref="IWalletProvider.GetSignerAsync"/> returns <c>null</c>.
 /// </summary>
 /// <remarks>
 /// Holds no signing material — the <c>walletId</c> is captured at construction

--- a/NArk.Core/Wallet/RemoteArkadeWalletSigner.cs
+++ b/NArk.Core/Wallet/RemoteArkadeWalletSigner.cs
@@ -1,0 +1,46 @@
+using NArk.Abstractions.Wallets;
+using NBitcoin;
+using NBitcoin.Scripting;
+using NBitcoin.Secp256k1;
+using NBitcoin.Secp256k1.Musig;
+
+namespace NArk.Core.Wallet;
+
+/// <summary>
+/// Pure proxy implementation of <see cref="IArkadeWalletSigner"/> that
+/// forwards every call to an <see cref="IRemoteSignerTransport"/>. Used by
+/// <see cref="DefaultWalletProvider"/> for wallets of type
+/// <see cref="WalletType.Remote"/>.
+/// </summary>
+/// <remarks>
+/// Holds no signing material — the <c>walletId</c> is captured at construction
+/// time and tagged onto every transport call so a single transport instance
+/// can serve multiple wallets.
+/// </remarks>
+public class RemoteArkadeWalletSigner(string walletId, IRemoteSignerTransport transport) : IArkadeWalletSigner
+{
+    private readonly string _walletId = walletId ?? throw new ArgumentNullException(nameof(walletId));
+    private readonly IRemoteSignerTransport _transport = transport ?? throw new ArgumentNullException(nameof(transport));
+
+    public Task<ECPubKey> GetPubKey(OutputDescriptor descriptor, CancellationToken cancellationToken = default)
+        => _transport.GetPubKeyAsync(_walletId, descriptor, cancellationToken);
+
+    public Task<MusigPartialSignature> SignMusig(
+        OutputDescriptor descriptor,
+        MusigContext context,
+        MusigPrivNonce nonce,
+        CancellationToken cancellationToken = default)
+        => _transport.SignMusigAsync(_walletId, descriptor, context, nonce, cancellationToken);
+
+    public Task<(ECXOnlyPubKey, SecpSchnorrSignature)> Sign(
+        OutputDescriptor descriptor,
+        uint256 hash,
+        CancellationToken cancellationToken = default)
+        => _transport.SignAsync(_walletId, descriptor, hash, cancellationToken);
+
+    public Task<MusigPrivNonce> GenerateNonces(
+        OutputDescriptor descriptor,
+        MusigContext context,
+        CancellationToken cancellationToken = default)
+        => _transport.GenerateNoncesAsync(_walletId, descriptor, context, cancellationToken);
+}

--- a/NArk.Core/Wallet/WalletFactory.cs
+++ b/NArk.Core/Wallet/WalletFactory.cs
@@ -9,7 +9,8 @@ using NBitcoin.Secp256k1;
 namespace NArk.Core.Wallet;
 
 /// <summary>
-/// Factory for creating wallet info records from secrets (nsec or mnemonic).
+/// Factory for creating wallet info records from secrets (nsec or mnemonic),
+/// and watch-only wallets from an account descriptor.
 /// </summary>
 public static class WalletFactory
 {
@@ -30,6 +31,50 @@ public static class WalletFactory
         }
 
         return Task.FromResult(CreateHdWallet(walletSecret, destination, serverInfo));
+    }
+
+    /// <summary>
+    /// Creates a watch-only wallet from an account descriptor. The wallet
+    /// can derive addresses and observe VTXOs but holds no signing material —
+    /// <see cref="IWalletProvider.GetSignerAsync"/> will return <c>null</c>
+    /// for it, and signing-dependent operations (batch participation,
+    /// unilateral exits) will throw with a descriptive error.
+    /// </summary>
+    /// <param name="accountDescriptor">
+    /// The account descriptor to observe. May be a bare <c>tr(pubkey)</c> for
+    /// single-key style, or a <c>tr([fingerprint/path]xpub/0/*)</c> for
+    /// hierarchical-deterministic style; the wallet's address provider is
+    /// picked accordingly.
+    /// </param>
+    /// <param name="destination">
+    /// Optional sweep destination address (must be addressed to the same
+    /// Arkade server as <paramref name="serverInfo"/>).
+    /// </param>
+    /// <param name="serverInfo">The Arkade server the wallet is bound to.</param>
+    /// <param name="metadata">Optional initial metadata to attach to the wallet.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public static Task<ArkWalletInfo> CreateWatchOnlyWallet(
+        string accountDescriptor,
+        string? destination,
+        ArkServerInfo serverInfo,
+        IReadOnlyDictionary<string, string>? metadata = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(accountDescriptor);
+        if (destination is not null)
+        {
+            ValidateDestination(destination, serverInfo);
+        }
+
+        return Task.FromResult(new ArkWalletInfo(
+            Id: accountDescriptor,
+            Secret: null,
+            Destination: destination,
+            WalletType: WalletType.WatchOnly,
+            AccountDescriptor: accountDescriptor,
+            LastUsedIndex: 0,
+            Metadata: metadata
+        ));
     }
 
     public static void ValidateDestination(string destination, ArkServerInfo serverInfo)

--- a/NArk.Core/Wallet/WalletFactory.cs
+++ b/NArk.Core/Wallet/WalletFactory.cs
@@ -66,11 +66,16 @@ public static class WalletFactory
             ValidateDestination(destination, serverInfo);
         }
 
+        // Pick the derivation type from descriptor shape at creation time — the wildcard ('*')
+        // is the canonical signal for an HD-style descriptor (e.g. tr([fp/path]xpub/0/*)). A
+        // bare tr(pubkey) is single-key. Watch-only-ness is independent of this axis and is
+        // reflected by Secret=null; the wallet provider returns a null signer for it.
+        var walletType = accountDescriptor.Contains('*') ? WalletType.HD : WalletType.SingleKey;
         return Task.FromResult(new ArkWalletInfo(
             Id: accountDescriptor,
             Secret: null,
             Destination: destination,
-            WalletType: WalletType.WatchOnly,
+            WalletType: walletType,
             AccountDescriptor: accountDescriptor,
             LastUsedIndex: 0,
             Metadata: metadata

--- a/NArk.Storage.EfCore/Entities/ArkWalletEntity.cs
+++ b/NArk.Storage.EfCore/Entities/ArkWalletEntity.cs
@@ -12,13 +12,16 @@ public class ArkWalletEntity
     public string Id { get; set; } = "";
 
     /// <summary>
-    /// Signing material for the wallet, interpreted according to <see cref="WalletType"/>:
+    /// Signing material for the wallet when held locally, interpreted according to <see cref="WalletType"/>:
     /// <list type="bullet">
     ///   <item><description><see cref="Abstractions.Wallets.WalletType.SingleKey"/>: nsec private key.</description></item>
     ///   <item><description><see cref="Abstractions.Wallets.WalletType.HD"/>: BIP-39 mnemonic.</description></item>
-    ///   <item><description><see cref="Abstractions.Wallets.WalletType.WatchOnly"/>: null — no signing material.</description></item>
-    ///   <item><description><see cref="Abstractions.Wallets.WalletType.Remote"/>: null — signing proxied to an <see cref="Abstractions.Wallets.IRemoteSignerTransport"/>.</description></item>
     /// </list>
+    /// <c>null</c> / empty when no local signing material is present — the wallet is
+    /// then either watch-only, or remote-signed via a registered
+    /// <see cref="Abstractions.Wallets.IRemoteSignerTransport"/> that claims it through
+    /// <see cref="Abstractions.Wallets.IRemoteSignerTransport.KnowsWalletAsync"/>.
+    /// The signer-capability decision lives on the provider, not on a flag in the wallet record.
     /// </summary>
     public string? Wallet { get; set; }
 
@@ -60,7 +63,12 @@ public class ArkWalletEntity
     {
         builder.ToTable(options.WalletsTable, options.Schema);
         builder.HasKey(w => w.Id);
-        builder.HasIndex(w => w.Wallet).IsUnique();
+        // Filter to NOT-NULL rows so SQL Server (which treats NULLs as duplicate
+        // in unique indexes) doesn't reject multiple watch-only / remote-signed
+        // wallets that legitimately share a null Wallet column. Postgres + SQLite
+        // already treat NULLs as distinct, but the filter is harmless there and
+        // makes the intent explicit at the schema level.
+        builder.HasIndex(w => w.Wallet).IsUnique().HasFilter("\"Wallet\" IS NOT NULL");
         builder.Property(w => w.WalletType).HasDefaultValue(WalletType.SingleKey);
         builder.Property(w => w.AccountDescriptor).HasDefaultValue("TODO_MIGRATION");
         builder.Property(w => w.LastUsedIndex).HasDefaultValue(0);

--- a/NArk.Storage.EfCore/Entities/ArkWalletEntity.cs
+++ b/NArk.Storage.EfCore/Entities/ArkWalletEntity.cs
@@ -12,10 +12,15 @@ public class ArkWalletEntity
     public string Id { get; set; } = "";
 
     /// <summary>
-    /// For legacy wallets: the nsec private key.
-    /// For HD wallets: the BIP-39 mnemonic.
+    /// Signing material for the wallet, interpreted according to <see cref="WalletType"/>:
+    /// <list type="bullet">
+    ///   <item><description><see cref="Abstractions.Wallets.WalletType.SingleKey"/>: nsec private key.</description></item>
+    ///   <item><description><see cref="Abstractions.Wallets.WalletType.HD"/>: BIP-39 mnemonic.</description></item>
+    ///   <item><description><see cref="Abstractions.Wallets.WalletType.WatchOnly"/>: null — no signing material.</description></item>
+    ///   <item><description><see cref="Abstractions.Wallets.WalletType.Remote"/>: null — signing proxied to an <see cref="Abstractions.Wallets.IRemoteSignerTransport"/>.</description></item>
+    /// </list>
     /// </summary>
-    public string Wallet { get; set; } = "";
+    public string? Wallet { get; set; }
 
     /// <summary>
     /// Destination address for swept funds.

--- a/README.md
+++ b/README.md
@@ -114,14 +114,24 @@ NArk.Storage.EfCore (optional, provider-agnostic persistence)
 
 ## Wallet Management
 
-The SDK supports four wallet types:
+Wallets are described along two orthogonal axes; capability is answered by the provider, not by a tag on the data.
 
-| `WalletType` | `Secret` | Signer | Use case |
+**Key derivation** (`WalletType`):
+
+| `WalletType` | Script shape | Use case |
+| --- | --- | --- |
+| `HD` | `tr([fp/path]xpub/0/*)` | Per-contract derivation, boarding support |
+| `SingleKey` | `tr(pubkey)` | Static key, simple integrations |
+
+**Signing capability** — decided at `IWalletProvider.GetSignerAsync` time:
+
+| `ArkWalletInfo.Secret` | `IRemoteSignerTransport.KnowsWalletAsync` | Returns | Meaning |
 | --- | --- | --- | --- |
-| `HD` | BIP-39 mnemonic | `HierarchicalDeterministicWalletSigner` | Per-contract derivation, boarding support |
-| `SingleKey` | Nostr `nsec` | `NSecWalletSigner` | Static key, simple integrations |
-| `WatchOnly` | `null` / empty | `null` — observe only | Dashboards, accounting, paired devices |
-| `Remote` | `null` / empty | `RemoteArkadeWalletSigner` (proxy) | Hardware wallets, server-side signers, browser extensions |
+| non-empty | — | local signer | sign locally |
+| null/empty | `true` | `RemoteArkadeWalletSigner` proxy | sign via transport |
+| null/empty | `false` (or no transport) | `null` | watch-only |
+
+Any combination of the two axes is valid — a watch-only `HD`, a remote-signed `SingleKey`, etc.
 
 **HD Wallets** — BIP-39 mnemonic with BIP-86 taproot derivation (`m/86'/cointype'/0'`):
 
@@ -144,39 +154,29 @@ var wallet = await WalletFactory.CreateWallet(
 // wallet.WalletType == WalletType.SingleKey
 ```
 
-**Watch-Only Wallets** — observe-only from an account descriptor; no signing material is stored. Signing-dependent operations (batch participation, unilateral exits) throw a descriptive error.
+**Watch-Only and Remote-Signed Wallets** — same data shape (`Secret = null` on a normal `ArkWalletInfo`); the runtime distinction is made by whether an `IRemoteSignerTransport` is registered and claims the wallet:
 
 ```csharp
+// Build the wallet record once. WalletType is inferred from the descriptor shape
+// (wildcard → HD, bare → SingleKey).
 var wallet = await WalletFactory.CreateWatchOnlyWallet(
     accountDescriptor: "tr([abcd1234/86'/1'/0']tpub.../0/*)",
     destination: null,
     serverInfo);
-// wallet.WalletType == WalletType.WatchOnly
-// wallet.Secret == null
-```
-
-**Remote-Signing Wallets** — signing is proxied to an `IRemoteSignerTransport` registered in DI. The SDK never sees private material.
-
-```csharp
-// 1. Implement IRemoteSignerTransport for your bridge (HWI, server, extension).
-public class MyRemoteSignerTransport : IRemoteSignerTransport { /* ... */ }
-
-// 2. Register it alongside DefaultWalletProvider (optional — only consumers
-// that use WalletType.Remote need to register one).
-services.AddSingleton<IRemoteSignerTransport, MyRemoteSignerTransport>();
-
-// 3. Construct the wallet record directly with WalletType.Remote.
-var wallet = new ArkWalletInfo(
-    Id: accountDescriptor,
-    Secret: null,
-    Destination: null,
-    WalletType: WalletType.Remote,
-    AccountDescriptor: accountDescriptor,
-    LastUsedIndex: 0);
+// wallet.WalletType == WalletType.HD, wallet.Secret == null
 await walletStorage.SaveWallet(wallet);
-```
 
-If a `WalletType.Remote` wallet is loaded but no transport is registered, `GetSignerAsync` throws with a clear message identifying the missing registration.
+// To make the same wallet remote-signed instead of watch-only, register an
+// IRemoteSignerTransport whose KnowsWalletAsync returns true for wallet.Id:
+public class MyRemoteSignerTransport : IRemoteSignerTransport
+{
+    public Task<bool> KnowsWalletAsync(string walletId, CancellationToken ct) => _bridge.IsPairedAsync(walletId, ct);
+    // … sign methods …
+}
+services.AddSingleton<IRemoteSignerTransport, MyRemoteSignerTransport>();
+// GetSignerAsync now returns a RemoteArkadeWalletSigner for that walletId,
+// instead of null. Same data; different signer-source.
+```
 
 Save and load wallets through `IWalletStorage`:
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,14 @@ NArk.Storage.EfCore (optional, provider-agnostic persistence)
 
 ## Wallet Management
 
-The SDK supports two wallet types:
+The SDK supports four wallet types:
+
+| `WalletType` | `Secret` | Signer | Use case |
+| --- | --- | --- | --- |
+| `HD` | BIP-39 mnemonic | `HierarchicalDeterministicWalletSigner` | Per-contract derivation, boarding support |
+| `SingleKey` | Nostr `nsec` | `NSecWalletSigner` | Static key, simple integrations |
+| `WatchOnly` | `null` / empty | `null` — observe only | Dashboards, accounting, paired devices |
+| `Remote` | `null` / empty | `RemoteArkadeWalletSigner` (proxy) | Hardware wallets, server-side signers, browser extensions |
 
 **HD Wallets** — BIP-39 mnemonic with BIP-86 taproot derivation (`m/86'/cointype'/0'`):
 
@@ -136,6 +143,40 @@ var wallet = await WalletFactory.CreateWallet(
     serverInfo);
 // wallet.WalletType == WalletType.SingleKey
 ```
+
+**Watch-Only Wallets** — observe-only from an account descriptor; no signing material is stored. Signing-dependent operations (batch participation, unilateral exits) throw a descriptive error.
+
+```csharp
+var wallet = await WalletFactory.CreateWatchOnlyWallet(
+    accountDescriptor: "tr([abcd1234/86'/1'/0']tpub.../0/*)",
+    destination: null,
+    serverInfo);
+// wallet.WalletType == WalletType.WatchOnly
+// wallet.Secret == null
+```
+
+**Remote-Signing Wallets** — signing is proxied to an `IRemoteSignerTransport` registered in DI. The SDK never sees private material.
+
+```csharp
+// 1. Implement IRemoteSignerTransport for your bridge (HWI, server, extension).
+public class MyRemoteSignerTransport : IRemoteSignerTransport { /* ... */ }
+
+// 2. Register it alongside DefaultWalletProvider (optional — only consumers
+// that use WalletType.Remote need to register one).
+services.AddSingleton<IRemoteSignerTransport, MyRemoteSignerTransport>();
+
+// 3. Construct the wallet record directly with WalletType.Remote.
+var wallet = new ArkWalletInfo(
+    Id: accountDescriptor,
+    Secret: null,
+    Destination: null,
+    WalletType: WalletType.Remote,
+    AccountDescriptor: accountDescriptor,
+    LastUsedIndex: 0);
+await walletStorage.SaveWallet(wallet);
+```
+
+If a `WalletType.Remote` wallet is loaded but no transport is registered, `GetSignerAsync` throws with a clear message identifying the missing registration.
 
 Save and load wallets through `IWalletStorage`:
 

--- a/docs/articles/wallets.md
+++ b/docs/articles/wallets.md
@@ -1,17 +1,25 @@
 # Wallets
 
-Wallets are stored in `IWalletStorage` and materialized as address/signing providers on demand by `IWalletProvider` (default: `DefaultWalletProvider`). Signing material (when present) lives in `ArkWalletInfo.Secret`.
+Wallets are stored in `IWalletStorage` and materialized as address/signing providers on demand by `IWalletProvider` (default: `DefaultWalletProvider`).
 
-`WalletType` selects the signing flavour:
+Two orthogonal axes describe any wallet — keep them separate at every layer:
 
-| `WalletType` | `Secret` | `GetSignerAsync` returns | Use case |
+**1. Key-derivation flavour** (`WalletType`):
+
+| `WalletType` | Script shape | Use case |
+| --- | --- | --- |
+| `SingleKey` | `tr(pubkey)` — one flat key | Static key, simple integrations |
+| `HD` | `tr([fp/path]xpub/0/*)` — xpub-derived child set | Per-contract derivation, boarding support |
+
+**2. Signing capability** — answered by `IWalletProvider.GetSignerAsync`, *not* by the data type:
+
+| `ArkWalletInfo.Secret` | `IRemoteSignerTransport` claims it | `GetSignerAsync` returns | Capability |
 | --- | --- | --- | --- |
-| `HD` | BIP-39 mnemonic | `HierarchicalDeterministicWalletSigner` | Per-contract derivation, boarding support |
-| `SingleKey` | Nostr `nsec` | `NSecWalletSigner` | Static key, simple integrations |
-| `WatchOnly` | `null` / empty | `null` | Observe-only — addresses + VTXOs, no signing |
-| `Remote` | `null` / empty | `RemoteArkadeWalletSigner` (proxy) | Signing proxied to `IRemoteSignerTransport` |
+| non-empty | — | local signer (HD or SingleKey) | sign locally |
+| null / empty | yes (`KnowsWalletAsync` → `true`) | `RemoteArkadeWalletSigner` proxy | sign via transport |
+| null / empty | no | `null` | watch-only |
 
-`ArkWalletInfo.Secret` MUST be non-null/non-empty for `HD` and `SingleKey`, and MUST be null/empty for `WatchOnly` and `Remote`.
+Capability lives at the *provider* boundary, not as a tag on the wallet record. Any combination of the two axes is valid: a remote-signed `SingleKey`, a watch-only `HD`, etc.
 
 ## HD Wallets (BIP-39)
 
@@ -29,20 +37,14 @@ Created from a Nostr `nsec` (raw 32-byte secret). All operations use a single st
 - No boarding address support
 - Suitable for testing or lightweight integrations
 
-## Watch-Only Wallets
+## Watch-Only and Remote-Signed Wallets
 
-Created from an account descriptor only — no signing material. The SDK can derive addresses, observe VTXOs, and report balances, but signing-dependent operations (batch participation, unilateral exits) throw a descriptive `InvalidOperationException`. Useful for accounting dashboards, paired devices where the signer lives elsewhere, or air-gapped setups.
+Both are described by the same data shape — `Secret = null` on an otherwise normal `ArkWalletInfo` — and distinguished at runtime by `IWalletProvider.GetSignerAsync`:
 
-The descriptor shape picks the address provider:
+- No `IRemoteSignerTransport` registered, or `KnowsWalletAsync(walletId)` returns `false` → `GetSignerAsync` returns `null`. Watch-only: addresses and VTXOs are observable, signing-dependent operations (batch participation, unilateral exits) throw a descriptive `InvalidOperationException`.
+- An `IRemoteSignerTransport` is registered and claims the wallet → `GetSignerAsync` returns a `RemoteArkadeWalletSigner` proxy. Every signing call is forwarded to the transport. The transport sees `walletId` on every call so one instance can serve many wallets (server-side signing service, HWI bridge, browser-extension wallet, …).
 
-- `tr(<pubkey-hex>)` — single-key style, one reusable address
-- `tr([<fingerprint>/<path>]<xpub>/0/*)` — HD style, new derivation per contract
-
-## Remote-Signing Wallets
-
-The wallet record holds no key material; signing is proxied to an `IRemoteSignerTransport` resolved from DI. The transport sees `walletId` on every call so a single transport instance can serve many wallets (e.g. a server-side signing service, an HWI bridge, a browser-extension wallet).
-
-Implement `IRemoteSignerTransport` for your bridge, register it in DI alongside `IWalletProvider`, and store wallets with `WalletType = WalletType.Remote`. If a remote wallet is loaded but no transport is registered, `GetSignerAsync` throws with a clear error.
+`WalletType` is independent: a watch-only HD wallet derives addresses from its xpub; a watch-only single-key wallet has one fixed address. Same for remote — derivation is whatever the descriptor encodes; the signer-source is whatever the transport claims.
 
 ## Creating a Wallet
 
@@ -67,36 +69,31 @@ var sk = await WalletFactory.CreateWallet(
     cancellationToken: ct);
 await walletStorage.SaveWallet(sk, ct);
 
-// Watch-only wallet (from an account descriptor — no signing material).
-var watchOnly = await WalletFactory.CreateWatchOnlyWallet(
+// Watch-only OR remote-signed: same data shape — null Secret + the descriptor. Whether the
+// wallet ends up watch-only or remote-signed is decided at GetSignerAsync time by whether an
+// IRemoteSignerTransport is registered and claims this walletId (KnowsWalletAsync).
+var nonLocal = await WalletFactory.CreateWatchOnlyWallet(
     accountDescriptor: "tr([abcd1234/86'/1'/0']tpub.../0/*)",
     destination: null,
     serverInfo: serverInfo,
     cancellationToken: ct);
-await walletStorage.SaveWallet(watchOnly, ct);
-
-// Remote-signing wallet (signing proxied to an IRemoteSignerTransport).
-// Construct ArkWalletInfo directly with WalletType.Remote — the transport
-// must be registered in DI before GetSignerAsync is called for this wallet.
-var remote = new ArkWalletInfo(
-    Id: "tr([abcd1234/86'/1'/0']tpub.../0/*)",
-    Secret: null,
-    Destination: null,
-    WalletType: WalletType.Remote,
-    AccountDescriptor: "tr([abcd1234/86'/1'/0']tpub.../0/*)",
-    LastUsedIndex: 0);
-await walletStorage.SaveWallet(remote, ct);
+await walletStorage.SaveWallet(nonLocal, ct);
 ```
 
 `ArkWalletInfo.Id` is the deterministic wallet identifier derived from the descriptor — two imports of the same seed produce the same `Id`.
 
 ## Implementing a Remote Signer
 
-For `WalletType.Remote` wallets the SDK never sees private material; every signing call is forwarded to an `IRemoteSignerTransport` you register in DI. Mirror `IArkadeWalletSigner` with an extra `walletId` parameter on each method:
+For wallets whose `Secret` is null, the SDK never sees private material; every signing call is forwarded to an `IRemoteSignerTransport` you register in DI. The transport itself decides which wallets it can sign for via `KnowsWalletAsync` — wallets it doesn't claim fall through to watch-only.
+
+Mirror `IArkadeWalletSigner` with an extra `walletId` parameter on each method, plus the `KnowsWalletAsync` probe:
 
 ```csharp
 public class HardwareSignerTransport : IRemoteSignerTransport
 {
+    public Task<bool> KnowsWalletAsync(string walletId, CancellationToken ct)
+        => _bridge.IsPairedAsync(walletId, ct);
+
     public Task<ECPubKey> GetPubKeyAsync(string walletId, OutputDescriptor descriptor, CancellationToken ct)
         => _bridge.GetPubKeyAsync(walletId, descriptor.ToString(), ct);
 

--- a/docs/articles/wallets.md
+++ b/docs/articles/wallets.md
@@ -1,6 +1,17 @@
 # Wallets
 
-Wallets are stored in `IWalletStorage` and materialized as address/signing providers on demand by `IWalletProvider` (default: `DefaultWalletProvider`). The secret material itself lives in `ArkWalletInfo.Secret`.
+Wallets are stored in `IWalletStorage` and materialized as address/signing providers on demand by `IWalletProvider` (default: `DefaultWalletProvider`). Signing material (when present) lives in `ArkWalletInfo.Secret`.
+
+`WalletType` selects the signing flavour:
+
+| `WalletType` | `Secret` | `GetSignerAsync` returns | Use case |
+| --- | --- | --- | --- |
+| `HD` | BIP-39 mnemonic | `HierarchicalDeterministicWalletSigner` | Per-contract derivation, boarding support |
+| `SingleKey` | Nostr `nsec` | `NSecWalletSigner` | Static key, simple integrations |
+| `WatchOnly` | `null` / empty | `null` | Observe-only — addresses + VTXOs, no signing |
+| `Remote` | `null` / empty | `RemoteArkadeWalletSigner` (proxy) | Signing proxied to `IRemoteSignerTransport` |
+
+`ArkWalletInfo.Secret` MUST be non-null/non-empty for `HD` and `SingleKey`, and MUST be null/empty for `WatchOnly` and `Remote`.
 
 ## HD Wallets (BIP-39)
 
@@ -17,6 +28,21 @@ Created from a Nostr `nsec` (raw 32-byte secret). All operations use a single st
 - Simpler setup
 - No boarding address support
 - Suitable for testing or lightweight integrations
+
+## Watch-Only Wallets
+
+Created from an account descriptor only — no signing material. The SDK can derive addresses, observe VTXOs, and report balances, but signing-dependent operations (batch participation, unilateral exits) throw a descriptive `InvalidOperationException`. Useful for accounting dashboards, paired devices where the signer lives elsewhere, or air-gapped setups.
+
+The descriptor shape picks the address provider:
+
+- `tr(<pubkey-hex>)` — single-key style, one reusable address
+- `tr([<fingerprint>/<path>]<xpub>/0/*)` — HD style, new derivation per contract
+
+## Remote-Signing Wallets
+
+The wallet record holds no key material; signing is proxied to an `IRemoteSignerTransport` resolved from DI. The transport sees `walletId` on every call so a single transport instance can serve many wallets (e.g. a server-side signing service, an HWI bridge, a browser-extension wallet).
+
+Implement `IRemoteSignerTransport` for your bridge, register it in DI alongside `IWalletProvider`, and store wallets with `WalletType = WalletType.Remote`. If a remote wallet is loaded but no transport is registered, `GetSignerAsync` throws with a clear error.
 
 ## Creating a Wallet
 
@@ -40,9 +66,57 @@ var sk = await WalletFactory.CreateWallet(
     serverInfo: serverInfo,
     cancellationToken: ct);
 await walletStorage.SaveWallet(sk, ct);
+
+// Watch-only wallet (from an account descriptor — no signing material).
+var watchOnly = await WalletFactory.CreateWatchOnlyWallet(
+    accountDescriptor: "tr([abcd1234/86'/1'/0']tpub.../0/*)",
+    destination: null,
+    serverInfo: serverInfo,
+    cancellationToken: ct);
+await walletStorage.SaveWallet(watchOnly, ct);
+
+// Remote-signing wallet (signing proxied to an IRemoteSignerTransport).
+// Construct ArkWalletInfo directly with WalletType.Remote — the transport
+// must be registered in DI before GetSignerAsync is called for this wallet.
+var remote = new ArkWalletInfo(
+    Id: "tr([abcd1234/86'/1'/0']tpub.../0/*)",
+    Secret: null,
+    Destination: null,
+    WalletType: WalletType.Remote,
+    AccountDescriptor: "tr([abcd1234/86'/1'/0']tpub.../0/*)",
+    LastUsedIndex: 0);
+await walletStorage.SaveWallet(remote, ct);
 ```
 
 `ArkWalletInfo.Id` is the deterministic wallet identifier derived from the descriptor — two imports of the same seed produce the same `Id`.
+
+## Implementing a Remote Signer
+
+For `WalletType.Remote` wallets the SDK never sees private material; every signing call is forwarded to an `IRemoteSignerTransport` you register in DI. Mirror `IArkadeWalletSigner` with an extra `walletId` parameter on each method:
+
+```csharp
+public class HardwareSignerTransport : IRemoteSignerTransport
+{
+    public Task<ECPubKey> GetPubKeyAsync(string walletId, OutputDescriptor descriptor, CancellationToken ct)
+        => _bridge.GetPubKeyAsync(walletId, descriptor.ToString(), ct);
+
+    public Task<MusigPartialSignature> SignMusigAsync(string walletId, OutputDescriptor descriptor,
+        MusigContext context, MusigPrivNonce nonce, CancellationToken ct)
+        => _bridge.SignMusigAsync(walletId, descriptor.ToString(), context, nonce, ct);
+
+    public Task<(ECXOnlyPubKey, SecpSchnorrSignature)> SignAsync(string walletId, OutputDescriptor descriptor,
+        uint256 hash, CancellationToken ct)
+        => _bridge.SignAsync(walletId, descriptor.ToString(), hash, ct);
+
+    public Task<MusigPrivNonce> GenerateNoncesAsync(string walletId, OutputDescriptor descriptor,
+        MusigContext context, CancellationToken ct)
+        => _bridge.GenerateNoncesAsync(walletId, descriptor.ToString(), context, ct);
+}
+
+services.AddSingleton<IRemoteSignerTransport, HardwareSignerTransport>();
+```
+
+`DefaultWalletProvider` accepts the transport as an optional constructor dependency — existing setups that don't use remote signing don't need to register one.
 
 ## Using a Wallet
 

--- a/samples/NArk.Wallet/NArk.Wallet.Client/Pages/Backup.razor
+++ b/samples/NArk.Wallet/NArk.Wallet.Client/Pages/Backup.razor
@@ -61,6 +61,21 @@
             I understand, show my secret
         </button>
     }
+    else if (string.IsNullOrEmpty(_wallet.Secret))
+    {
+        <!-- Watch-only / Remote wallets have no local secret to back up -->
+        <div class="glass-card mb-16">
+            <div style="text-align:center;padding:20px 0 12px;">
+                <p style="font-size:16px;font-weight:600;margin-bottom:8px;">No backup required</p>
+                <p class="text-secondary" style="font-size:13px;line-height:1.6;">
+                    This is a @(_wallet.WalletType.ToString().ToLowerInvariant()) wallet — it holds no
+                    signing material locally. Back up the @(_wallet.WalletType == WalletType.WatchOnly
+                    ? "account descriptor" : "remote-signer configuration") that bootstrapped it
+                    instead.
+                </p>
+            </div>
+        </div>
+    }
     else
     {
         <!-- Revealed secret -->

--- a/samples/NArk.Wallet/NArk.Wallet.Client/Pages/Backup.razor
+++ b/samples/NArk.Wallet/NArk.Wallet.Client/Pages/Backup.razor
@@ -63,15 +63,13 @@
     }
     else if (string.IsNullOrEmpty(_wallet.Secret))
     {
-        <!-- Watch-only / Remote wallets have no local secret to back up -->
+        <!-- No local secret → watch-only or remote-signed; either way nothing to reveal here. -->
         <div class="glass-card mb-16">
             <div style="text-align:center;padding:20px 0 12px;">
                 <p style="font-size:16px;font-weight:600;margin-bottom:8px;">No backup required</p>
                 <p class="text-secondary" style="font-size:13px;line-height:1.6;">
-                    This is a @(_wallet.WalletType.ToString().ToLowerInvariant()) wallet — it holds no
-                    signing material locally. Back up the @(_wallet.WalletType == WalletType.WatchOnly
-                    ? "account descriptor" : "remote-signer configuration") that bootstrapped it
-                    instead.
+                    This wallet holds no signing material locally. Back up the account descriptor
+                    (or remote-signer configuration) that bootstrapped it instead.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
## Summary

Reworked after self-review (see commit \`rework(wallets): capability lives at the signer provider, not on WalletType\`). \`WalletType\` stays as the *key-derivation* axis only (\`SingleKey\` | \`HD\`); watch-only and remote-signing are answered at the signer-provider boundary, not encoded as separate enum cases.

## Why the rework

The original draft added \`WalletType.WatchOnly\` and \`WalletType.Remote\`, which conflated two orthogonal axes:

1. **Key derivation** — single tweaked key vs. xpub-derived child set.
2. **Key availability** — local key, remote signer, or no key.

The smell was already visible in the diff: the address provider had to recover the derivation by sniffing the descriptor (\`tr(pubkey)\` vs \`*\`), because the enum had collapsed it. Configurations like *HD + watch-only* and *HD + remote-signed* couldn't be expressed without that recovery step.

## New model

| Axis | Values | Source of truth |
| --- | --- | --- |
| Key derivation | \`SingleKey\` \| \`HD\` | \`WalletType\` |
| Key availability | local / remote / watch-only | \`IWalletProvider.GetSignerAsync\` (a signer, or \`null\`) |

\`GetSignerAsync\` dispatch:

\`\`\`
Secret non-empty → local signer (HD or SingleKey)
Secret null/empty + IRemoteSignerTransport.KnowsWalletAsync(id) → RemoteArkadeWalletSigner proxy
otherwise → null (watch-only)
\`\`\`

Capability lives on the interface. The data record carries no \`IsWatchOnly\` / \`IsRemote\` flag — \`Secret = null\` is the only signal, and the transport is the source of truth for the remote/watch-only distinction.

## What's in this PR

| File | Change |
| --- | --- |
| \`NArk.Abstractions/Wallets/WalletType.cs\` | Two values only: \`SingleKey\`, \`HD\`. Doc explains the two-axis model. |
| \`NArk.Abstractions/Wallets/ArkWalletInfo.cs\` | \`Secret\` nullable; doc says null/empty = no local key, capability decided at the provider. |
| \`NArk.Abstractions/Wallets/IRemoteSignerTransport.cs\` | New \`KnowsWalletAsync(walletId, ct)\` probe — transport claims which wallets it signs for. |
| \`NArk.Core/Wallet/DefaultWalletProvider.cs\` | \`GetSignerAsync\` dispatches on \`Secret\` first, then probes the transport, then returns null. \`GetAddressProviderAsync\` dispatches purely on \`WalletType\` — no descriptor sniffing. |
| \`NArk.Core/Wallet/RemoteArkadeWalletSigner.cs\` | Unchanged — pure proxy. |
| \`NArk.Core/Wallet/WalletFactory.cs\` | \`CreateWatchOnlyWallet\` infers \`WalletType\` from descriptor shape at creation time (one place, encoded in data). |
| \`NArk.Core/Wallet/HierarchicalDeterministicWalletSigner.cs\` | Explicit \`InvalidOperationException\` if a null mnemonic reaches an HD signer (defensive cleanup, kept from earlier commits). |
| \`NArk.Core/Batches/TreeSignerSession.cs\` | Hoisted signer null-checks above per-VTXO loops (kept from earlier commits). |
| \`NArk.Storage.EfCore/Entities/ArkWalletEntity.cs\` | \`Wallet\` column nullable to persist Secret-less wallets. |
| \`README.md\`, \`docs/articles/wallets.md\` | Rewritten around the two-axis model with the dispatch table. |
| \`samples/.../Backup.razor\` | The Secret-null branch is now generic — no enum check needed. |

## What's NOT in this PR

- **Tests** — still deferred to phase 2 alongside the batched-RPC reshape of \`TreeSignerSession\`. All 404 existing unit tests pass under the rework.
- **\`TreeSignerSession\` batched-RPC reshape** — current per-VTXO chattiness works correctly for remote signers; reshaping is an obvious optimization target.

## Test plan

- [x] \`dotnet build NArk.sln\` — 0 errors
- [x] \`dotnet test NArk.Tests\` — 404 / 404