### PR TITLE
fix(wallets): keep MuSig2 secret nonce inside the signer

### DIFF
--- a/NArk.Abstractions/Wallets/IArkadeWalletSigner.cs
+++ b/NArk.Abstractions/Wallets/IArkadeWalletSigner.cs
@@ -10,12 +10,16 @@ namespace NArk.Abstractions.Wallets;
 /// designed so the secret half never leaves the signer:
 /// <list type="number">
 ///   <item><description><see cref="GenerateNonces"/> derives the secret nonce internally and returns only the public half.</description></item>
-///   <item><description>The signer keeps the secret nonce indexed by <paramref name="context"/>'s aggregate pubkey.</description></item>
-///   <item><description><see cref="SignMusig"/> looks the secret nonce back up by the same context, uses it, and consumes it.</description></item>
+///   <item><description>The signer keeps the secret nonce indexed by the caller-supplied <c>sessionId</c>.</description></item>
+///   <item><description><see cref="SignMusig"/> looks the secret nonce back up by the same <c>sessionId</c>, uses it, and consumes it.</description></item>
 /// </list>
-/// Callers pass the same <see cref="MusigContext"/> instance (or one with an identical
-/// <see cref="MusigContext.AggregatePubKey"/>) to both calls. Calling <see cref="SignMusig"/>
-/// without a prior matching <see cref="GenerateNonces"/> on the same signer throws.
+/// The caller must pass a <em>session-unique</em> <c>sessionId</c> to both calls — typically a
+/// transaction identifier (e.g. a tree-node txid in batch participation), or any string the
+/// caller can correlate. <see cref="MusigContext.AggregatePubKey"/> on its own is <em>not</em>
+/// unique per signing operation: in a batch tree, multiple transactions can share the same
+/// cosigner set and taproot tweak, so their contexts have identical aggregate pubkeys but
+/// different sighashes. The sighash is buried inside <see cref="MusigContext"/> and cannot
+/// be observed by the signer, so disambiguation has to be caller-supplied.
 /// </summary>
 public interface IArkadeWalletSigner
 {
@@ -26,17 +30,27 @@ public interface IArkadeWalletSigner
 
     /// <summary>
     /// Produces a MuSig2 partial signature for the given context using the descriptor's
-    /// private key and the secret nonce generated for the same context by a prior call
-    /// to <see cref="GenerateNonces"/>. The secret nonce is consumed and cannot be reused
-    /// for another <see cref="SignMusig"/> call (MuSig2 nonce reuse leaks the private key).
+    /// private key and the secret nonce generated under the same <paramref name="sessionId"/>
+    /// by a prior call to <see cref="GenerateNonces"/>. The secret nonce is consumed and cannot
+    /// be reused for another <see cref="SignMusig"/> call (MuSig2 nonce reuse leaks the private
+    /// key).
     /// </summary>
+    /// <param name="descriptor">The descriptor identifying the signing key.</param>
+    /// <param name="context">The MuSig2 context (cosigner set + sighash) the nonce was generated for.</param>
+    /// <param name="sessionId">
+    /// The same session identifier that was passed to the matching <see cref="GenerateNonces"/>
+    /// call. Typically a transaction identifier (txid) or any other string unique to this signing
+    /// operation within the signer's scope.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <exception cref="InvalidOperationException">
-    /// No secret nonce is stored for <paramref name="context"/> — <see cref="GenerateNonces"/>
-    /// was not called for this context on this signer instance, or the nonce was already consumed.
+    /// No secret nonce is stored for <paramref name="sessionId"/> — <see cref="GenerateNonces"/>
+    /// was not called for this session on this signer, or the nonce was already consumed.
     /// </exception>
     Task<MusigPartialSignature> SignMusig(
         OutputDescriptor descriptor,
         MusigContext context,
+        string sessionId,
         CancellationToken cancellationToken = default);
 
 
@@ -47,14 +61,22 @@ public interface IArkadeWalletSigner
 
     /// <summary>
     /// Generates a fresh MuSig2 nonce pair for <paramref name="context"/>, retains the
-    /// secret half indexed by the context's aggregate pubkey, and returns the public half.
-    /// Calling twice for the same context (without an intervening <see cref="SignMusig"/>
-    /// to consume the prior nonce) throws — generating a fresh nonce on top of an unused
-    /// one would orphan secret material in the signer's store.
+    /// secret half indexed by <paramref name="sessionId"/>, and returns the public half.
+    /// Calling twice with the same <paramref name="sessionId"/> (without an intervening
+    /// <see cref="SignMusig"/> to consume the prior nonce) throws — generating a fresh nonce
+    /// on top of an unused one would orphan secret material in the signer's store.
     /// </summary>
+    /// <param name="descriptor">The descriptor identifying the signing key.</param>
+    /// <param name="context">The MuSig2 context the nonce is generated for.</param>
+    /// <param name="sessionId">
+    /// A caller-supplied identifier unique to this signing operation. Must match the value
+    /// later passed to <see cref="SignMusig"/>. Typically a transaction identifier (txid).
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     Task<MusigPubNonce> GenerateNonces(
         OutputDescriptor descriptor,
         MusigContext context,
+        string sessionId,
         CancellationToken cancellationToken = default
     );
 }

--- a/NArk.Abstractions/Wallets/IArkadeWalletSigner.cs
+++ b/NArk.Abstractions/Wallets/IArkadeWalletSigner.cs
@@ -5,6 +5,18 @@ using NBitcoin.Secp256k1.Musig;
 
 namespace NArk.Abstractions.Wallets;
 
