### PR TITLE
fix(tests): fix failing integration tests for a new regtest version 

### DIFF
--- a/.env.regtest
+++ b/.env.regtest
@@ -16,6 +16,8 @@ BITCOIN_LOW_FEE=true
 # 3600 (1 hour) sits cleanly in between both bounds.
 ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.3
 ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.3
+# SDK tests hardcode "ark" for docker exec — keep the override container name consistent.
+ARK_CONTAINER=ark
 ARKD_VTXO_TREE_EXPIRY=3600
 ARKD_UNILATERAL_EXIT_DELAY=512
 ARKD_BOARDING_EXIT_DELAY=2048

--- a/.env.regtest
+++ b/.env.regtest
@@ -22,13 +22,6 @@ ARKD_VTXO_TREE_EXPIRY=3600
 ARKD_UNILATERAL_EXIT_DELAY=512
 ARKD_BOARDING_EXIT_DELAY=2048
 
-# ── Fulmine override ───────────────────────────────────────────────────────
-# Default (0.01 BTC ≈ 990k sats after fees) is exhausted after the first
-# SendArkdNoteTo call (500k sats), leaving only 490k settled — less than the
-# 500k the next test needs. 1 BTC gives ~99M sats, comfortably covering
-# the full E2E suite (≈39 tests × up to 500k sats each).
-FULMINE_FAUCET_AMOUNT=1
-
 # ── Boltz override ─────────────────────────────────────────────────────────
 # regtest/.env.defaults pins BOLTZ_IMAGE=boltz/boltz:latest. That tag was
 # re-pushed on 2026-05-12 at 15:51 UTC with a 3.13.0-7ae3002e dev build that

--- a/.env.regtest
+++ b/.env.regtest
@@ -22,6 +22,13 @@ ARKD_VTXO_TREE_EXPIRY=3600
 ARKD_UNILATERAL_EXIT_DELAY=512
 ARKD_BOARDING_EXIT_DELAY=2048
 
+# ── Fulmine override ───────────────────────────────────────────────────────
+# Default (0.01 BTC ≈ 990k sats after fees) is exhausted after the first
+# SendArkdNoteTo call (500k sats), leaving only 490k settled — less than the
+# 500k the next test needs. 1 BTC gives ~99M sats, comfortably covering
+# the full E2E suite (≈39 tests × up to 500k sats each).
+FULMINE_FAUCET_AMOUNT=1
+
 # ── Boltz override ─────────────────────────────────────────────────────────
 # regtest/.env.defaults pins BOLTZ_IMAGE=boltz/boltz:latest. That tag was
 # re-pushed on 2026-05-12 at 15:51 UTC with a 3.13.0-7ae3002e dev build that

--- a/NArk.Tests.End2End/BuilderStyleTests.cs
+++ b/NArk.Tests.End2End/BuilderStyleTests.cs
@@ -1,10 +1,8 @@
-using CliWrap;
-using CliWrap.Buffered;
+using NArk.Tests.End2End.Common;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using NArk.Abstractions.Intents;
 using NArk.Abstractions.Wallets;
-using NArk.Blockchain;
 using NArk.Hosting;
 using NArk.Core.Models.Options;
 using NArk.Safety.AsyncKeyedLock;
@@ -51,12 +49,7 @@ public class BuilderStyleTests
         var fp = await wallet.CreateTestWallet();
         var contract = await contractService.DeriveContract(fp, NextContractPurpose.Receive, cancellationToken: CancellationToken.None);
 
-        await Cli.Wrap("docker")
-            .WithArguments([
-                "exec", "ark", "ark", "send", "--to", contract.GetArkAddress().ToString(false), "--amount",
-                "50000", "--password", "secret"
-            ])
-            .ExecuteBufferedAsync();
+        await DockerHelper.SendArkdNoteTo(contract.GetArkAddress().ToString(false), 50000);
 
         var gotBatchTcs = new TaskCompletionSource();
 

