### PR TITLE
feat(contracts): per-type ContractScope (on-chain/off-chain)

### DIFF
--- a/NArk.Abstractions/Contracts/ArkContract.cs
+++ b/NArk.Abstractions/Contracts/ArkContract.cs
@@ -16,6 +16,13 @@ public abstract class ArkContract(OutputDescriptor server)
     /// <summary>Contract type discriminator string (e.g. <c>"vtxo"</c>, <c>"boarding"</c>).</summary>
     public abstract string Type { get; }
 
+    /// <summary>
+    /// The layer this contract type's funds live on by default (on-chain vs off-chain).
+    /// Abstract so every contract type makes an explicit, compile-time scope decision.
+    /// Used as the fallback when <see cref="ToEntity"/> is called without a scope override.
+    /// </summary>
+    public abstract ContractScope DefaultScope { get; }
+
     /// <summary>The Arkade server key descriptor. Null for contracts that predate multi-server support.</summary>
     public OutputDescriptor? Server { get; } = server;
 
@@ -63,12 +70,24 @@ public abstract class ArkContract(OutputDescriptor server)
         return spendInfo.OutputPubKey.ScriptPubKey;
     }
 
-    /// <summary>Creates a storage entity for this contract, ready to persist.</summary>
+    /// <summary>
+    /// Projects this contract into a persistable <see cref="ArkContractEntity"/>.
+    /// </summary>
+    /// <param name="walletIdentifier">The wallet that owns the contract.</param>
+    /// <param name="defaultServerKey">Reserved for address derivation parity; not persisted.</param>
+    /// <param name="createdAt">Creation timestamp; defaults to now.</param>
+    /// <param name="activityState">Initial activity state; defaults to Active.</param>
+    /// <param name="scopeOverride">
+    /// Per-instance scope override. When null, the entity's effective scope is
+    /// <see cref="DefaultScope"/>. The override is write-time only — the persisted
+    /// column always means "this contract's effective scope."
+    /// </param>
     public ArkContractEntity ToEntity(
         string walletIdentifier,
         OutputDescriptor? defaultServerKey = null,
         DateTimeOffset? createdAt = null,
-        ContractActivityState activityState = ContractActivityState.Active)
+        ContractActivityState activityState = ContractActivityState.Active,
+        ContractScope? scopeOverride = null)
     {
         return new ArkContractEntity(
             GetScriptPubKey().ToHex(),
@@ -77,7 +96,10 @@ public abstract class ArkContract(OutputDescriptor server)
             GetContractData(),
             walletIdentifier,
             createdAt ?? DateTimeOffset.UtcNow
-        );
+        )
+        {
+            Scope = scopeOverride ?? DefaultScope
+        };
     }
 
     /// <summary>Returns the script builders for each tapscript leaf in the tree.</summary>

--- a/NArk.Abstractions/Contracts/ArkContractEntity.cs
+++ b/NArk.Abstractions/Contracts/ArkContractEntity.cs
@@ -15,4 +15,10 @@ public record ArkContractEntity(
     /// Separate from AdditionalData which stores contract crypto params.
     /// </summary>
     public Dictionary<string, string>? Metadata { get; init; }
+
+    /// <summary>
+    /// The effective layer this contract's funds live on (on-chain vs off-chain).
+    /// Resolved at write time from the contract's <c>DefaultScope</c> or an explicit override.
+    /// </summary>
+    public ContractScope Scope { get; init; }
 }

--- a/NArk.Abstractions/Contracts/ContractScope.cs
+++ b/NArk.Abstractions/Contracts/ContractScope.cs
@@ -1,0 +1,24 @@
+namespace NArk.Abstractions.Contracts;
+
+/// <summary>
+/// Identifies the layer a contract's funds live on: on-chain (a boarding UTXO,
+/// synced/swept via Esplora/NBXplorer) or off-chain (a VTXO, synced via the
+/// Arkade indexer). A contract whose funds can appear on both layers uses
+/// <see cref="Onchain"/> | <see cref="Offchain"/>.
+/// </summary>
+/// <remarks>
+/// Query this only via the bitwise form <c>(Scope &amp; X) == X</c>, which EF Core
+/// translates to SQL across Npgsql, SQLite and SqlServer. A value carrying both
+/// flags therefore satisfies an <see cref="Onchain"/>-include and an
+/// <see cref="Offchain"/>-include filter alike. Never use <c>HasFlag</c>: EF Core
+/// does not translate it (it client-evaluates or throws).
+/// </remarks>
+[Flags]
+public enum ContractScope
+{
+    /// <summary>Funds live on-chain (a boarding UTXO).</summary>
+    Onchain = 1,
+
+    /// <summary>Funds live off-chain (a VTXO synced via the Arkade indexer).</summary>
+    Offchain = 2,
+}