+/// <summary>
+/// Wallet-side signer used during MuSig2 batch participation. The MuSig2 nonce flow is
+/// designed so the secret half never leaves the signer:
+/// <list type="number">
+///   <item><description><see cref="GenerateNonces"/> derives the secret nonce internally and returns only the public half.</description></item>
+///   <item><description>The signer keeps the secret nonce indexed by <paramref name="context"/>'s aggregate pubkey.</description></item>
+///   <item><description><see cref="SignMusig"/> looks the secret nonce back up by the same context, uses it, and consumes it.</description></item>
+/// </list>
+/// Callers pass the same <see cref="MusigContext"/> instance (or one with an identical
+/// <see cref="MusigContext.AggregatePubKey"/>) to both calls. Calling <see cref="SignMusig"/>
+/// without a prior matching <see cref="GenerateNonces"/> on the same signer throws.
+/// </summary>
 public interface IArkadeWalletSigner
 {
     /// <summary>
@@ -12,10 +24,19 @@ public interface IArkadeWalletSigner
     /// </summary>
     Task<ECPubKey> GetPubKey(OutputDescriptor descriptor, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Produces a MuSig2 partial signature for the given context using the descriptor's
+    /// private key and the secret nonce generated for the same context by a prior call
+    /// to <see cref="GenerateNonces"/>. The secret nonce is consumed and cannot be reused
+    /// for another <see cref="SignMusig"/> call (MuSig2 nonce reuse leaks the private key).
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// No secret nonce is stored for <paramref name="context"/> — <see cref="GenerateNonces"/>
+    /// was not called for this context on this signer instance, or the nonce was already consumed.
+    /// </exception>
     Task<MusigPartialSignature> SignMusig(
         OutputDescriptor descriptor,
         MusigContext context,
-        MusigPrivNonce nonce,
         CancellationToken cancellationToken = default);
 
 
@@ -24,7 +45,14 @@ public interface IArkadeWalletSigner
         uint256 hash,
         CancellationToken cancellationToken = default);
 
-    Task<MusigPrivNonce> GenerateNonces(
+    /// <summary>
+    /// Generates a fresh MuSig2 nonce pair for <paramref name="context"/>, retains the
+    /// secret half indexed by the context's aggregate pubkey, and returns the public half.
+    /// Calling twice for the same context (without an intervening <see cref="SignMusig"/>
+    /// to consume the prior nonce) throws — generating a fresh nonce on top of an unused
+    /// one would orphan secret material in the signer's store.
+    /// </summary>
+    Task<MusigPubNonce> GenerateNonces(
         OutputDescriptor descriptor,
         MusigContext context,
         CancellationToken cancellationToken = default

--- a/NArk.Abstractions/Wallets/IRemoteSignerTransport.cs
+++ b/NArk.Abstractions/Wallets/IRemoteSignerTransport.cs
@@ -19,15 +19,12 @@ namespace NArk.Abstractions.Wallets;
 /// watch-only (<see cref="IWalletProvider.GetSignerAsync"/> returns <c>null</c>). Capability is
 /// answered by this interface, not by a flag on the wallet record.
 /// <para>
-/// <b>SECURITY LIMITATION (phase 1):</b> <see cref="GenerateNoncesAsync"/> currently returns
-/// the MuSig2 secret nonce to the SDK and <see cref="SignMusigAsync"/> accepts it back across
-/// the transport. The cryptographic argument for remote signing — that private material never
-/// leaves the signer — does <i>not</i> hold under this interface. The intended phase-2 shape
-/// has <see cref="GenerateNoncesAsync"/> returning only the public nonce and
-/// <see cref="SignMusigAsync"/> taking no nonce parameter (the signer remembers it indexed by
-/// context). Tracked in <see href="https://github.com/arkade-os/dotnet-sdk/issues/111">#111</see>;
-/// do not rely on nonce confidentiality of an <see cref="IRemoteSignerTransport"/>
-/// implementation until that is fixed.
+/// The MuSig2 nonce flow keeps the secret half on the transport side:
+/// <see cref="GenerateNoncesAsync"/> returns only the public nonce, the implementation retains
+/// the secret half indexed by the context, and <see cref="SignMusigAsync"/> consumes it on use.
+/// Implementations need an eviction policy for abandoned nonces (TTL or bounded count) so the
+/// store does not grow without bound — the SDK-side <see cref="IArkadeWalletSigner"/> contract
+/// requires SignMusig to throw if no matching nonce is found.
 /// </para>
 /// </remarks>
 public interface IRemoteSignerTransport
@@ -53,22 +50,23 @@ public interface IRemoteSignerTransport
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Produces a MuSig2 partial signature for the given context and nonce
-    /// using the descriptor's private key.
+    /// Produces a MuSig2 partial signature for the given context using the descriptor's
+    /// private key and the secret nonce the transport retained when <see cref="GenerateNoncesAsync"/>
+    /// was called for the same context. The secret nonce is consumed on this call.
     /// </summary>
     /// <param name="walletId">The wallet whose key signs.</param>
     /// <param name="descriptor">The descriptor identifying the signing key.</param>
-    /// <param name="context">The MuSig2 context (cosigner set + sighash).</param>
-    /// <param name="nonce">The secret nonce produced earlier by <see cref="GenerateNoncesAsync"/>.</param>
+    /// <param name="context">The MuSig2 context (cosigner set + sighash) the nonce was generated for.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    // TODO: SECURITY — drop the `nonce` parameter and have the signer dereference
-    // the private nonce it kept after GenerateNoncesAsync via a context key. Phase-2,
-    // tracked at https://github.com/arkade-os/dotnet-sdk/issues/111.
+    /// <exception cref="InvalidOperationException">
+    /// No secret nonce is stored for <paramref name="walletId"/> + <paramref name="context"/>
+    /// (it was never generated, was already consumed, or has been evicted by the transport's
+    /// eviction policy).
+    /// </exception>
     Task<MusigPartialSignature> SignMusigAsync(
         string walletId,
         OutputDescriptor descriptor,
         MusigContext context,
-        MusigPrivNonce nonce,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -87,19 +85,17 @@ public interface IRemoteSignerTransport
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Generates the secret nonce for the supplied MuSig2 context. The returned
-    /// nonce is bound to <paramref name="context"/> and must be passed back
-    /// into <see cref="SignMusigAsync"/> on the same context.
+    /// Generates a fresh MuSig2 nonce pair for the supplied context, retains the secret
+    /// half on the transport side indexed by <paramref name="walletId"/> +
+    /// <paramref name="context"/>, and returns the public half so the caller can complete
+    /// nonce aggregation with cosigners. The secret half never crosses the transport
+    /// boundary — that is the cryptographic claim of remote signing.
     /// </summary>
     /// <param name="walletId">The wallet whose key contributes the nonce.</param>
     /// <param name="descriptor">The descriptor identifying the signing key.</param>
     /// <param name="context">The MuSig2 context the nonce is generated for.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    // TODO: SECURITY — return MusigPubNonce instead and keep the private nonce on
-    // the signer indexed by context. Today the SDK receives the secret half, which
-    // breaks the cryptographic argument for remote signing. Phase-2, tracked at
-    // https://github.com/arkade-os/dotnet-sdk/issues/111.
-    Task<MusigPrivNonce> GenerateNoncesAsync(
+    Task<MusigPubNonce> GenerateNoncesAsync(
         string walletId,
         OutputDescriptor descriptor,
         MusigContext context,

--- a/NArk.Abstractions/Wallets/IRemoteSignerTransport.cs
+++ b/NArk.Abstractions/Wallets/IRemoteSignerTransport.cs
@@ -21,10 +21,11 @@ namespace NArk.Abstractions.Wallets;
 /// <para>
 /// The MuSig2 nonce flow keeps the secret half on the transport side:
 /// <see cref="GenerateNoncesAsync"/> returns only the public nonce, the implementation retains
-/// the secret half indexed by the context, and <see cref="SignMusigAsync"/> consumes it on use.
-/// Implementations need an eviction policy for abandoned nonces (TTL or bounded count) so the
-/// store does not grow without bound — the SDK-side <see cref="IArkadeWalletSigner"/> contract
-/// requires SignMusig to throw if no matching nonce is found.
+/// the secret half indexed by <c>walletId</c> + <c>sessionId</c>, and <see cref="SignMusigAsync"/>
+/// consumes it on use. Implementations need an eviction policy for abandoned nonces (TTL or
+/// bounded count) so the store does not grow without bound — the SDK-side
+/// <see cref="IArkadeWalletSigner"/> contract requires SignMusig to throw if no matching nonce
+/// is found.
 /// </para>
 /// </remarks>
 public interface IRemoteSignerTransport
@@ -52,14 +53,16 @@ public interface IRemoteSignerTransport
     /// <summary>
     /// Produces a MuSig2 partial signature for the given context using the descriptor's
     /// private key and the secret nonce the transport retained when <see cref="GenerateNoncesAsync"/>
-    /// was called for the same context. The secret nonce is consumed on this call.
+    /// was called for the same <paramref name="sessionId"/>. The secret nonce is consumed on
+    /// this call.
     /// </summary>
     /// <param name="walletId">The wallet whose key signs.</param>
     /// <param name="descriptor">The descriptor identifying the signing key.</param>
     /// <param name="context">The MuSig2 context (cosigner set + sighash) the nonce was generated for.</param>
+    /// <param name="sessionId">The same session identifier that was passed to <see cref="GenerateNoncesAsync"/>.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <exception cref="InvalidOperationException">
-    /// No secret nonce is stored for <paramref name="walletId"/> + <paramref name="context"/>
+    /// No secret nonce is stored for <paramref name="walletId"/> + <paramref name="sessionId"/>
     /// (it was never generated, was already consumed, or has been evicted by the transport's
     /// eviction policy).
     /// </exception>
@@ -67,6 +70,7 @@ public interface IRemoteSignerTransport
         string walletId,
         OutputDescriptor descriptor,
         MusigContext context,
+        string sessionId,
         CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -87,17 +91,23 @@ public interface IRemoteSignerTransport
     /// <summary>
     /// Generates a fresh MuSig2 nonce pair for the supplied context, retains the secret
     /// half on the transport side indexed by <paramref name="walletId"/> +
-    /// <paramref name="context"/>, and returns the public half so the caller can complete
+    /// <paramref name="sessionId"/>, and returns the public half so the caller can complete
     /// nonce aggregation with cosigners. The secret half never crosses the transport
     /// boundary — that is the cryptographic claim of remote signing.
     /// </summary>
     /// <param name="walletId">The wallet whose key contributes the nonce.</param>
     /// <param name="descriptor">The descriptor identifying the signing key.</param>
     /// <param name="context">The MuSig2 context the nonce is generated for.</param>
+    /// <param name="sessionId">
+    /// A caller-supplied identifier unique to this signing operation, used to correlate this
+    /// nonce with the matching <see cref="SignMusigAsync"/> call. Typically a transaction
+    /// identifier (txid).
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task<MusigPubNonce> GenerateNoncesAsync(
         string walletId,
         OutputDescriptor descriptor,
         MusigContext context,
+        string sessionId,
         CancellationToken cancellationToken = default);
 }

--- a/NArk.Core/Batches/TreeSignerSession.cs
+++ b/NArk.Core/Batches/TreeSignerSession.cs
@@ -168,9 +168,11 @@ public class TreeSignerSession
         var res = new Dictionary<uint256, MusigPubNonce>();
         foreach (var (txid, musigContext) in _musigContexts!)
         {
-            // Signer stores the secret half indexed by musigContext.AggregatePubKey;
-            // SignPartialAsync passes the same context back so the signer can look it up.
-            res[txid] = await signer.GenerateNonces(_descriptor, musigContext, cancellationToken);
+            // Signer stores the secret half indexed by sessionId (the tree-node txid here);
+            // SignPartialAsync passes the same txid back so the signer can look it up.
+            // AggregatePubKey alone wouldn't disambiguate: tree nodes can share cosigner set +
+            // tweak, so multiple contexts have identical aggregate pubkeys.
+            res[txid] = await signer.GenerateNonces(_descriptor, musigContext, txid.ToString(), cancellationToken);
         }
 
         return res;
@@ -198,9 +200,9 @@ public class TreeSignerSession
                      ?? throw new InvalidOperationException(
                          $"Wallet '{_walletId}' has no signer; watch-only wallets cannot participate in batch signing.");
 
-        // Signer looks up the secret nonce internally by musigContext.AggregatePubKey
-        // (set when GenerateNonces was called for the same context) and consumes it.
-        var partialSig = await signer.SignMusig(_descriptor, musigContext, cancellationToken);
+        // Signer looks up the secret nonce by sessionId (the tree-node txid, same as we passed
+        // to GenerateNonces) and consumes it.
+        var partialSig = await signer.SignMusig(_descriptor, musigContext, txid.ToString(), cancellationToken);
 
         return partialSig;
     }

--- a/NArk.Core/Batches/TreeSignerSession.cs
+++ b/NArk.Core/Batches/TreeSignerSession.cs
@@ -16,7 +16,9 @@ namespace NArk.Core.Batches;
 /// </summary>
 public class TreeSignerSession
 {
-    private Dictionary<uint256, (MusigPrivNonce secNonce, MusigPubNonce pubNonce)>? _myNonces;
+    // Public nonces only — the secret half stays inside the signer and is consumed
+    // when SignMusig is called for the same MusigContext.
+    private Dictionary<uint256, MusigPubNonce>? _myNonces;
     private Dictionary<uint256, MusigContext>? _musigContexts;
     private readonly string _walletId;
     private readonly IWalletProvider _walletProvider;
@@ -113,7 +115,7 @@ public class TreeSignerSession
     {
         _myNonces ??= await GenerateNoncesAsync(cancellationToken);
 
-        return _myNonces.ToDictionary(pair => pair.Key, pair => pair.Value.pubNonce);
+        return new Dictionary<uint256, MusigPubNonce>(_myNonces);
     }
 
     public void VerifyAggregatedNonces(Dictionary<uint256, MusigPubNonce> expectedAggregateNonces,
@@ -150,7 +152,7 @@ public class TreeSignerSession
         return sigs;
     }
 
-    private async Task<Dictionary<uint256, (MusigPrivNonce secNonce, MusigPubNonce pubNonce)>> GenerateNoncesAsync(CancellationToken cancellationToken = default)
+    private async Task<Dictionary<uint256, MusigPubNonce>> GenerateNoncesAsync(CancellationToken cancellationToken = default)
     {
         if (_musigContexts == null)
             await CreateMusigContexts(cancellationToken);
@@ -163,12 +165,12 @@ public class TreeSignerSession
                      ?? throw new InvalidOperationException(
                          $"Wallet '{_walletId}' has no signer; watch-only wallets cannot participate in batch signing.");
 
-        var res = new Dictionary<uint256, (MusigPrivNonce secNonce, MusigPubNonce pubNonce)>();
+        var res = new Dictionary<uint256, MusigPubNonce>();
         foreach (var (txid, musigContext) in _musigContexts!)
         {
-            // Generate nonce tied to this specific context
-            var nonce = await signer.GenerateNonces(_descriptor, musigContext, cancellationToken);
-            res[txid] = (nonce, nonce.CreatePubNonce());
+            // Signer stores the secret half indexed by musigContext.AggregatePubKey;
+            // SignPartialAsync passes the same context back so the signer can look it up.
+            res[txid] = await signer.GenerateNonces(_descriptor, musigContext, cancellationToken);
         }
 
         return res;
@@ -182,8 +184,8 @@ public class TreeSignerSession
 
         var txid = g.Root.GetGlobalTransaction().GetHash();
 
-        if (!_myNonces.TryGetValue(txid, out var myNonce))
-            throw new InvalidOperationException("missing private nonce");
+        if (!_myNonces.ContainsKey(txid))
+            throw new InvalidOperationException("missing nonce for this txid — GetNoncesAsync must run first");
 
         if (!_musigContexts.TryGetValue(txid, out var musigContext))
             throw new InvalidOperationException("missing musig context");
@@ -196,9 +198,9 @@ public class TreeSignerSession
                      ?? throw new InvalidOperationException(
                          $"Wallet '{_walletId}' has no signer; watch-only wallets cannot participate in batch signing.");
 
-        // Use the wallet signer to create a MUSIG2 partial signature
-        // The context already has the correct sighash from nonce generation
-        var partialSig = await signer.SignMusig(_descriptor, musigContext, myNonce.secNonce, cancellationToken);
+        // Signer looks up the secret nonce internally by musigContext.AggregatePubKey
+        // (set when GenerateNonces was called for the same context) and consumes it.
+        var partialSig = await signer.SignMusig(_descriptor, musigContext, cancellationToken);
 
         return partialSig;
     }
@@ -258,10 +260,10 @@ public class TreeSignerSession
         if (!_musigContexts.TryGetValue(txid, out var musigContext))
             return Task.CompletedTask;
 
-        if (_myNonces is null || !_myNonces.TryGetValue(txid, out var myNonce))
-            throw new InvalidOperationException("missing private nonce");
+        if (_myNonces is null || !_myNonces.TryGetValue(txid, out var myPubNonce))
+            throw new InvalidOperationException("missing my public nonce");
 
-        if (!nonces.Any(nonce => nonce.ToBytes().SequenceEqual(myNonce.pubNonce.ToBytes())))
+        if (!nonces.Any(nonce => nonce.ToBytes().SequenceEqual(myPubNonce.ToBytes())))
         {
             throw new InvalidOperationException("missing my nonce");
         }

--- a/NArk.Core/Wallet/DefaultWalletProvider.cs
+++ b/NArk.Core/Wallet/DefaultWalletProvider.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using NArk.Abstractions;
 using NArk.Abstractions.Contracts;
@@ -28,6 +29,12 @@ public class DefaultWalletProvider(
     IRemoteSignerTransport? remoteSignerTransport = null)
     : IWalletProvider
 {
+    // Signer instances must be reused across calls so the MuSig2 secret-nonce store on each
+    // signer (populated by GenerateNonces, consumed by SignMusig — see IArkadeWalletSigner)
+    // survives between the two calls. The cache key includes the wallet's secret so a wallet
+    // re-imported with a different mnemonic gets a fresh signer.
+    private readonly ConcurrentDictionary<string, IArkadeWalletSigner> _signerCache = new();
+
     public async Task<IArkadeWalletSigner?> GetSignerAsync(string identifier, CancellationToken cancellationToken = default)
     {
         try
@@ -42,12 +49,13 @@ public class DefaultWalletProvider(
             // Local signing material present → produce a local signer of the right shape.
             if (!string.IsNullOrEmpty(wallet.Secret))
             {
-                return wallet.WalletType switch
+                var cacheKey = $"local:{wallet.Id}:{wallet.Secret.GetHashCode():x}";
+                return _signerCache.GetOrAdd(cacheKey, _ => wallet.WalletType switch
                 {
                     WalletType.HD => new HierarchicalDeterministicWalletSigner(wallet),
                     WalletType.SingleKey => NSecWalletSigner.FromNsec(wallet.Secret, logger),
                     _ => throw new ArgumentOutOfRangeException(nameof(wallet.WalletType))
-                };
+                });
             }
 
             // No local secret → ask the remote-signer transport (if any) whether it can sign for
@@ -56,7 +64,8 @@ public class DefaultWalletProvider(
             if (remoteSignerTransport is not null
                 && await remoteSignerTransport.KnowsWalletAsync(wallet.Id, cancellationToken).ConfigureAwait(false))
             {
-                return new RemoteArkadeWalletSigner(wallet.Id, remoteSignerTransport);
+                return _signerCache.GetOrAdd($"remote:{wallet.Id}",
+                    _ => new RemoteArkadeWalletSigner(wallet.Id, remoteSignerTransport));
             }
 
             // No local key, no remote signer claims it → watch-only.

--- a/NArk.Core/Wallet/HierarchicalDeterministicWalletSigner.cs
+++ b/NArk.Core/Wallet/HierarchicalDeterministicWalletSigner.cs
@@ -21,8 +21,8 @@ public class HierarchicalDeterministicWalletSigner(ArkWalletInfo wallet) : IArka
     // wallet object, so this introduces no new exposure surface.
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, ExtKey> _extKeyCache = new();
 
-    // Per-instance secret nonce store; see NSecWalletSigner for the rationale.
-    // Keyed by the (tweaked) aggregate pubkey hex of the MuSig2 context.
+    // Per-session secret nonce store; see NSecWalletSigner for the rationale.
+    // Keyed by the caller-supplied sessionId.
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, MusigPrivNonce> _secNonces = new();
 
     private Task<ECPrivKey> DerivePrivateKey(OutputDescriptor descriptor)
@@ -41,13 +41,12 @@ public class HierarchicalDeterministicWalletSigner(ArkWalletInfo wallet) : IArka
     }
 
     public async Task<MusigPartialSignature> SignMusig(OutputDescriptor descriptor, MusigContext context,
-        CancellationToken cancellationToken = default)
+        string sessionId, CancellationToken cancellationToken = default)
     {
-        var key = ContextKey(context);
-        if (!_secNonces.TryRemove(key, out var nonce))
+        if (!_secNonces.TryRemove(sessionId, out var nonce))
             throw new InvalidOperationException(
-                $"No secret nonce stored for the given MuSig2 context (aggregate pubkey {key}). " +
-                "Call GenerateNonces for this context first; nonces are consumed on use and cannot be replayed.");
+                $"No secret nonce stored for sessionId '{sessionId}'. " +
+                "Call GenerateNonces with the same sessionId first; nonces are consumed on use and cannot be replayed.");
         var privKey = await DerivePrivateKey(descriptor);
         return context.Sign(privKey, nonce);
     }
@@ -58,19 +57,20 @@ public class HierarchicalDeterministicWalletSigner(ArkWalletInfo wallet) : IArka
         return (privKey.CreateXOnlyPubKey(), privKey.SignBIP340(hash.ToBytes()));
     }
 
-    public async Task<MusigPubNonce> GenerateNonces(OutputDescriptor descriptor, MusigContext context, CancellationToken cancellationToken = default)
+    public async Task<MusigPubNonce> GenerateNonces(OutputDescriptor descriptor, MusigContext context,
+        string sessionId, CancellationToken cancellationToken = default)
     {
+        if (_secNonces.ContainsKey(sessionId))
+            throw new InvalidOperationException(
+                $"A secret nonce is already stored for sessionId '{sessionId}'. " +
+                "Call SignMusig to consume it before generating a fresh nonce for the same session; " +
+                "MuSig2 nonce reuse leaks the private key.");
         var privKey = await DerivePrivateKey(descriptor);
         var nonce = context.GenerateNonce(privKey);
-        var key = ContextKey(context);
-        if (!_secNonces.TryAdd(key, nonce))
+        if (!_secNonces.TryAdd(sessionId, nonce))
             throw new InvalidOperationException(
-                $"A secret nonce is already stored for this MuSig2 context (aggregate pubkey {key}). " +
-                "Call SignMusig to consume it before generating a fresh nonce for the same context; " +
-                "MuSig2 nonce reuse leaks the private key.");
+                $"A secret nonce was concurrently stored for sessionId '{sessionId}'. " +
+                "sessionId must be unique per signing operation.");
         return nonce.CreatePubNonce();
     }
-
-    private static string ContextKey(MusigContext context) =>
-        Convert.ToHexString(context.AggregatePubKey.ToBytes()).ToLowerInvariant();
 }

--- a/NArk.Core/Wallet/HierarchicalDeterministicWalletSigner.cs
+++ b/NArk.Core/Wallet/HierarchicalDeterministicWalletSigner.cs
@@ -21,6 +21,10 @@ public class HierarchicalDeterministicWalletSigner(ArkWalletInfo wallet) : IArka
     // wallet object, so this introduces no new exposure surface.
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, ExtKey> _extKeyCache = new();
 
+    // Per-instance secret nonce store; see NSecWalletSigner for the rationale.
+    // Keyed by the (tweaked) aggregate pubkey hex of the MuSig2 context.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, MusigPrivNonce> _secNonces = new();
+
     private Task<ECPrivKey> DerivePrivateKey(OutputDescriptor descriptor)
     {
         var fullPath = descriptor.Extract().FullPath ?? throw new InvalidOperationException();
@@ -36,9 +40,14 @@ public class HierarchicalDeterministicWalletSigner(ArkWalletInfo wallet) : IArka
         return privKey.CreatePubKey();
     }
 
-    public async Task<MusigPartialSignature> SignMusig(OutputDescriptor descriptor, MusigContext context, MusigPrivNonce nonce,
+    public async Task<MusigPartialSignature> SignMusig(OutputDescriptor descriptor, MusigContext context,
         CancellationToken cancellationToken = default)
     {
+        var key = ContextKey(context);
+        if (!_secNonces.TryRemove(key, out var nonce))
+            throw new InvalidOperationException(
+                $"No secret nonce stored for the given MuSig2 context (aggregate pubkey {key}). " +
+                "Call GenerateNonces for this context first; nonces are consumed on use and cannot be replayed.");
         var privKey = await DerivePrivateKey(descriptor);
         return context.Sign(privKey, nonce);
     }
@@ -49,9 +58,19 @@ public class HierarchicalDeterministicWalletSigner(ArkWalletInfo wallet) : IArka
         return (privKey.CreateXOnlyPubKey(), privKey.SignBIP340(hash.ToBytes()));
     }
 
-    public async Task<MusigPrivNonce> GenerateNonces(OutputDescriptor descriptor, MusigContext context, CancellationToken cancellationToken = default)
+    public async Task<MusigPubNonce> GenerateNonces(OutputDescriptor descriptor, MusigContext context, CancellationToken cancellationToken = default)
     {
         var privKey = await DerivePrivateKey(descriptor);
-        return context.GenerateNonce(privKey);
+        var nonce = context.GenerateNonce(privKey);
+        var key = ContextKey(context);
+        if (!_secNonces.TryAdd(key, nonce))
+            throw new InvalidOperationException(
+                $"A secret nonce is already stored for this MuSig2 context (aggregate pubkey {key}). " +
+                "Call SignMusig to consume it before generating a fresh nonce for the same context; " +
+                "MuSig2 nonce reuse leaks the private key.");
+        return nonce.CreatePubNonce();
     }
+
+    private static string ContextKey(MusigContext context) =>
+        Convert.ToHexString(context.AggregatePubKey.ToBytes()).ToLowerInvariant();
 }

--- a/NArk.Core/Wallet/NSecWalletSigner.cs
+++ b/NArk.Core/Wallet/NSecWalletSigner.cs
@@ -15,10 +15,13 @@ public class NSecWalletSigner(ECPrivKey privateKey, ILogger? logger = null) : IA
     private readonly ECPubKey _publicKey = privateKey.CreatePubKey();
     private readonly ECXOnlyPubKey _xOnlyPubKey = privateKey.CreateXOnlyPubKey();
 
-    // Per-context secret nonce store. Keyed by the (tweaked) aggregate pubkey hex —
-    // a content fingerprint of the cosigner set + taproot tweaks. ConcurrentDictionary
-    // lets GenerateNonces / SignMusig race safely if a caller parallelises across
-    // contexts; each entry is removed on SignMusig consumption so the store doesn't grow.
+    // Per-session secret nonce store. Keyed by the caller-supplied sessionId — typically a
+    // txid in batch participation. AggregatePubKey alone is not unique per signing operation
+    // in a batch tree (multiple tree nodes can share cosigner set + tweak), and the sighash
+    // is internal to MusigContext and can't be observed by the signer; the caller is the only
+    // one with enough information to produce a disambiguating session identifier.
+    // ConcurrentDictionary lets GenerateNonces / SignMusig race safely if a caller parallelises
+    // across sessions; each entry is removed on SignMusig consumption so the store doesn't grow.
     private readonly ConcurrentDictionary<string, MusigPrivNonce> _secNonces = new();
 
     public static NSecWalletSigner FromNsec(string nsec, ILogger? logger = null)
@@ -64,18 +67,18 @@ public class NSecWalletSigner(ECPrivKey privateKey, ILogger? logger = null) : IA
     }
 
     public Task<MusigPartialSignature> SignMusig(OutputDescriptor descriptor, MusigContext context,
-        CancellationToken cancellationToken = default)
+        string sessionId, CancellationToken cancellationToken = default)
     {
-        var key = ContextKey(context);
-        if (!_secNonces.TryRemove(key, out var nonce))
+        if (!_secNonces.TryRemove(sessionId, out var nonce))
             throw new InvalidOperationException(
-                $"No secret nonce stored for the given MuSig2 context (aggregate pubkey {key}). " +
-                "Call GenerateNonces for this context first; nonces are consumed on use and cannot be replayed.");
+                $"No secret nonce stored for sessionId '{sessionId}'. " +
+                "Call GenerateNonces with the same sessionId first; nonces are consumed on use and cannot be replayed.");
 
         logger?.LogInformation(
-            "SignMusig called. Descriptor={Descriptor}, SignerCompressed={SignerCompressed}",
+            "SignMusig called. Descriptor={Descriptor}, SignerCompressed={SignerCompressed}, SessionId={SessionId}",
             descriptor.ToString(),
-            Convert.ToHexString(_publicKey.ToBytes()).ToLowerInvariant());
+            Convert.ToHexString(_publicKey.ToBytes()).ToLowerInvariant(),
+            sessionId);
         var sig = context.Sign(privateKey, nonce);
         logger?.LogInformation("SignMusig produced partial signature successfully");
         return Task.FromResult(sig);