--- a/NArk.Tests.End2End/ChainSwapTests.cs
+++ b/NArk.Tests.End2End/ChainSwapTests.cs
@@ -1,5 +1,3 @@
-using CliWrap;
-using CliWrap.Buffered;
 using Microsoft.Extensions.Options;
 using NArk.Blockchain;
 using NArk.Core.Fees;
@@ -112,11 +110,8 @@ public class ChainSwapTests
         Assert.That(swapId, Is.Not.Null.And.Not.Empty);
 
         // Fund the BTC lockup address with the exact expected amount
-        var sendResult = await Cli.Wrap("docker")
-            .WithArguments(["exec", "bitcoin", "bitcoin-cli", "-rpcwallet=", "sendtoaddress", btcAddress, btcAmount])
-            .ExecuteBufferedAsync();
-        Console.WriteLine($"[BTC→ARK] sendtoaddress result: exit={sendResult.ExitCode}, stdout={sendResult.StandardOutput.Trim()}, stderr={sendResult.StandardError.Trim()}");
-        Assert.That(sendResult.ExitCode, Is.EqualTo(0), $"sendtoaddress failed: {sendResult.StandardError}");
+        var txid = await DockerHelper.BitcoinSendToAddress(btcAddress, btcAmount);
+        Console.WriteLine($"[BTC→ARK] sendtoaddress txid: {txid}");
 
         // Mine blocks periodically so Boltz confirms the BTC lockup, locks ARK, and we claim
         for (var i = 0; i < 15; i++)
@@ -195,10 +190,7 @@ public class ChainSwapTests
         await swapMgr.StartAsync(CancellationToken.None);
 
         // Generate a BTC destination address from the bitcoin node
-        var addrResult = await Cli.Wrap("docker")
-            .WithArguments(["exec", "bitcoin", "bitcoin-cli", "-rpcwallet=", "getnewaddress"])
-            .ExecuteBufferedAsync();
-        var btcDestination = BitcoinAddress.Create(addrResult.StandardOutput.Trim(), Network.RegTest);
+        var btcDestination = BitcoinAddress.Create(await DockerHelper.BitcoinGetNewAddress(), Network.RegTest);
 
         // Create ARK→BTC chain swap
         var swapId = await swapMgr.InitiateArkToBtcChainSwap(
@@ -321,11 +313,8 @@ public class ChainSwapTests
         // covered by the test wallet's UTXO budget.
         var fundAmount = originalExpectedSats + 1000;
         var btcAmount = (fundAmount / 100_000_000m).ToString("0.########");
-        var sendResult = await Cli.Wrap("docker")
-            .WithArguments(["exec", "bitcoin", "bitcoin-cli", "-rpcwallet=", "sendtoaddress", btcAddress, btcAmount])
-            .ExecuteBufferedAsync(token);
-        Console.WriteLine($"[BTC→ARK reneg] Funded {fundAmount} sats (expected+1000), exit={sendResult.ExitCode}");
-        Assert.That(sendResult.ExitCode, Is.EqualTo(0), $"sendtoaddress failed: {sendResult.StandardError}");
+        var txid = await DockerHelper.BitcoinSendToAddress(btcAddress, btcAmount, token);
+        Console.WriteLine($"[BTC→ARK reneg] Funded {fundAmount} sats (expected+1000), txid={txid}");
 
         // Mine to confirm the lockup so Boltz emits transaction.lockupFailed
         // and the SDK's PollSwapState gets the chance to renegotiate.
@@ -519,10 +508,7 @@ public class ChainSwapTests
 
         // Generate a BTC destination from the bitcoin node — Boltz needs a
         // real BTC address even though we'll never reach the claim step.
-        var addrResult = await Cli.Wrap("docker")
-            .WithArguments(["exec", "bitcoin", "bitcoin-cli", "-rpcwallet=", "getnewaddress"])
-            .ExecuteBufferedAsync(token);
-        var btcDestination = BitcoinAddress.Create(addrResult.StandardOutput.Trim(), Network.RegTest);
+        var btcDestination = BitcoinAddress.Create(await DockerHelper.BitcoinGetNewAddress(token), Network.RegTest);
 
         var swapId = await swapMgr.InitiateArkToBtcChainSwap(
             testingPrerequisite.walletIdentifier, 50_000, btcDestination, token);

--- a/NArk.Tests.End2End/Common/DockerHelper.cs
+++ b/NArk.Tests.End2End/Common/DockerHelper.cs
@@ -91,12 +91,14 @@ public static class DockerHelper
     }
 
     /// <summary>