--- a/NArk.Abstractions/Contracts/IContractStorage.cs
+++ b/NArk.Abstractions/Contracts/IContractStorage.cs
@@ -19,6 +19,10 @@ public interface IContractStorage : IActiveScriptsProvider
     /// <param name="searchText">Filter by script containing this text. If null, no text filter.</param>
     /// <param name="skip">Number of records to skip (for pagination). If null, no skip.</param>
     /// <param name="take">Number of records to take (for pagination). If null, no limit.</param>
+    /// <param name="scope">
+    /// Filter by contract scope (on-chain/off-chain) via bitwise include
+    /// <c>(Scope &amp; scope) == scope</c>. If null, no scope filter.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task<IReadOnlyCollection<ArkContractEntity>> GetContracts(
         string[]? walletIds = null,
@@ -28,6 +32,7 @@ public interface IContractStorage : IActiveScriptsProvider
         string? searchText = null,
         int? skip = null,
         int? take = null,
+        ContractScope? scope = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>Inserts or updates a contract record.</summary>

--- a/NArk.Core/Contracts/ArkBoardingContract.cs
+++ b/NArk.Core/Contracts/ArkBoardingContract.cs
@@ -21,6 +21,9 @@ public class ArkBoardingContract(OutputDescriptor server, Sequence exitDelay, Ou
     public override string Type => ContractType;
     public const string ContractType = "Boarding";
 
+    /// <summary>Boarding funds live on-chain as a boarding UTXO.</summary>
+    public override ContractScope DefaultScope => ContractScope.Onchain;
+
 
     /// <summary>
     /// Boarding contracts use on-chain Bitcoin addresses, not Ark addresses.

--- a/NArk.Core/Contracts/ArkDelegateContract.cs
+++ b/NArk.Core/Contracts/ArkDelegateContract.cs
@@ -17,6 +17,9 @@ public class ArkDelegateContract : ArkContract
     public override string Type => ContractType;
     public const string ContractType = "Delegate";
 
+    /// <summary>Delegate funds live off-chain as a VTXO.</summary>
+    public override ContractScope DefaultScope => ContractScope.Offchain;
+
     public ArkDelegateContract(
         OutputDescriptor server,
         Sequence exitDelay,

--- a/NArk.Core/Contracts/ArkNoteContract.cs
+++ b/NArk.Core/Contracts/ArkNoteContract.cs
@@ -19,6 +19,9 @@ public class ArkNoteContract(uint amount, byte[] preimage) : ArkContract(null!)
     public override string Type => ContractType;
     public const string ContractType = "arknote";
 
+    /// <summary>Arkade note funds live off-chain as a VTXO.</summary>
+    public override ContractScope DefaultScope => ContractScope.Offchain;
+
     protected override IEnumerable<ScriptBuilder> GetScriptBuilders()
     {
         yield return CreateClaimScript();

--- a/NArk.Core/Contracts/ArkPaymentContract.cs
+++ b/NArk.Core/Contracts/ArkPaymentContract.cs
@@ -21,6 +21,9 @@ public class ArkPaymentContract(OutputDescriptor server, Sequence exitDelay, Out
     public override string Type => ContractType;
     public const string ContractType = "Payment";
 
+    /// <summary>Payment funds live off-chain as a VTXO.</summary>
+    public override ContractScope DefaultScope => ContractScope.Offchain;
+
 
     protected override IEnumerable<ScriptBuilder> GetScriptBuilders()
     {

--- a/NArk.Core/Contracts/GenericArkContract.cs
+++ b/NArk.Core/Contracts/GenericArkContract.cs
@@ -8,6 +8,9 @@ public class GenericArkContract(OutputDescriptor server, IEnumerable<ScriptBuild
 {
     public override string Type { get; } = "generic";
 
+    /// <summary>Generic contracts default to off-chain (VTXO) unless overridden at write time.</summary>
+    public override ContractScope DefaultScope => ContractScope.Offchain;
+
     protected override IEnumerable<ScriptBuilder> GetScriptBuilders()
     {
         return scriptBuilders;

--- a/NArk.Core/Contracts/HashLockedArkPaymentContract.cs
+++ b/NArk.Core/Contracts/HashLockedArkPaymentContract.cs
@@ -40,6 +40,9 @@ public class HashLockedArkPaymentContract(
 
     public override string Type => ContractType;
     public const string ContractType = "HashLockPaymentContract";
+
+    /// <summary>Hash-locked payment funds live off-chain as a VTXO.</summary>
+    public override ContractScope DefaultScope => ContractScope.Offchain;
     public byte[] Preimage => preimage;
     public Sequence ExitDelay => _exitDelay;
     public HashLockTypeOption HashLockType => hashLockType;

--- a/NArk.Core/Contracts/UnknownArkContract.cs
+++ b/NArk.Core/Contracts/UnknownArkContract.cs
@@ -30,6 +30,12 @@ public class UnknownArkContract : ArkContract
 
     public override string Type => ContractType;
 
+    /// <summary>
+    /// Unknown contracts default to off-chain; a persisted Unknown contract carries
+    /// its stored effective scope when loaded.
+    /// </summary>
+    public override ContractScope DefaultScope => ContractScope.Offchain;
+
     protected override IEnumerable<ScriptBuilder> GetScriptBuilders()
     {
         throw new InvalidOperationException("Unknown contract cannot be used for signing");

--- a/NArk.Core/Contracts/VHTLCContract.cs
+++ b/NArk.Core/Contracts/VHTLCContract.cs
@@ -77,6 +77,9 @@ public class VHTLCContract : ArkContract
     public override string Type => ContractType;
     public const string ContractType = "HTLC";
 
+    /// <summary>VHTLC funds live off-chain as a VTXO.</summary>
+    public override ContractScope DefaultScope => ContractScope.Offchain;
+
 
     protected override IEnumerable<ScriptBuilder> GetScriptBuilders()
     {

--- a/NArk.Core/Services/BoardingUtxoPollService.cs
+++ b/NArk.Core/Services/BoardingUtxoPollService.cs
@@ -75,7 +75,7 @@ public class BoardingUtxoPollService(
     private async Task<bool> HasUnspentBoardingVtxosAsync(CancellationToken cancellationToken)
     {
         var boardingContracts = await contractStorage.GetContracts(
-            contractTypes: [ArkBoardingContract.ContractType],
+            scope: ContractScope.Onchain,
             cancellationToken: cancellationToken);
 
         if (boardingContracts.Count == 0)

--- a/NArk.Core/Services/BoardingUtxoSyncService.cs
+++ b/NArk.Core/Services/BoardingUtxoSyncService.cs
@@ -40,7 +40,7 @@ public class BoardingUtxoSyncService
     public async Task SyncAsync(CancellationToken cancellationToken = default)
     {
         var boardingContracts = await _contractStorage.GetContracts(
-            contractTypes: [ArkBoardingContract.ContractType],
+            scope: ContractScope.Onchain,
             cancellationToken: cancellationToken);
 
         if (boardingContracts.Count == 0)

--- a/NArk.Core/Services/OnchainSweepService.cs
+++ b/NArk.Core/Services/OnchainSweepService.cs
@@ -57,7 +57,7 @@ public class OnchainSweepService(
         var scripts = expiredUnrolled.Select(v => v.Script).Distinct().ToArray();
         var contracts = await contractStorage.GetContracts(
             scripts: scripts,
-            contractTypes: [ArkBoardingContract.ContractType],
+            scope: ContractScope.Onchain,
             cancellationToken: cancellationToken);
 
         var contractByScript = contracts.ToDictionary(c => c.Script);

--- a/NArk.Storage.EfCore/Entities/ArkWalletContractEntity.cs
+++ b/NArk.Storage.EfCore/Entities/ArkWalletContractEntity.cs
@@ -13,6 +13,13 @@ public class ArkWalletContractEntity
     public ContractActivityState ActivityState { get; set; } = ContractActivityState.Inactive;
     public string Type { get; set; } = "";
 
+    /// <summary>
+    /// The effective layer this contract's funds live on (on-chain vs off-chain).
+    /// Indexed so sync/recovery/sweep can filter by scope in SQL. Defaults to
+    /// <see cref="ContractScope.Offchain"/> for rows written before this column existed.
+    /// </summary>
+    public ContractScope Scope { get; set; } = ContractScope.Offchain;
+
     [Column("ContractData", TypeName = "jsonb")]
     public string ContractDataJson { get; set; } = "{}";
 
@@ -44,6 +51,8 @@ public class ArkWalletContractEntity
     {
         builder.ToTable(options.WalletContractsTable, options.Schema);
         builder.HasKey(w => new { w.Script, w.WalletId });
+
+        builder.HasIndex(w => w.Scope);
 
         builder.HasOne(w => w.Wallet)
             .WithMany(w => w.Contracts)

--- a/NArk.Storage.EfCore/Storage/EfCoreContractStorage.cs
+++ b/NArk.Storage.EfCore/Storage/EfCoreContractStorage.cs
@@ -26,6 +26,7 @@ public class EfCoreContractStorage : IContractStorage
         string? searchText = null,
         int? skip = null,
         int? take = null,
+        ContractScope? scope = null,
         CancellationToken cancellationToken = default)
     {
         await using var db = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
@@ -69,6 +70,13 @@ public class EfCoreContractStorage : IContractStorage
         if (contractTypes is { })
         {
             query = query.Where(c => contractTypes.Contains(c.Type));
+        }
+
+        if (scope is { } s)
+        {
+            // Bitwise include: a row whose scope carries every bit of `s` matches.
+            // Must NOT use HasFlag — EF Core does not translate it to SQL.
+            query = query.Where(c => (c.Scope & s) == s);
         }
 
         query = query.OrderByDescending(c => c.CreatedAt);
@@ -133,6 +141,7 @@ public class EfCoreContractStorage : IContractStorage
         target.Type = source.Type;
         target.ContractData = source.AdditionalData;
         target.Metadata = source.Metadata ?? target.Metadata;
+        target.Scope = source.Scope;
     }
 
     private static ArkWalletContractEntity NewEntity(ArkContractEntity source) => new()
@@ -143,6 +152,7 @@ public class EfCoreContractStorage : IContractStorage
         Type = source.Type,
         ContractData = source.AdditionalData,
         Metadata = source.Metadata,
+        Scope = source.Scope,
         CreatedAt = source.CreatedAt
     };
 
@@ -222,7 +232,8 @@ public class EfCoreContractStorage : IContractStorage
             CreatedAt: entity.CreatedAt
         )
         {
-            Metadata = entity.Metadata
+            Metadata = entity.Metadata,
+            Scope = entity.Scope
         };
     }
 

--- a/NArk.Swaps/Recovery/WalletRecoveryService.cs
+++ b/NArk.Swaps/Recovery/WalletRecoveryService.cs
@@ -83,7 +83,7 @@ public class WalletRecoveryService(
         var contracts = await contractStorage.GetContracts(
             walletIds: [walletId], cancellationToken: cancellationToken);
         var offchainScripts = contracts
-            .Where(c => c.Type != ArkBoardingContract.ContractType)
+            .Where(c => (c.Scope & ContractScope.Offchain) != 0)
             .Select(c => c.Script)
             .ToHashSet();
         var vtxosSynced = offchainScripts.Count > 0

--- a/NArk.Tests/BoardingUtxoSyncServiceTests.cs
+++ b/NArk.Tests/BoardingUtxoSyncServiceTests.cs
@@ -55,6 +55,7 @@ public class BoardingUtxoSyncServiceTests
                 Arg.Any<string?>(),
                 Arg.Any<int?>(),
                 Arg.Any<int?>(),
+                Arg.Any<ContractScope?>(),
                 Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyCollection<ArkContractEntity>>(entities));
     }

--- a/NArk.Tests/ContractScopeTests.cs
+++ b/NArk.Tests/ContractScopeTests.cs
@@ -1,0 +1,147 @@
+using NArk.Abstractions;
+using NArk.Abstractions.Contracts;
+using NArk.Abstractions.Extensions;
+using NArk.Core.Contracts;
+using NArk.Core.Enums;
+using NArk.Core.Extensions;
+using NBitcoin;
+using NBitcoin.Scripting;
+
+namespace NArk.Tests;
+
+[TestFixture]
+public class ContractScopeTests
+{
+    private static readonly OutputDescriptor TestServerKey =
+        KeyExtensions.ParseOutputDescriptor(
+            "03aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88",
+            Network.RegTest);
+
+    private static readonly OutputDescriptor TestUserKey =
+        KeyExtensions.ParseOutputDescriptor(
+            "030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4",
+            Network.RegTest);
+
+    private static readonly OutputDescriptor TestDelegateKey =
+        KeyExtensions.ParseOutputDescriptor(
+            "021e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b",
+            Network.RegTest);
+
+    private static readonly OutputDescriptor TestReceiverKey =
+        KeyExtensions.ParseOutputDescriptor(
+            "02a1633cafcc01ebfb6d78e39f687a1f0995c62fc95f51ead10a02ee0be551b5dc",
+            Network.RegTest);
+
+    private static readonly Sequence DefaultExitDelay = new(144);
+
+    private static ArkBoardingContract CreateBoarding()
+        => new(TestServerKey, DefaultExitDelay, TestUserKey);
+
+    private static ArkPaymentContract CreatePayment()
+        => new(TestServerKey, DefaultExitDelay, TestUserKey);
+
+    private static HashLockedArkPaymentContract CreateHashLockPayment()
+        => new(TestServerKey, DefaultExitDelay, TestUserKey,
+            Convert.FromHexString("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"),
+            HashLockTypeOption.Sha256);
+
+    private static ArkDelegateContract CreateDelegate()
+        => new(TestServerKey, DefaultExitDelay, TestUserKey, TestDelegateKey);
+
+    private static VHTLCContract CreateVhtlc()
+        => new(TestServerKey, TestUserKey, TestReceiverKey,
+            Convert.FromHexString("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"),
+            new LockTime(1000),
+            new Sequence(144),
+            new Sequence(144),
+            new Sequence(144));
+
+    private static ArkNoteContract CreateNote()
+        => new(50_000, Convert.FromHexString("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"));
+
+    private static UnknownArkContract CreateUnknown()
+        => new(
+            ArkAddress.Parse(
+                "tark1qz4d2t2czchfaml2l3ad3gwde2qxpd0srhc7wkpnvtg99cnxyz8c3pnvvhnhumhwhqthmlxmdryakwx99s6508y8dunj9sty2p5mr7unh5re63"),
+            TestServerKey,
+            mainnet: false);
+
+    [Test]
+    public void BoardingContract_DefaultScope_IsOnchain()
+    {
+        Assert.That(CreateBoarding().DefaultScope, Is.EqualTo(ContractScope.Onchain));
+    }
+
+    [Test]
+    public void PaymentContract_DefaultScope_IsOffchain()
+    {
+        Assert.That(CreatePayment().DefaultScope, Is.EqualTo(ContractScope.Offchain));
+    }
+
+    [Test]
+    public void HashLockPaymentContract_DefaultScope_IsOffchain()
+    {
+        Assert.That(CreateHashLockPayment().DefaultScope, Is.EqualTo(ContractScope.Offchain));
+    }
+
+    [Test]
+    public void DelegateContract_DefaultScope_IsOffchain()
+    {
+        Assert.That(CreateDelegate().DefaultScope, Is.EqualTo(ContractScope.Offchain));
+    }
+
+    [Test]
+    public void VhtlcContract_DefaultScope_IsOffchain()
+    {
+        Assert.That(CreateVhtlc().DefaultScope, Is.EqualTo(ContractScope.Offchain));
+    }
+
+    [Test]
+    public void NoteContract_DefaultScope_IsOffchain()
+    {
+        Assert.That(CreateNote().DefaultScope, Is.EqualTo(ContractScope.Offchain));
+    }
+
+    [Test]
+    public void UnknownContract_DefaultScope_IsOffchain()
+    {
+        Assert.That(CreateUnknown().DefaultScope, Is.EqualTo(ContractScope.Offchain));
+    }
+
+    [Test]
+    public void ToEntity_NullOverride_UsesDefaultScope()
+    {
+        var boarding = CreateBoarding().ToEntity("w");
+        Assert.That(boarding.Scope, Is.EqualTo(ContractScope.Onchain));
+
+        var payment = CreatePayment().ToEntity("w");
+        Assert.That(payment.Scope, Is.EqualTo(ContractScope.Offchain));
+    }
+
+    [Test]
+    public void ToEntity_ExplicitOverride_UsesOverride()
+    {
+        // Boarding defaults Onchain; override to Offchain should win.
+        var overridden = CreateBoarding().ToEntity("w", scopeOverride: ContractScope.Offchain);
+        Assert.That(overridden.Scope, Is.EqualTo(ContractScope.Offchain));
+
+        // Payment defaults Offchain; override to Both should win.
+        var both = CreatePayment().ToEntity("w", scopeOverride: ContractScope.Onchain | ContractScope.Offchain);
+        Assert.That(both.Scope, Is.EqualTo(ContractScope.Onchain | ContractScope.Offchain));
+    }
+
+    [Test]
+    public void Flags_Both_IsOnchainOrOffchain()
+    {
+        var both = ContractScope.Onchain | ContractScope.Offchain;
+
+        // A "Both" value satisfies both an Onchain-include and an Offchain-include
+        // bitwise check — the same predicate EF Core translates to SQL.
+        Assert.That((both & ContractScope.Onchain) == ContractScope.Onchain, Is.True);
+        Assert.That((both & ContractScope.Offchain) == ContractScope.Offchain, Is.True);
+
+        // A pure Onchain value satisfies the Onchain check but not the Offchain check.
+        Assert.That((ContractScope.Onchain & ContractScope.Onchain) == ContractScope.Onchain, Is.True);
+        Assert.That((ContractScope.Onchain & ContractScope.Offchain) == ContractScope.Offchain, Is.False);
+    }
+}

--- a/NArk.Tests/EfCoreContractScopeStorageTests.cs
+++ b/NArk.Tests/EfCoreContractScopeStorageTests.cs
@@ -1,0 +1,139 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NArk.Abstractions.Contracts;
+using NArk.Storage.EfCore;
+using NArk.Storage.EfCore.Storage;
+
+namespace NArk.Tests;
+
+/// <summary>
+/// Pins the SQLite behaviour of the <c>GetContracts(scope:)</c> filter. Uses a real
+/// SQLite provider (not InMemory) on purpose: the bitwise <c>(Scope &amp; s) == s</c>
+/// predicate must translate to SQL. InMemory would client-evaluate it and silently
+/// hide a non-translatable query (the <c>HasFlag</c>-vs-bitwise trap).
+/// </summary>
+[TestFixture]
+public class EfCoreContractScopeStorageTests
+{
+    private SqliteConnection _connection = null!;
+    private DbContextOptions<TestArkDbContext> _dbOptions = null!;
+    private EfCoreContractStorage _storage = null!;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _dbOptions = new DbContextOptionsBuilder<TestArkDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        await using (var ctx = new TestArkDbContext(_dbOptions))
+        {
+            await ctx.Database.EnsureCreatedAsync();
+            ctx.Add(new Storage.EfCore.Entities.ArkWalletEntity { Id = "w", Wallet = "mnemonic" });
+            await ctx.SaveChangesAsync();
+        }
+
+        _storage = new EfCoreContractStorage(new TestArkDbContextFactory(_dbOptions), new ArkStorageOptions());
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _connection.Dispose();
+    }
+
+    private async Task SeedAsync(string script, ContractScope scope)
+    {
+        await _storage.SaveContract(new ArkContractEntity(
+            Script: script,
+            ActivityState: ContractActivityState.Active,
+            Type: "t-" + script,
+            AdditionalData: new Dictionary<string, string>(),
+            WalletIdentifier: "w",
+            CreatedAt: DateTimeOffset.UtcNow)
+        {
+            Scope = scope
+        });
+    }
+
+    [Test]
+    public async Task GetContracts_ScopeOnchain_ReturnsOnlyOnchainAndBoth()
+    {
+        await SeedAsync("onchain1", ContractScope.Onchain);
+        await SeedAsync("offchain1", ContractScope.Offchain);
+        await SeedAsync("both1", ContractScope.Onchain | ContractScope.Offchain);
+
+        var result = await _storage.GetContracts(scope: ContractScope.Onchain);
+
+        var scripts = result.Select(c => c.Script).ToHashSet();
+        Assert.That(scripts, Does.Contain("onchain1"));
+        Assert.That(scripts, Does.Contain("both1"));
+        Assert.That(scripts, Does.Not.Contain("offchain1"));
+    }
+
+    [Test]
+    public async Task GetContracts_ScopeOffchain_ReturnsOnlyOffchainAndBoth()
+    {
+        await SeedAsync("onchain1", ContractScope.Onchain);
+        await SeedAsync("offchain1", ContractScope.Offchain);
+        await SeedAsync("both1", ContractScope.Onchain | ContractScope.Offchain);
+
+        var result = await _storage.GetContracts(scope: ContractScope.Offchain);
+
+        var scripts = result.Select(c => c.Script).ToHashSet();
+        Assert.That(scripts, Does.Contain("offchain1"));
+        Assert.That(scripts, Does.Contain("both1"));
+        Assert.That(scripts, Does.Not.Contain("onchain1"));
+    }
+
+    [Test]
+    public async Task GetContracts_NoScope_ReturnsAll()
+    {
+        await SeedAsync("onchain1", ContractScope.Onchain);
+        await SeedAsync("offchain1", ContractScope.Offchain);
+
+        var result = await _storage.GetContracts();
+
+        var scripts = result.Select(c => c.Script).ToHashSet();
+        Assert.That(scripts, Does.Contain("onchain1"));
+        Assert.That(scripts, Does.Contain("offchain1"));
+    }
+
+    [Test]
+    public async Task GetContracts_ScopeFilter_TranslatesToSqlOnSqlite()
+    {
+        // Real SQLite: if the bitwise predicate didn't translate, this would throw
+        // (or, on InMemory, silently client-evaluate). Asserting it runs is the point.
+        await SeedAsync("onchain1", ContractScope.Onchain);
+
+        Assert.DoesNotThrowAsync(async () =>
+            await _storage.GetContracts(scope: ContractScope.Onchain));
+    }
+
+    [Test]
+    public async Task GetContracts_RoundTripsScope()
+    {
+        await SeedAsync("onchain1", ContractScope.Onchain);
+
+        var result = await _storage.GetContracts(scripts: new[] { "onchain1" });
+        Assert.That(result.Single().Scope, Is.EqualTo(ContractScope.Onchain));
+    }
+
+    private class TestArkDbContext(DbContextOptions<TestArkDbContext> options) : DbContext(options)
+    {
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+            // SQLite refuses ORDER BY on DateTimeOffset columns; opt into the
+            // ticks-based storage (same as the SQLite sample wallet) so GetContracts'
+            // OrderByDescending(CreatedAt) runs server-side.
+            => modelBuilder.ConfigureArkEntities(o => o.StoreDateTimeOffsetAsTicks = true);
+    }
+
+    private class TestArkDbContextFactory(DbContextOptions<TestArkDbContext> options) : IArkDbContextFactory
+    {
+        public Task<DbContext> CreateDbContextAsync(CancellationToken ct = default)
+            => Task.FromResult<DbContext>(new TestArkDbContext(options));
+    }
+}

--- a/NArk.Tests/OnchainSweepServiceTests.cs
+++ b/NArk.Tests/OnchainSweepServiceTests.cs
@@ -142,6 +142,7 @@ public class OnchainSweepServiceTests
                 Arg.Any<string?>(),
                 Arg.Any<int?>(),
                 Arg.Any<int?>(),
+                Arg.Any<ContractScope?>(),
                 Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyCollection<ArkContractEntity>>(entities));
     }
@@ -249,6 +250,7 @@ public class OnchainSweepServiceTests
             Arg.Any<string?>(),
             Arg.Any<int?>(),
             Arg.Any<int?>(),
+            Arg.Any<ContractScope?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -325,6 +327,7 @@ public class OnchainSweepServiceTests
             Arg.Any<string?>(),
             Arg.Any<int?>(),
             Arg.Any<int?>(),
+            Arg.Any<ContractScope?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -357,6 +360,7 @@ public class OnchainSweepServiceTests
             Arg.Any<string?>(),
             Arg.Any<int?>(),
             Arg.Any<int?>(),
+            Arg.Any<ContractScope?>(),
             Arg.Any<CancellationToken>());
     }
 }

--- a/README.md
+++ b/README.md
@@ -638,6 +638,36 @@ var contract = await contractService.DeriveContract(
 // The contract's script can be converted to an ArkAddress for display
 ```
 
+### Contract scope (on-chain / off-chain)
+
+Every contract type declares which layer(s) its funds live on via
+`ArkContract.DefaultScope`, a `[Flags] ContractScope` (`Onchain`, `Offchain`, or
+both). Boarding contracts are `Onchain`; payment, VHTLC, delegate, hash-lock,
+note and unknown contracts are `Offchain`. This replaces ad-hoc
+`Type == "Boarding"` checks — sync, sweep and recovery ask the scope instead.
+
+The resolved scope is persisted on each contract (`ArkContractEntity.Scope`) and
+is SQL-queryable. Filter by scope through `IContractStorage.GetContracts`:
+
+```csharp
+// On-chain contracts to poll/sweep (boarding UTXOs, etc.)
+var onchain = await contractStorage.GetContracts(scope: ContractScope.Onchain);
+
+// Off-chain contracts (VTXOs) — also matches dual-scope contracts
+var offchain = await contractStorage.GetContracts(scope: ContractScope.Offchain);
+```
+
+The filter translates to a SQL bitwise predicate, so a dual-scope contract
+(`Onchain | Offchain`) is returned by both queries. A per-instance override can
+be supplied at persistence time via `ArkContract.ToEntity(scopeOverride: …)`;
+when omitted, the type's `DefaultScope` is used.
+
+> EF Core note: query scope with the bitwise form (the SDK does this internally);
+> `Enum.HasFlag` does **not** translate to SQL. The `Scope` column ships via the
+> entity configuration — consumers that manage their own schema with EF
+> migrations should add a migration that creates the column (default `Offchain`)
+> and backfills existing boarding rows to `Onchain`.
+
 ## HD Wallet Recovery
 
 When importing an HD wallet from its mnemonic, the SDK has no record of contracts the previous instance derived. `HdWalletRecoveryService` rebuilds that state by sweeping derivation indices via gap-limit and asking each registered `IContractDiscoveryProvider` whether it ever saw activity at that index.


### PR DESCRIPTION
## What

Makes a contract's layer — on-chain (boarding UTXOs) vs off-chain (VTXOs) — a first-class property instead of scattered `Type == "Boarding"` checks.

- `[Flags] ContractScope { Onchain = 1, Offchain = 2 }` (`Both = Onchain | Offchain`).
- `ArkContract.DefaultScope` (**abstract** — every contract type must declare its scope, so a new type can't silently inherit the wrong default). Boarding ⇒ `Onchain`; Payment, HashLockPayment, Delegate, VHTLC, Note, Unknown, Generic ⇒ `Offchain`.
- Resolved scope persisted on `ArkContractEntity.Scope` / `ArkWalletContractEntity` (indexed). `ToEntity(scopeOverride:)` is the per-instance escape hatch (`Scope = scopeOverride ?? DefaultScope`); nothing sets it yet (YAGNI).
- `IContractStorage.GetContracts(scope:)` filters via the SQL-translatable bitwise predicate `(Scope & s) == s` — **not** `HasFlag` (EF Core doesn't translate it).
- Consumers migrated off the boarding-type check: `BoardingUtxoPollService`, `BoardingUtxoSyncService`, `OnchainSweepService` → `scope: Onchain`; `WalletRecoveryService` → off-chain bitwise filter.

## Tests (TDD)

- Per-type `DefaultScope`, `ToEntity` override resolution, flags semantics.
- A **SQLite-backed** `GetContracts(scope:)` test (real SQLite, not InMemory — InMemory client-evaluates and would hide a non-SQL-translatable query). Verifies the bitwise predicate translates and that a dual-scope contract matches both filters.
- `dotnet build NArk.sln` clean; `dotnet test NArk.Tests` → 437 passing.

## Schema / migration note

`NArk.Storage.EfCore` is provider-agnostic with **no migrations history** (consumers own their schema via `EnsureCreated` or their own migrations). The `Scope` column therefore ships via entity configuration (`ArkWalletContractEntity.Configure`, indexed). Consumers that manage their schema with EF migrations should add a migration creating the column (default `Offchain`) and backfilling existing boarding rows to `Onchain` — documented in the README.

## Notes

- `GenericArkContract` (a concrete `: ArkContract` subclass) also implements `DefaultScope` ⇒ `Offchain` (mandatory since the property is abstract); preserves its prior implicit behavior.
- README gains a 'Contract scope' section.