@@ -118,24 +121,27 @@ public class NSecWalletSigner(ECPrivKey privateKey, ILogger? logger = null) : IA
         return Task.FromResult((_xOnlyPubKey, sig));
     }
 
-    public Task<MusigPubNonce> GenerateNonces(OutputDescriptor descriptor, MusigContext context, CancellationToken cancellationToken = default)
+    public Task<MusigPubNonce> GenerateNonces(OutputDescriptor descriptor, MusigContext context,
+        string sessionId, CancellationToken cancellationToken = default)
     {
-        var key = ContextKey(context);
+        if (_secNonces.ContainsKey(sessionId))
+            throw new InvalidOperationException(
+                $"A secret nonce is already stored for sessionId '{sessionId}'. " +
+                "Call SignMusig to consume it before generating a fresh nonce for the same session; " +
+                "MuSig2 nonce reuse leaks the private key.");
         logger?.LogInformation(
-            "GenerateNonces called. Descriptor={Descriptor}, SignerCompressed={SignerCompressed}, ContextKey={ContextKey}",
+            "GenerateNonces called. Descriptor={Descriptor}, SignerCompressed={SignerCompressed}, SessionId={SessionId}",
             descriptor.ToString(),
             Convert.ToHexString(_publicKey.ToBytes()).ToLowerInvariant(),
-            key);
+            sessionId);
         var nonce = context.GenerateNonce(privateKey);