+    /// Not really a Docker helper, but a http fulmine endpoint one.
     /// Sends <paramref name="amountSats"/> sats as an Arkade VTXO to <paramref name="arkAddress"/>
-    /// via Fulmine's offchain send API. Fulmine is pre-funded by start-env.sh.
+    /// via Fulmine's offchain send API. Ensures Fulmine has sufficient balance before sending.
     /// </summary>
     public static async Task SendArkdNoteTo(string arkAddress, long amountSats,
         CancellationToken ct = default)
     {
+        await FulmineLiquidityHelper.EnsureArkLiquidity(minBalance: amountSats, maxAttempts: 5);
         using var http = new HttpClient { BaseAddress = new Uri("http://localhost:7003") };
         var response = await http.PostAsJsonAsync(
             "/api/v1/send/offchain",

--- a/NArk.Tests.End2End/Common/DockerHelper.cs
+++ b/NArk.Tests.End2End/Common/DockerHelper.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using CliWrap;
@@ -90,36 +91,25 @@ public static class DockerHelper
     }
 
     /// <summary>
-    /// Adds an extra unspent VTXO to an already-funded wallet's existing
-    /// receive contract by issuing another <c>ark send</c> from arkd. Used
-    /// by concurrency tests where two parallel swaps must each lock their
-    /// own VTXO without hitting <c>AlreadyLockedVtxoException</c>.
+    /// Sends <paramref name="amountSats"/> sats as an Arkade VTXO to <paramref name="arkAddress"/>
+    /// via Fulmine's offchain send API. Fulmine is pre-funded by start-env.sh.
     /// </summary>
-    /// <remarks>
-    /// Must be invoked AFTER the wallet has at least one VTXO already (so a
-    /// receive script is registered with arkd) and BEFORE the swap that
-    /// needs the extra VTXO is initiated. Each call creates one additional
-    /// <paramref name="amountSats"/>-sat VTXO at the same script. The
-    /// supplied <paramref name="onVtxoArrived"/> callback is invoked when a
-    /// new unspent VTXO lands at the receive script — typical use is a
-    /// <see cref="TaskCompletionSource"/> the caller awaits.
-    /// </remarks>
     public static async Task SendArkdNoteTo(string arkAddress, long amountSats,
         CancellationToken ct = default)
     {
-        var result = await CliWrap.Cli.Wrap("docker")
-            .WithArguments([
-                "exec", "ark", "ark", "send", "--to", arkAddress,
-                "--amount", amountSats.ToString(),
-                "--password", "secret"
-            ])
-            .WithValidation(CliWrap.CommandResultValidation.None)
-            .ExecuteBufferedAsync(ct);
+        using var http = new HttpClient { BaseAddress = new Uri("http://localhost:7003") };
+        var response = await http.PostAsJsonAsync(
+            "/api/v1/send/offchain",
+            new { address = arkAddress, amount = amountSats },
+            ct);
 
-        if (!result.IsSuccess)
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(ct);
             throw new InvalidOperationException(
-                $"ark send to {arkAddress} for {amountSats} sats failed (exit={result.ExitCode}): " +
-                $"stdout={result.StandardOutput.Trim()}, stderr={result.StandardError.Trim()}");
+                $"Fulmine send offchain to {arkAddress} for {amountSats} sats failed " +
+                $"({response.StatusCode}): {body}");
+        }
     }
 
     /// <summary>
