### PR TITLE
fix(payments): allow ArkBip21.Build() with no address when lightning is set

### DIFF
--- a/NArk.Abstractions/Payments/Bip21PaymentInfo.cs
+++ b/NArk.Abstractions/Payments/Bip21PaymentInfo.cs
@@ -158,13 +158,32 @@ public class ArkBip21
     /// <summary>
     /// Builds the BIP21 URI string.
     /// Format: <c>bitcoin:[onchain_address]?amount=X&amp;ark=Y&amp;lightning=Z</c>
+    /// <para>At least one destination must be set: an ark address, an on-chain address, or a
+    /// lightning value (BOLT11 / LNURL — itself a destination). <c>assetId</c> alone is not a
+    /// destination — it constrains <i>what</i> to send, not <i>where</i> — so it does not satisfy
+    /// the precondition; pair it with an ark address.</para>
+    /// <para>The on-chain address slot may be empty when only ark or only lightning is set — e.g.
+    /// a Lightning-only URI <c>bitcoin:?lightning=lnurl1…</c>. The <c>bitcoin:</c> scheme stays
+    /// consistent across per-path toggle states; any LN-capable wallet (or BIP21 parser that
+    /// understands the <c>lightning=</c> param) routes off the query string. Strict parsers
+    /// that require a path-position address should set one via <see cref="WithOnchainAddress"/>
+    /// or <see cref="WithArkAddress"/>; the SDK no longer forces it.</para>
     /// </summary>
-    /// <exception cref="InvalidOperationException">No address was set (need at least ark or onchain).</exception>
+    /// <exception cref="InvalidOperationException">
+    /// No destination was set. Call <see cref="WithArkAddress"/>, <see cref="WithOnchainAddress"/>,
+    /// or <see cref="WithLightning"/>. An asset alone is not a destination.
+    /// </exception>
     public string Build()
     {
-        if (string.IsNullOrWhiteSpace(_arkAddress) && string.IsNullOrWhiteSpace(_onchainAddress))
+        if (string.IsNullOrWhiteSpace(_arkAddress)
+            && string.IsNullOrWhiteSpace(_onchainAddress)
+            && string.IsNullOrWhiteSpace(_lightning))
+        {
             throw new InvalidOperationException(
-                "At least one address is required. Call WithArkAddress() or WithOnchainAddress() before Build().");
+                "At least one destination is required. Call WithArkAddress, WithOnchainAddress, " +
+                "or WithLightning before Build(). (WithAssetId is a constraint on what to send, " +
+                "not a destination — it can't stand alone.)");
+        }
 
         var sb = new StringBuilder("bitcoin:");
         sb.Append(_onchainAddress ?? string.Empty);

--- a/NArk.Tests/ArkBip21Tests.cs
+++ b/NArk.Tests/ArkBip21Tests.cs
@@ -217,8 +217,9 @@ public class ArkBip21Tests
     }
 
     [Test]
-    public void Build_NoAddress_Throws()
+    public void Build_NothingSet_Throws()
     {
+        // Empty builder — no ark, onchain, lightning, asset, or custom params — still rejected.
         Assert.Throws<InvalidOperationException>(() => ArkBip21.Create().Build());
     }
 
@@ -230,6 +231,59 @@ public class ArkBip21Tests
             .Build();
 
         Assert.That(uri, Is.EqualTo("bitcoin:bc1qtest"));
