### PR TITLE
fix(e2e): close batch-topic subscription race + serialize concurrent submarine swap creation

### DIFF
--- a/NArk.Core/Services/BatchManagementService.cs
+++ b/NArk.Core/Services/BatchManagementService.cs
@@ -167,6 +167,18 @@ public class BatchManagementService(
             case StreamStartedEvent streamStarted:
                 _streamId = streamStarted.StreamId;
                 logger?.LogDebug("Event stream started with ID {StreamId}", _streamId);
+                // An intent that reached WaitingForBatch during the stream-connect
+                // window (before _streamId was set) had its OnIntentChanged topic
+                // subscription silently skipped by UpdateTopicsAsync's null-stream
+                // guard, with no retry. Left unsubscribed, the intent never receives
+                // its BatchStartedEvent, never participates in signing, and gets
+                // re-proposed every batch round forever (a permanent settle stall).
+                // Now that the stream is live, reconcile by re-subscribing every
+                // active intent's topics. UpdateStreamTopics add is idempotent, so
+                // re-adding already-subscribed topics is a no-op.
+                var reconcileTopics = GetAllTopics();
+                if (reconcileTopics.Length > 0)
+                    await UpdateTopicsAsync(addTopics: reconcileTopics);
                 break;
 
             case BatchStartedEvent batchStarted:

--- a/NArk.Tests.End2End/SwapManagementServiceTests.cs
+++ b/NArk.Tests.End2End/SwapManagementServiceTests.cs
@@ -407,6 +407,14 @@ public class SwapManagementServiceTests
         var settledA = new TaskCompletionSource();
         var settledB = new TaskCompletionSource();
 
+        // Boltz serializes swap creation through its Postgres backend under
+        // SERIALIZABLE isolation; two CreateSubmarineSwap POSTs racing in
+        // parallel abort one another with SQLSTATE 40001 ("could not serialize
+        // access due to read/write dependencies among transactions"). Gate just
+        // the creation call so both swaps still poll and settle concurrently
+        // afterwards but don't collide on Boltz's swap-insert transaction.
+        using var createGate = new SemaphoreSlim(1, 1);
+
         async Task<string> RunSwapAsync(
             (ISafetyService safetyService, InMemoryWalletProvider walletProvider, string walletIdentifier,
                 IVtxoStorage vtxoStorage, ContractService contractService, IContractStorage contracts,
@@ -453,7 +461,17 @@ public class SwapManagementServiceTests
 
             var invoice = BOLT11PaymentRequest.Parse(
                 await DockerHelper.CreateLndInvoice(invoiceSats, expirySecs: 0), Network.RegTest);
-            var swapId = await swapMgr.InitiateSubmarineSwap(prereq.walletIdentifier, invoice, autoPay: true, token);
+
+            string swapId;
+            await createGate.WaitAsync(token);
+            try
+            {
+                swapId = await swapMgr.InitiateSubmarineSwap(prereq.walletIdentifier, invoice, autoPay: true, token);
+            }
+            finally
+            {
+                createGate.Release();
+            }
 
             await settledTcs.Task.WaitAsync(TimeSpan.FromMinutes(5), token);
             await swapMgr.DisposeAsync();


### PR DESCRIPTION
Hardens the dotnet-sdk E2E suite so master goes (and stays) green. Two independent flakes, two fixes.

## 1. Batch-topic subscription race (production fix) — `BatchManagementService`

**Symptom:** `CanStartUnilateralExitForSettledVtxo` intermittently times out after 2 min waiting on `BatchSucceeded`. arkd logs show the intent registered and was then **re-proposed in every batch round for 6+ minutes, never finalizing**.

**Root cause:** When an intent reaches `WaitingForBatch`, `OnIntentChanged` subscribes the event stream to its topics via fire-and-forget `UpdateTopicsAsync`. That call **silently skips when `_streamId` is still null** (stream-connect handshake hasn''t returned `StreamStartedEvent` yet) and never retries. An intent that crosses into `WaitingForBatch` inside that connect window is never subscribed → never receives its `BatchStartedEvent` → never signs → arkd re-proposes it forever. A permanent settle stall, timing-dependent (hence flaky), and able to strand **any** settle test.

**Fix:** on `StreamStartedEvent`, reconcile by re-subscribing every active intent''s topics. `UpdateStreamTopics` add is idempotent (server-side set union) and already exception-guarded, so re-adding existing topics is a no-op — the reconcile only adds topics stranded during the connect window. Internal bugfix, no public API change.

## 2. Concurrent submarine swap creation race (test fix) — `SwapManagementServiceTests`

**Symptom:** `ConcurrentSubmarineSwapsBothComplete` failed master at `6b69b9e` (#114) with `HttpRequestException: {"error":"could not serialize access due to read/write dependencies among transactions"}`.

**Root cause:** two parallel `InitiateSubmarineSwap` calls POST Boltz `/v2/swap/submarine` simultaneously; Boltz''s SERIALIZABLE Postgres backend aborts one with SQLSTATE 40001.

**Fix:** gate only the creation call with a shared `SemaphoreSlim` so both swaps still poll and settle concurrently but don''t collide on Boltz''s swap-insert transaction.

## Test plan

- [ ] `ConcurrentSubmarineSwapsBothComplete` green
- [ ] `CanStartUnilateralExitForSettledVtxo` green
- [ ] Full E2E suite green across **5 sequential runs** to confirm both races are gone

## Notes

- Verified locally only by compile (E2E needs nigiri/arkd/boltz); behavioural verification is via CI.
- Sibling `SubmarineAndReverseSwapsCompleteInParallel` already wraps its reverse-swap creation in `RetryWithSettle`; left as-is.