-        if (!_secNonces.TryAdd(key, nonce))
+        if (!_secNonces.TryAdd(sessionId, nonce))
+            // Race: another thread populated this sessionId between the ContainsKey check and now.
+            // Caller bug — duplicate sessionId from two concurrent callers — but defend against it.
             throw new InvalidOperationException(
-                $"A secret nonce is already stored for this MuSig2 context (aggregate pubkey {key}). " +
-                "Call SignMusig to consume it before generating a fresh nonce for the same context; " +
-                "MuSig2 nonce reuse leaks the private key.");
+                $"A secret nonce was concurrently stored for sessionId '{sessionId}'. " +
+                "sessionId must be unique per signing operation.");
         logger?.LogInformation("GenerateNonces produced nonce successfully");
         return Task.FromResult(nonce.CreatePubNonce());
     }
-
-    private static string ContextKey(MusigContext context) =>
-        Convert.ToHexString(context.AggregatePubKey.ToBytes()).ToLowerInvariant();
 }

--- a/NArk.Core/Wallet/NSecWalletSigner.cs
+++ b/NArk.Core/Wallet/NSecWalletSigner.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using NArk.Abstractions.Extensions;
 using NArk.Abstractions.Wallets;
@@ -13,6 +14,12 @@ public class NSecWalletSigner(ECPrivKey privateKey, ILogger? logger = null) : IA
 {
     private readonly ECPubKey _publicKey = privateKey.CreatePubKey();
     private readonly ECXOnlyPubKey _xOnlyPubKey = privateKey.CreateXOnlyPubKey();
+
+    // Per-context secret nonce store. Keyed by the (tweaked) aggregate pubkey hex —
+    // a content fingerprint of the cosigner set + taproot tweaks. ConcurrentDictionary
+    // lets GenerateNonces / SignMusig race safely if a caller parallelises across
+    // contexts; each entry is removed on SignMusig consumption so the store doesn't grow.
+    private readonly ConcurrentDictionary<string, MusigPrivNonce> _secNonces = new();
 
     public static NSecWalletSigner FromNsec(string nsec, ILogger? logger = null)
     {
@@ -56,9 +63,15 @@ public class NSecWalletSigner(ECPrivKey privateKey, ILogger? logger = null) : IA
         return Task.FromResult(_publicKey);
     }
 
-    public Task<MusigPartialSignature> SignMusig(OutputDescriptor descriptor, MusigContext context, MusigPrivNonce nonce,
+    public Task<MusigPartialSignature> SignMusig(OutputDescriptor descriptor, MusigContext context,
         CancellationToken cancellationToken = default)
     {
+        var key = ContextKey(context);
+        if (!_secNonces.TryRemove(key, out var nonce))
+            throw new InvalidOperationException(
+                $"No secret nonce stored for the given MuSig2 context (aggregate pubkey {key}). " +
+                "Call GenerateNonces for this context first; nonces are consumed on use and cannot be replayed.");
+
         logger?.LogInformation(
             "SignMusig called. Descriptor={Descriptor}, SignerCompressed={SignerCompressed}",
             descriptor.ToString(),
@@ -105,14 +118,24 @@ public class NSecWalletSigner(ECPrivKey privateKey, ILogger? logger = null) : IA
         return Task.FromResult((_xOnlyPubKey, sig));
     }
 
-    public Task<MusigPrivNonce> GenerateNonces(OutputDescriptor descriptor, MusigContext context, CancellationToken cancellationToken = default)
+    public Task<MusigPubNonce> GenerateNonces(OutputDescriptor descriptor, MusigContext context, CancellationToken cancellationToken = default)
     {
+        var key = ContextKey(context);
         logger?.LogInformation(
-            "GenerateNonces called. Descriptor={Descriptor}, SignerCompressed={SignerCompressed}",
+            "GenerateNonces called. Descriptor={Descriptor}, SignerCompressed={SignerCompressed}, ContextKey={ContextKey}",
             descriptor.ToString(),
-            Convert.ToHexString(_publicKey.ToBytes()).ToLowerInvariant());
+            Convert.ToHexString(_publicKey.ToBytes()).ToLowerInvariant(),
+            key);
         var nonce = context.GenerateNonce(privateKey);
+        if (!_secNonces.TryAdd(key, nonce))
+            throw new InvalidOperationException(
+                $"A secret nonce is already stored for this MuSig2 context (aggregate pubkey {key}). " +
+                "Call SignMusig to consume it before generating a fresh nonce for the same context; " +
+                "MuSig2 nonce reuse leaks the private key.");
         logger?.LogInformation("GenerateNonces produced nonce successfully");
-        return Task.FromResult(nonce);
+        return Task.FromResult(nonce.CreatePubNonce());
     }
+
+    private static string ContextKey(MusigContext context) =>
+        Convert.ToHexString(context.AggregatePubKey.ToBytes()).ToLowerInvariant();
 }

--- a/NArk.Core/Wallet/RemoteArkadeWalletSigner.cs
+++ b/NArk.Core/Wallet/RemoteArkadeWalletSigner.cs
@@ -32,8 +32,9 @@ public class RemoteArkadeWalletSigner(string walletId, IRemoteSignerTransport tr
     public Task<MusigPartialSignature> SignMusig(
         OutputDescriptor descriptor,
         MusigContext context,
+        string sessionId,
         CancellationToken cancellationToken = default)
-        => _transport.SignMusigAsync(_walletId, descriptor, context, cancellationToken);
+        => _transport.SignMusigAsync(_walletId, descriptor, context, sessionId, cancellationToken);
 
     public Task<(ECXOnlyPubKey, SecpSchnorrSignature)> Sign(
         OutputDescriptor descriptor,
@@ -44,6 +45,7 @@ public class RemoteArkadeWalletSigner(string walletId, IRemoteSignerTransport tr
     public Task<MusigPubNonce> GenerateNonces(
         OutputDescriptor descriptor,
         MusigContext context,
+        string sessionId,
         CancellationToken cancellationToken = default)
-        => _transport.GenerateNoncesAsync(_walletId, descriptor, context, cancellationToken);
+        => _transport.GenerateNoncesAsync(_walletId, descriptor, context, sessionId, cancellationToken);
 }

--- a/NArk.Core/Wallet/RemoteArkadeWalletSigner.cs
+++ b/NArk.Core/Wallet/RemoteArkadeWalletSigner.cs
@@ -32,9 +32,8 @@ public class RemoteArkadeWalletSigner(string walletId, IRemoteSignerTransport tr
     public Task<MusigPartialSignature> SignMusig(
         OutputDescriptor descriptor,
         MusigContext context,
-        MusigPrivNonce nonce,
         CancellationToken cancellationToken = default)
-        => _transport.SignMusigAsync(_walletId, descriptor, context, nonce, cancellationToken);
+        => _transport.SignMusigAsync(_walletId, descriptor, context, cancellationToken);
 
     public Task<(ECXOnlyPubKey, SecpSchnorrSignature)> Sign(
         OutputDescriptor descriptor,
@@ -42,7 +41,7 @@ public class RemoteArkadeWalletSigner(string walletId, IRemoteSignerTransport tr
         CancellationToken cancellationToken = default)
         => _transport.SignAsync(_walletId, descriptor, hash, cancellationToken);
 
-    public Task<MusigPrivNonce> GenerateNonces(
+    public Task<MusigPubNonce> GenerateNonces(
         OutputDescriptor descriptor,
         MusigContext context,
         CancellationToken cancellationToken = default)

--- a/NArk.Tests.End2End/Wallets/SimpleSeedWallet.cs
+++ b/NArk.Tests.End2End/Wallets/SimpleSeedWallet.cs
@@ -63,13 +63,12 @@ public class SimpleSeedWallet : IArkadeWalletSigner, IArkadeAddressProvider
 
 
     public async Task<MusigPartialSignature> SignMusig(OutputDescriptor descriptor, MusigContext context,
-        CancellationToken cancellationToken = default)
+        string sessionId, CancellationToken cancellationToken = default)
     {
-        var key = ContextKey(context);
-        if (!_secNonces.TryRemove(key, out var nonce))
+        if (!_secNonces.TryRemove(sessionId, out var nonce))
             throw new InvalidOperationException(
-                $"No secret nonce stored for the given MuSig2 context (aggregate pubkey {key}). " +
-                "Call GenerateNonces for this context first.");
+                $"No secret nonce stored for sessionId '{sessionId}'. " +
+                "Call GenerateNonces with the same sessionId first.");
         var privKey = await DerivePrivateKey(descriptor, cancellationToken);
         return context.Sign(privKey, nonce);
     }
@@ -87,19 +86,19 @@ public class SimpleSeedWallet : IArkadeWalletSigner, IArkadeAddressProvider
         return (privKey.CreateXOnlyPubKey(), privKey.SignBIP340(hash.ToBytes()));
     }
 
-    public async Task<MusigPubNonce> GenerateNonces(OutputDescriptor descriptor, MusigContext context, CancellationToken cancellationToken = default)
+    public async Task<MusigPubNonce> GenerateNonces(OutputDescriptor descriptor, MusigContext context,
+        string sessionId, CancellationToken cancellationToken = default)
     {
-        var nonce = context.GenerateNonce(await DerivePrivateKey(descriptor, cancellationToken));
-        var key = ContextKey(context);
-        if (!_secNonces.TryAdd(key, nonce))
+        if (_secNonces.ContainsKey(sessionId))
             throw new InvalidOperationException(
-                $"A secret nonce is already stored for this MuSig2 context (aggregate pubkey {key}); " +
+                $"A secret nonce is already stored for sessionId '{sessionId}'; " +
                 "call SignMusig to consume it before regenerating.");
+        var nonce = context.GenerateNonce(await DerivePrivateKey(descriptor, cancellationToken));
+        if (!_secNonces.TryAdd(sessionId, nonce))
+            throw new InvalidOperationException(
+                $"A secret nonce was concurrently stored for sessionId '{sessionId}'.");
         return nonce.CreatePubNonce();
     }
-
-    private static string ContextKey(MusigContext context) =>
-        Convert.ToHexString(context.AggregatePubKey.ToBytes()).ToLowerInvariant();
 
     public async Task<bool> IsOurs(OutputDescriptor descriptor, CancellationToken cancellationToken = default)
     {

--- a/NArk.Tests.End2End/Wallets/SimpleSeedWallet.cs
+++ b/NArk.Tests.End2End/Wallets/SimpleSeedWallet.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using NArk.Abstractions.Contracts;
 using NArk.Abstractions.Wallets;
 using NArk.Core.Contracts;
@@ -18,6 +19,7 @@ public class SimpleSeedWallet : IArkadeWalletSigner, IArkadeAddressProvider
     private readonly string _mnemonic;
     private int _lastIndex;
     private readonly IClientTransport _clientTransport;
+    private readonly ConcurrentDictionary<string, MusigPrivNonce> _secNonces = new();
 
     private SimpleSeedWallet(string identifier, string descriptor, string mnemonic, int lastIndex, IClientTransport clientTransport)
     {
@@ -60,9 +62,14 @@ public class SimpleSeedWallet : IArkadeWalletSigner, IArkadeAddressProvider
     }
 
 
-    public async Task<MusigPartialSignature> SignMusig(OutputDescriptor descriptor, MusigContext context, MusigPrivNonce nonce,
+    public async Task<MusigPartialSignature> SignMusig(OutputDescriptor descriptor, MusigContext context,
         CancellationToken cancellationToken = default)
     {
+        var key = ContextKey(context);
+        if (!_secNonces.TryRemove(key, out var nonce))
+            throw new InvalidOperationException(
+                $"No secret nonce stored for the given MuSig2 context (aggregate pubkey {key}). " +
+                "Call GenerateNonces for this context first.");
         var privKey = await DerivePrivateKey(descriptor, cancellationToken);
         return context.Sign(privKey, nonce);
     }
@@ -80,10 +87,19 @@ public class SimpleSeedWallet : IArkadeWalletSigner, IArkadeAddressProvider
         return (privKey.CreateXOnlyPubKey(), privKey.SignBIP340(hash.ToBytes()));
     }
 
-    public async Task<MusigPrivNonce> GenerateNonces(OutputDescriptor descriptor, MusigContext context, CancellationToken cancellationToken = default)
+    public async Task<MusigPubNonce> GenerateNonces(OutputDescriptor descriptor, MusigContext context, CancellationToken cancellationToken = default)
     {
-        return context.GenerateNonce(await DerivePrivateKey(descriptor, cancellationToken));
+        var nonce = context.GenerateNonce(await DerivePrivateKey(descriptor, cancellationToken));
+        var key = ContextKey(context);
+        if (!_secNonces.TryAdd(key, nonce))
+            throw new InvalidOperationException(
+                $"A secret nonce is already stored for this MuSig2 context (aggregate pubkey {key}); " +
+                "call SignMusig to consume it before regenerating.");
+        return nonce.CreatePubNonce();
     }
+
+    private static string ContextKey(MusigContext context) =>
+        Convert.ToHexString(context.AggregatePubKey.ToBytes()).ToLowerInvariant();
 
     public async Task<bool> IsOurs(OutputDescriptor descriptor, CancellationToken cancellationToken = default)
     {

--- a/NArk.Tests/NSecWalletSignerParityTests.cs
+++ b/NArk.Tests/NSecWalletSignerParityTests.cs
@@ -184,11 +184,9 @@ public class NSecWalletSignerParityTests
         var clientContext = new MusigContext(cosignerKeys, fakeSighash, signerPubKey);
         var serverContext = new MusigContext(cosignerKeys, fakeSighash, serverPub);
 
-        // Generate nonces
-        var clientNonce = signer.GenerateNonces(descriptor, clientContext).Result;
+        // Generate nonces — signer stores the secret half internally and returns the public nonce.
+        var clientPubNonce = signer.GenerateNonces(descriptor, clientContext).Result;
         var serverNonce = serverContext.GenerateNonce(serverPrivKey);
-
-        var clientPubNonce = clientNonce.CreatePubNonce();
         var serverPubNonce = serverNonce.CreatePubNonce();
 
         // Aggregate nonces
@@ -196,11 +194,11 @@ public class NSecWalletSignerParityTests
         clientContext.ProcessNonces(allNonces);
         serverContext.ProcessNonces(allNonces);
 
-        // Sign
+        // Sign — signer looks up the stored secret nonce by aggregate-pubkey of the same context.
         MusigPartialSignature clientSig = null!;
         Assert.DoesNotThrowAsync(async () =>
         {
-            clientSig = await signer.SignMusig(descriptor, clientContext, clientNonce);
+            clientSig = await signer.SignMusig(descriptor, clientContext);
         });
 
         var serverSig = serverContext.Sign(serverPrivKey, serverNonce);

--- a/NArk.Tests/NSecWalletSignerParityTests.cs
+++ b/NArk.Tests/NSecWalletSignerParityTests.cs
@@ -157,7 +157,7 @@ public class NSecWalletSignerParityTests
         // "signing pubkey doesn't match" when parity was wrong
         Assert.DoesNotThrowAsync(async () =>
         {
-            await signer.GenerateNonces(descriptor, musigContext);
+            await signer.GenerateNonces(descriptor, musigContext, sessionId: "test-parity");
         });
     }
 
@@ -185,7 +185,8 @@ public class NSecWalletSignerParityTests
         var serverContext = new MusigContext(cosignerKeys, fakeSighash, serverPub);
 
         // Generate nonces — signer stores the secret half internally and returns the public nonce.
-        var clientPubNonce = signer.GenerateNonces(descriptor, clientContext).Result;
+        const string sessionId = "test-full-musig2-flow";
+        var clientPubNonce = signer.GenerateNonces(descriptor, clientContext, sessionId).Result;
         var serverNonce = serverContext.GenerateNonce(serverPrivKey);
         var serverPubNonce = serverNonce.CreatePubNonce();
 
@@ -194,11 +195,11 @@ public class NSecWalletSignerParityTests
         clientContext.ProcessNonces(allNonces);
         serverContext.ProcessNonces(allNonces);
 
-        // Sign — signer looks up the stored secret nonce by aggregate-pubkey of the same context.
+        // Sign — signer looks up the stored secret nonce by sessionId.
         MusigPartialSignature clientSig = null!;
         Assert.DoesNotThrowAsync(async () =>
         {
-            clientSig = await signer.SignMusig(descriptor, clientContext);
+            clientSig = await signer.SignMusig(descriptor, clientContext, sessionId);
         });
 
         var serverSig = serverContext.Sign(serverPrivKey, serverNonce);

--- a/docs/articles/wallets.md
+++ b/docs/articles/wallets.md
@@ -98,16 +98,16 @@ public class HardwareSignerTransport : IRemoteSignerTransport
         => _bridge.GetPubKeyAsync(walletId, descriptor.ToString(), ct);
 
     public Task<MusigPartialSignature> SignMusigAsync(string walletId, OutputDescriptor descriptor,
-        MusigContext context, CancellationToken ct)
-        => _bridge.SignMusigAsync(walletId, descriptor.ToString(), context, ct);
+        MusigContext context, string sessionId, CancellationToken ct)
+        => _bridge.SignMusigAsync(walletId, descriptor.ToString(), context, sessionId, ct);
 
     public Task<(ECXOnlyPubKey, SecpSchnorrSignature)> SignAsync(string walletId, OutputDescriptor descriptor,
         uint256 hash, CancellationToken ct)
         => _bridge.SignAsync(walletId, descriptor.ToString(), hash, ct);
 
     public Task<MusigPubNonce> GenerateNoncesAsync(string walletId, OutputDescriptor descriptor,
-        MusigContext context, CancellationToken ct)
-        => _bridge.GenerateNoncesAsync(walletId, descriptor.ToString(), context, ct);
+        MusigContext context, string sessionId, CancellationToken ct)
+        => _bridge.GenerateNoncesAsync(walletId, descriptor.ToString(), context, sessionId, ct);
 }
 
 services.AddSingleton<IRemoteSignerTransport, HardwareSignerTransport>();
@@ -118,14 +118,26 @@ services.AddSingleton<IRemoteSignerTransport, HardwareSignerTransport>();
 ### MuSig2 Nonce Lifecycle
 
 The MuSig2 nonce flow keeps the secret half on the signer side: `GenerateNoncesAsync` retains the
-secret nonce, indexed by `walletId` + `MusigContext.AggregatePubKey`, and returns only the public
-half. `SignMusigAsync` looks the secret up by the same context and consumes it on use — calling
-`SignMusigAsync` without a prior matching `GenerateNoncesAsync` throws.
+secret nonce, indexed by `walletId` + a caller-supplied `sessionId`, and returns only the public
+half. `SignMusigAsync` looks the secret up by the same `sessionId` and consumes it on use —
+calling `SignMusigAsync` without a prior matching `GenerateNoncesAsync` throws.
+
+`sessionId` must be unique per signing operation within the signer's scope. In batch participation,
+`TreeSignerSession` passes each tree-node txid as the sessionId; for other flows the caller picks
+something equally disambiguating. `MusigContext.AggregatePubKey` is *not* enough on its own —
+multiple tree nodes can share cosigner set + tweak, so their contexts have identical aggregate
+pubkeys but different sighashes. The sighash is internal to `MusigContext` and can't be observed
+by the signer, so the disambiguator has to come from the caller.
 
 Implementations need an eviction policy for abandoned nonces (TTL or bounded count) so the secret
 nonce store does not grow unbounded if a caller generates a nonce but never signs. The in-process
-`NSecWalletSigner` / `HierarchicalDeterministicWalletSigner` rely on remove-on-consume; long-lived
-transport implementations need to add a sweep.
+`NSecWalletSigner` / `HierarchicalDeterministicWalletSigner` rely on remove-on-consume;
+long-lived transport implementations need to add a sweep.
+
+`DefaultWalletProvider` caches signer instances per wallet so that the secret-nonce store on a
+local signer survives between the `GenerateNonces` call and the matching `SignMusig` call. A
+fresh signer per call would silently break MuSig2 signing — the second call would always find an
+empty store.
 
 ## Using a Wallet
 

--- a/docs/articles/wallets.md
+++ b/docs/articles/wallets.md
@@ -98,14 +98,14 @@ public class HardwareSignerTransport : IRemoteSignerTransport
         => _bridge.GetPubKeyAsync(walletId, descriptor.ToString(), ct);
 
     public Task<MusigPartialSignature> SignMusigAsync(string walletId, OutputDescriptor descriptor,
-        MusigContext context, MusigPrivNonce nonce, CancellationToken ct)
-        => _bridge.SignMusigAsync(walletId, descriptor.ToString(), context, nonce, ct);
+        MusigContext context, CancellationToken ct)
+        => _bridge.SignMusigAsync(walletId, descriptor.ToString(), context, ct);
 
     public Task<(ECXOnlyPubKey, SecpSchnorrSignature)> SignAsync(string walletId, OutputDescriptor descriptor,
         uint256 hash, CancellationToken ct)
         => _bridge.SignAsync(walletId, descriptor.ToString(), hash, ct);
 