+    }
+
+    [Test]
+    public void Build_LightningOnly_EmitsEmptyAddressForm()
+    {
+        // A receive screen toggling off both ark and onchain (chip UI) should still get a
+        // bitcoin: URI carrying the lightning value, not a raw LNURL — the scheme stays
+        // consistent across toggle states.
+        var uri = ArkBip21.Create()
+            .WithLightning("lnurl1dp68gurn8ghj7")
+            .Build();
+
+        Assert.That(uri, Does.StartWith("bitcoin:?"));
+        Assert.That(uri, Does.Contain("lightning="));
+    }
+
+    [Test]
+    public void Build_LightningPlusAmountAndLabel_NoAddress_Works()
+    {
+        var uri = ArkBip21.Create()
+            .WithLightning("lnbc100n1p")
+            .WithAmount(0.0005m)
+            .WithCustomParameter("label", "Lunch")
+            .Build();
+
+        Assert.That(uri, Does.StartWith("bitcoin:?"));
+        Assert.That(uri, Does.Contain("amount=0.0005"));
+        Assert.That(uri, Does.Contain("lightning="));
+        Assert.That(uri, Does.Contain("label=Lunch"));
+    }
+
+    [Test]
+    public void Build_AssetOnly_Throws()
+    {
+        // asset= constrains *what* to send (forces Ark-only delivery in PreferredMethod) — it is
+        // not itself a destination. Without an accompanying ark/onchain/lightning the payer has
+        // nowhere to send, so Build() rejects it.
+        Assert.Throws<InvalidOperationException>(() => ArkBip21.Create().WithAssetId("abc123").Build());
+    }
+
+    [Test]
+    public void Build_AssetPlusArk_Works()
+    {
+        // Asset paired with an ark address is the canonical pattern: ark provides the
+        // destination, asset narrows the payment to a specific token.
+        var uri = ArkBip21.Create()
+            .WithArkAddress("tark1qtest")
+            .WithAssetId("abc123")
+            .Build();
+
+        Assert.That(uri, Does.StartWith("bitcoin:?"));
+        Assert.That(uri, Does.Contain("ark=tark1qtest"));
+        Assert.That(uri, Does.Contain("asset=abc123"));
     }
 
     // ── Roundtrip ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

\`ArkBip21.Build()\` rejected any URI without an ark or onchain address — even when the caller had a perfectly good \`lightning=\` to ship. Receive screens that let the user toggle paths off (e.g. WalletWasabi's Arkade receive page chip-row, where you can drop Arkade + on-chain and keep only Lightning) had to fall back to either emitting a raw LNURL/BOLT11 at the QR layer or building the \`bitcoin:\` URI manually.

Neither is great. BIP21's grammar leaves the address-position optional in practice; \`bitcoin:?lightning=…\` is widely accepted, and any wallet that understands the \`lightning=\` query param routes off it the same way it would in a full BIP21. Keeping the scheme consistent across toggle states is the right default — the QR doesn't change shape just because the user dropped the ark chip.

## Behaviour change

The precondition widens from "≥1 address" to "≥1 **destination**" — ark, onchain, or lightning. \`assetId\` deliberately does NOT count: it constrains *what* to send (forces Ark-only delivery in \`PreferredMethod\`) but is not itself a destination, so it can't stand alone.

| Before | After |
| --- | --- |
| \`Create().WithLightning(…).Build()\` → throws | \`bitcoin:?lightning=…\` |
| \`Create().WithAssetId(…).Build()\` → throws | unchanged: still throws (no destination) |
| \`Create().WithAssetId(…).WithArkAddress(…).Build()\` | unchanged: \`bitcoin:?ark=…&asset=…\` |
| \`Create().Build()\` → throws | unchanged: still throws |
| Callers that always set an address | unchanged |

The exception message now names the three valid destinations and explicitly calls out that \`WithAssetId\` doesn't satisfy it — pointing the caller at the right fix when they hit it.

## Tests

- Renamed \`Build_NoAddress_Throws\` → \`Build_NothingSet_Throws\` (the spec widened from "address" to "destination").
- Added \`Build_LightningOnly_EmitsEmptyAddressForm\`, \`Build_LightningPlusAmountAndLabel_NoAddress_Works\` pinning the new lightning-only path.
- Added \`Build_AssetOnly_Throws\` pinning that asset alone is not a destination.
- Added \`Build_AssetPlusArk_Works\` pinning the canonical asset-with-destination shape.

\`dotnet test NArk.Tests\` — **408 / 408**.