@@ -131,5 +121,50 @@ public static class DockerHelper
         var output = await Exec("ark",
             ["arkd", "note", "--amount", amountSats.ToString()], ct);
         return output.Trim();
+    }
+
+    /// <summary>
+    /// Pays a BOLT11 invoice via the nigiri lnd node using lncli.
+    /// </summary>
+    public static async Task PayLndInvoice(string bolt11Invoice, CancellationToken ct = default)
+    {
+        var result = await Cli.Wrap("docker")
+            .WithArguments(["exec", "lnd", "lncli", "--network=regtest", "payinvoice", "--force", bolt11Invoice])
+            .WithValidation(CommandResultValidation.None)
+            .ExecuteBufferedAsync(ct);
+        if (!result.IsSuccess)
+            throw new InvalidOperationException(
+                $"lncli payinvoice failed (exit={result.ExitCode}): {result.StandardError.Trim()}");
+    }
+
+    /// <summary>
+    /// Sends BTC to an address via Bitcoin Core's bitcoin-cli.
+    /// Returns the transaction ID.
+    /// </summary>
+    public static async Task<string> BitcoinSendToAddress(string address, string btcAmount, CancellationToken ct = default)
+    {
+        var result = await Cli.Wrap("docker")
+            .WithArguments(["exec", "bitcoin", "bitcoin-cli", "-rpcwallet=", "sendtoaddress", address, btcAmount])
+            .WithValidation(CommandResultValidation.None)
+            .ExecuteBufferedAsync(ct);
+        if (!result.IsSuccess)
+            throw new InvalidOperationException(
+                $"bitcoin-cli sendtoaddress {address} {btcAmount} failed (exit={result.ExitCode}): {result.StandardError.Trim()}");
+        return result.StandardOutput.Trim();
+    }
+
+    /// <summary>
+    /// Gets a new address from the Bitcoin Core wallet.
+    /// </summary>
+    public static async Task<string> BitcoinGetNewAddress(CancellationToken ct = default)
+    {
+        var result = await Cli.Wrap("docker")
+            .WithArguments(["exec", "bitcoin", "bitcoin-cli", "-rpcwallet=", "getnewaddress"])
+            .WithValidation(CommandResultValidation.None)
+            .ExecuteBufferedAsync(ct);
+        if (!result.IsSuccess)
+            throw new InvalidOperationException(
+                $"bitcoin-cli getnewaddress failed (exit={result.ExitCode}): {result.StandardError.Trim()}");
+        return result.StandardOutput.Trim();
     }
 }

--- a/NArk.Tests.End2End/Common/FundedWalletHelper.cs
+++ b/NArk.Tests.End2End/Common/FundedWalletHelper.cs
@@ -1,5 +1,3 @@
-using CliWrap;
-using CliWrap.Buffered;
 using NArk.Abstractions.Contracts;
 using NArk.Abstractions.Extensions;
 using NArk.Abstractions.Safety;
@@ -13,7 +11,6 @@ using NArk.Tests.End2End.Core;
 using NArk.Tests.End2End.TestPersistance;
 using NArk.Core.Transport;
 using NArk.Transport.GrpcClient;
-using NBitcoin;
 
 namespace NArk.Tests.End2End.Common;
 
@@ -69,19 +66,7 @@ internal static class FundedWalletHelper
         // so concurrent tests that need parallel coin selection don't race
         // on a shared input.
         for (var i = 0; i < vtxoCount; i++)
-        {
-            var sendResult = await Cli.Wrap("docker")
-                .WithArguments([
-                    "exec", "ark", "ark", "send", "--to", contract.GetArkAddress().ToString(false), "--amount",
-                    amountSatsPerVtxo.ToString(), "--password", "secret"
-                ])
-                .WithValidation(CommandResultValidation.None)
-                .ExecuteBufferedAsync();
-
-            if (!sendResult.IsSuccess)
-                throw new InvalidOperationException(
-                    $"ark send #{i + 1} failed (exit={sendResult.ExitCode}): stdout={sendResult.StandardOutput}, stderr={sendResult.StandardError}");
-        }
+            await DockerHelper.SendArkdNoteTo(contract.GetArkAddress().ToString(false), amountSatsPerVtxo);
 
         await receivedAllVtxosTcs.Task.WaitAsync(TimeSpan.FromSeconds(15 * vtxoCount));
 
