### PR TITLE
Bump library projects from net8.0 to net10.0

### DIFF
--- a/NArk.Abstractions/NArk.Abstractions.csproj
+++ b/NArk.Abstractions/NArk.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>

--- a/NArk.Core/NArk.Core.csproj
+++ b/NArk.Core/NArk.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>

--- a/NArk.Scratchpad/NArk.Scratchpad.csproj
+++ b/NArk.Scratchpad/NArk.Scratchpad.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/NArk.Storage.EfCore/NArk.Storage.EfCore.csproj
+++ b/NArk.Storage.EfCore/NArk.Storage.EfCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>

--- a/NArk.Swaps/NArk.Swaps.csproj
+++ b/NArk.Swaps/NArk.Swaps.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <WarningsAsErrors>nullable</WarningsAsErrors>

--- a/NArk/NArk.csproj
+++ b/NArk/NArk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <PackageDescription>Meta-package for the Ark protocol .NET SDK. Pulls in NArk.Core (spending, batches, VTXO sync, wallets) and NArk.Swaps (Boltz integration).</PackageDescription>
     </PropertyGroup>


### PR DESCRIPTION
## Summary

- Bumps the six NArk library projects from `net8.0` to `net10.0`:
  - `NArk`, `NArk.Abstractions`, `NArk.Core`, `NArk.Scratchpad`, `NArk.Storage.EfCore`, `NArk.Swaps`
- Aligns library TFMs with test projects, which already target `net10.0` per `CLAUDE.md`.
- .NET 8 is EOL November 2026; .NET 10 LTS is the long-term target.

## Verification

- `dotnet build NArk.sln -c Release` → 0 errors
- `dotnet test NArk.Tests` → 418 / 418 passed

## Test plan

- [x] All NArk unit tests pass
- [ ] CI confirms green build across all jobs
- [ ] Downstream consumers (btcpay-arkade plugin, BTCPayApp) confirm continued compatibility