### PR TITLE
chore(regtest): bump arkd v0.9.3 -> v0.9.6

### DIFF
--- a/.env.regtest
+++ b/.env.regtest
@@ -14,8 +14,8 @@ BITCOIN_LOW_FEE=true
 #     2 hours. Push the expiry past 2h and batch tests waiting for that
 #     intent state time out.
 # 3600 (1 hour) sits cleanly in between both bounds.
-ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.3
-ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.3
+ARKD_IMAGE=ghcr.io/arkade-os/arkd:v0.9.6
+ARKD_WALLET_IMAGE=ghcr.io/arkade-os/arkd-wallet:v0.9.6
 # SDK tests hardcode "ark" for docker exec — keep the override container name consistent.
 ARK_CONTAINER=ark
 ARKD_VTXO_TREE_EXPIRY=3600


### PR DESCRIPTION
## Summary

Regtest arkd image was 3 releases behind master. Bumps both `ARKD_IMAGE` and `ARKD_WALLET_IMAGE` from `v0.9.3` to `v0.9.6`.

## Why

The motivating fix: **arkd v0.9.4 PR [#1034](https://github.com/arkade-os/arkd/pull/1034) — "fix: waitForConfirmation fallback to time.Now() in case of error"** addresses the nil-pointer panic in `scheduleSweepBatchOutput` we hit while probing `docker restart ark` as a test-harness reset between SDK E2E tests.

Cross-referenced against arkd's [#1031](https://github.com/arkade-os/arkd/issues/1031) which already has the panic stack at the same crash site (`service.go:3480`, hex PC `0x9352de`); both the original nbxplorer-DB-loss trigger and the new ark-wallet gRPC-stream-canceled trigger we observed are resolved by the same defensive change in #1034.

Other relevant changes picked up along the way:

| Version | Change |
|---|---|
| v0.9.4 | `waitForConfirmation` panic fix (#1034); FinalizeOffchainTx unrolled-input reject; configurable postgres pool limits; gRPC max receive size fix |
| v0.9.5 | Single-key wallet KeyID + NextIndex regression fixes; SubmitTx finalization hotfix; Postgres 17.8 |
| v0.9.6 | golang 1.26.3; nbxplorer 2.6.7; single-connection `GetSubscription`; gateway connection pooling; indexer tx filters |

Regtest-only change. The v0.9.4 mainnet exit-delay hardcode (#1018) is mainnet-only and doesn't affect our regtest's `ARKD_UNILATERAL_EXIT_DELAY=512`.

## Test plan

- [ ] CI passes on this PR (Build + E2E).
- [ ] After merge, open a follow-up to drop `[Explicit]` on `WalletRecoveryTests.FullRecovery_RestoresContracts_Index_AndFunds` (arkade-os/dotnet-sdk#104) and re-validate.