@@ -139,19 +124,8 @@ internal static class FundedWalletHelper
         var contract = await contractService.DeriveContract(walletId, NextContractPurpose.Receive);
         var delegateContract = (ArkDelegateContract)contract;
 
-        // Fund via ark send
         const int randomAmount = 500000;
-        var sendResult = await Cli.Wrap("docker")
-            .WithArguments([
-                "exec", "ark", "ark", "send", "--to", delegateContract.GetArkAddress().ToString(false), "--amount",
-                randomAmount.ToString(), "--password", "secret"
-            ])
-            .WithValidation(CommandResultValidation.None)
-            .ExecuteBufferedAsync();
-
-        if (!sendResult.IsSuccess)
-            throw new InvalidOperationException(
-                $"ark send failed (exit={sendResult.ExitCode}): stdout={sendResult.StandardOutput}, stderr={sendResult.StandardError}");
+        await DockerHelper.SendArkdNoteTo(delegateContract.GetArkAddress().ToString(false), randomAmount);
 
         await receivedFirstVtxoTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
 

--- a/NArk.Tests.End2End/OnchainTests.cs
+++ b/NArk.Tests.End2End/OnchainTests.cs
@@ -1,11 +1,9 @@
-using CliWrap;
-using CliWrap.Buffered;
+using NArk.Tests.End2End.Common;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using NArk.Abstractions;
 using NArk.Abstractions.Intents;
 using NArk.Abstractions.Wallets;
-using NArk.Blockchain;
 using NArk.Hosting;
 using NArk.Core.Models.Options;
 using NArk.Safety.AsyncKeyedLock;
@@ -65,12 +63,7 @@ public class OnchainTests
                 fundedTcs.TrySetResult();
         };
 
-        await Cli.Wrap("docker")
-            .WithArguments([
-                "exec", "ark", "ark", "send", "--to", contract.GetArkAddress().ToString(false), "--amount",
-                "50000", "--password", "secret"
-            ])
-            .ExecuteBufferedAsync();
+        await DockerHelper.SendArkdNoteTo(contract.GetArkAddress().ToString(false), 50000);
 
         await fundedTcs.Task.WaitAsync(TimeSpan.FromSeconds(15));
 

--- a/NArk.Tests.End2End/SwapManagementServiceTests.cs
+++ b/NArk.Tests.End2End/SwapManagementServiceTests.cs
@@ -1,5 +1,3 @@
-using CliWrap;
-using CliWrap.Buffered;
 using BTCPayServer.Lightning;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -11,7 +9,6 @@ using NArk.Core.Fees;
 using NArk.Core.Models.Options;
 using NArk.Core.Services;
 using NArk.Core.Transport;
-using NArk.Core.Wallet;
 using NArk.Swaps.Abstractions;
 using NArk.Swaps.Boltz;
 using NArk.Swaps.Boltz.Client;
@@ -152,9 +149,7 @@ public class SwapManagementServiceTests
             ));
 
         // Until Aspire has a way to run commands with parameters :(
-        await Cli.Wrap("docker")
-            .WithArguments(["exec", "lnd", "lncli", "--network=regtest", "payinvoice", "--force", invoice])
-            .ExecuteBufferedAsync();
+        await DockerHelper.PayLndInvoice(invoice);
 
         await settledSwapTcs.Task.WaitAsync(TimeSpan.FromMinutes(2));
     }
@@ -667,9 +662,7 @@ public class SwapManagementServiceTests
                 swapMgr.InitiateReverseSwap(prereq.walletIdentifier,
                     new CreateInvoiceParams(LightMoney.Satoshis(20000), "ParallelReverse", TimeSpan.FromHours(1)),
                     token));