-    public Task<MusigPrivNonce> GenerateNoncesAsync(string walletId, OutputDescriptor descriptor,
+    public Task<MusigPubNonce> GenerateNoncesAsync(string walletId, OutputDescriptor descriptor,
         MusigContext context, CancellationToken ct)
         => _bridge.GenerateNoncesAsync(walletId, descriptor.ToString(), context, ct);
 }
@@ -114,6 +114,18 @@ services.AddSingleton<IRemoteSignerTransport, HardwareSignerTransport>();
 ```
 
 `DefaultWalletProvider` accepts the transport as an optional constructor dependency — existing setups that don't use remote signing don't need to register one.
+
+### MuSig2 Nonce Lifecycle
+
+The MuSig2 nonce flow keeps the secret half on the signer side: `GenerateNoncesAsync` retains the
+secret nonce, indexed by `walletId` + `MusigContext.AggregatePubKey`, and returns only the public
+half. `SignMusigAsync` looks the secret up by the same context and consumes it on use — calling
+`SignMusigAsync` without a prior matching `GenerateNoncesAsync` throws.
+
+Implementations need an eviction policy for abandoned nonces (TTL or bounded count) so the secret
+nonce store does not grow unbounded if a caller generates a nonce but never signs. The in-process
+`NSecWalletSigner` / `HierarchicalDeterministicWalletSigner` rely on remove-on-consume; long-lived
+transport implementations need to add a sweep.
 
 ## Using a Wallet
 


### PR DESCRIPTION
Closes #111.

## Summary

The `IArkadeWalletSigner` / `IRemoteSignerTransport` contracts used to return `MusigPrivNonce` from `GenerateNonces` and require the caller to pass it back into `SignMusig`. That made the secret nonce cross the signer boundary — for the remote-signer transport it meant secret material round-tripped over the wire (the "remote signer" wasn't actually one); for in-process signers it encouraged callers to hold a MuSig2 secret in their own data structures where accidental reuse leaks the private key (MuSig2 nonce reuse is catastrophic).

This PR reshapes the contracts so:

- `GenerateNonces` returns `MusigPubNonce` only. The signer derives the secret nonce internally, stores it indexed by a caller-supplied `sessionId`, and returns the public half.
- `SignMusig` drops the `MusigPrivNonce` parameter and gains the same `sessionId`. The signer looks the secret back up by `sessionId` and consumes it on use. Throws if no matching nonce was generated.
- `GenerateNonces` throws if a nonce is already stored under the same `sessionId` (generating twice without an intervening `SignMusig` would orphan secret material).

## Why a sessionId rather than fingerprinting the MusigContext

`MusigContext.AggregatePubKey` is determined solely by the cosigner set + taproot tweak. In a batch tree, multiple transactions can share the same cosigner set + tweak, so their contexts produce *identical* aggregate pubkeys but different sighashes. The sighash (`msg32`) is `internal` in NBitcoin and not externally observable, so the signer can't disambiguate on its own. The caller (`TreeSignerSession`) is the only one with enough information to produce a session-unique identifier — it passes each tree-node txid.

## Why signers are now cached in DefaultWalletProvider

The secret-nonce store lives on the signer instance. `DefaultWalletProvider.GetSignerAsync` used to instantiate a fresh signer per call, which meant the `GenerateNonces` call populated one instance's store and `SignMusig` (different instance) always found an empty one. The cache key is `(walletId, secret-hash)` so a wallet re-imported with different signing material gets a fresh signer.

## Why this matters

The on-the-wire `IRemoteSignerTransport` shape is what changed semantics most meaningfully: with the old shape, a "remote signer" service exposing `SignMusigAsync(walletId, descriptor, context, nonce, ct)` was structurally indistinguishable from a key-material proxy — the secret nonce crossed the trust boundary every batch. With the new shape, the secret half never leaves the transport implementation, which is the cryptographic claim of remote signing.

## Changes

- `NArk.Abstractions/Wallets/IArkadeWalletSigner.cs`, `IRemoteSignerTransport.cs`: contract reshape + `sessionId` param + docs explaining the lifecycle and the AggregatePubKey-collision rationale.
- `NArk.Core/Wallet/NSecWalletSigner.cs`, `HierarchicalDeterministicWalletSigner.cs`: per-instance `ConcurrentDictionary<string, MusigPrivNonce>` keyed by `sessionId`; `SignMusig` `TryRemove`s on consume; `GenerateNonces` `ContainsKey`-checks before generating so duplicate-sessionId collisions don't burn entropy.
- `NArk.Core/Wallet/RemoteArkadeWalletSigner.cs`: pure passthrough — drops the nonce param, threads through `sessionId`.
- `NArk.Core/Wallet/DefaultWalletProvider.cs`: caches signer instances per `(walletId, secret-hash)` so the secret-nonce store survives between `GenerateNonces` and `SignMusig`.
- `NArk.Core/Batches/TreeSignerSession.cs`: `_myNonces` collapses from `Dictionary<uint256, (MusigPrivNonce, MusigPubNonce)>` to `Dictionary<uint256, MusigPubNonce>`; both `GenerateNonces` and `SignMusig` calls pass the tree-node `txid.ToString()` as `sessionId`.
- `NArk.Tests/NSecWalletSignerParityTests.cs`, `NArk.Tests.End2End/Wallets/SimpleSeedWallet.cs`: updated to new contract.
- `docs/articles/wallets.md`: updated remote-signer example + MuSig2 nonce lifecycle section + signer-caching rationale.

`IRemoteSignerTransport` documents that long-lived transports need an eviction policy (TTL or bounded count) for abandoned nonces — in-process signers get away with remove-on-consume because their lifetime is the cached singleton, but a server-side transport could leak unconsumed entries if a client generates a nonce and never signs.

## Breaking change

Yes — `IArkadeWalletSigner` and `IRemoteSignerTransport` are public surface. Any external implementation of either must:

1. Drop the `MusigPrivNonce` parameter from `SignMusig` / `SignMusigAsync`.
2. Change `GenerateNonces` / `GenerateNoncesAsync` return type to `MusigPubNonce`.
3. Accept a new `string sessionId` parameter on both `GenerateNonces` and `SignMusig`.
4. Internalise the secret nonce store with whatever eviction policy fits the transport's lifetime.

## Test plan

- [x] `dotnet build NArk.sln` — clean
- [x] `dotnet test NArk.Tests` — 418 passed, 0 failed
- [x] E2E CI — covered (was green on initial push; rerunning post review-fix)