-            await Cli.Wrap("docker")
-                .WithArguments(["exec", "lnd", "lncli", "--network=regtest", "payinvoice", "--force", revInvoice])
-                .ExecuteBufferedAsync(token);
+            await DockerHelper.PayLndInvoice(revInvoice, token);
             await revSettled.Task.WaitAsync(TimeSpan.FromMinutes(5), token);
             await swapMgr.DisposeAsync();
             await sweepMgr.DisposeAsync();

--- a/NArk.Tests.End2End/VtxoSynchronizationTests.cs
+++ b/NArk.Tests.End2End/VtxoSynchronizationTests.cs
@@ -1,12 +1,10 @@
 using System.Security.Cryptography;
-using CliWrap;
-using CliWrap.Buffered;
+using NArk.Tests.End2End.Common;
 using NArk.Abstractions;
 using NArk.Abstractions.Contracts;
 using NArk.Abstractions.Wallets;
 using NArk.Blockchain;
 using NArk.Core.Contracts;
-using NArk.Abstractions.Safety;
 using NArk.Safety.AsyncKeyedLock;
 using NArk.Core.Services;
 using NArk.Tests.End2End.TestPersistance;
@@ -67,12 +65,7 @@ public class VtxoSynchronizationTests
         );
         await contractService.ImportContract(fp, contract);
 
-        await Cli.Wrap("docker")
-            .WithArguments([
-                "exec", "ark", "ark", "send", "--to", contract.GetArkAddress().ToString(false), "--amount",
-                randomAmount.ToString(), "--password", "secret"
-            ])
-            .ExecuteBufferedAsync();
+        await DockerHelper.SendArkdNoteTo(contract.GetArkAddress().ToString(false), randomAmount);
 
         // Wait for the sync service to receive it
         await receiveTcs.Task.WaitAsync(TimeSpan.FromSeconds(15));
@@ -130,12 +123,7 @@ public class VtxoSynchronizationTests
 
         // Send funds to the contract
         var randomAmount = RandomNumberGenerator.GetInt32((int)info.Dust.Satoshi, 100000);
-        await Cli.Wrap("docker")
-            .WithArguments([
-                "exec", "ark", "ark", "send", "--to", contractAddress.ToString(false),
-                "--amount", randomAmount.ToString(), "--password", "secret"
-            ])
-            .ExecuteBufferedAsync();
+        await DockerHelper.SendArkdNoteTo(contractAddress.ToString(false), randomAmount);
 
         // Wait for auto-deactivation
         await deactivationTcs.Task.WaitAsync(TimeSpan.FromSeconds(15));
@@ -194,12 +182,7 @@ public class VtxoSynchronizationTests
             }
         };
 
-        await Cli.Wrap("docker")
-            .WithArguments([
-                "exec", "ark", "ark", "send", "--to", wallet1Address.ToString(false),
-                "--amount", randomAmount.ToString(), "--password", "secret"
-            ])
-            .ExecuteBufferedAsync();
+        await DockerHelper.SendArkdNoteTo(wallet1Address.ToString(false), randomAmount);
 
         // Wait for the sync service to receive it
         await receiveTcs.Task.WaitAsync(TimeSpan.FromSeconds(15));


### PR DESCRIPTION
## Summary

E2E tests used `docker exec ark ark send` to fund test wallets, requiring an initialized `ark`
CLI wallet that was never set up in CI. Fixed by:

- Setting `ARK_CONTAINER=ark` in `.env.regtest` (container name mismatch with compose override)
- Replacing `ark send` with Fulmine's `POST /api/v1/send/offchain` — Fulmine is already funded
  by `start-env.sh`, no extra setup needed. `EnsureArkLiquidity` auto-refunds if balance runs low.
- Centralizing all scattered `Cli.Wrap("docker")` calls into `DockerHelper` methods

## Test plan

- [x] `./regtest/start-env.sh` + `dotnet test NArk.Tests.End2End`
- [x] Previously failing tests (`CanReceiveVtxosFromImportedContract`, batch/swap tests) pass