### PR TITLE
fix(core): limit vtxos per intent to 50

### DIFF
--- a/NArk.Core/ArkTransactionLimits.cs
+++ b/NArk.Core/ArkTransactionLimits.cs
@@ -1,0 +1,20 @@
+namespace NArk.Core;
+
+/// <summary>
+/// Client-side guardrails mirroring the Arkade server's transaction limits.
+/// </summary>
+public static class ArkTransactionLimits
+{
+    /// <summary>
+    /// Maximum number of VTXO inputs to include in a single Arkade transaction
+    /// or intent. The Arkade server rejects transactions and intent proofs whose
+    /// weight exceeds its configured <c>max_tx_weight</c> (error code
+    /// <c>TX_TOO_LARGE</c>); this conservative input cap keeps generated
+    /// transactions under the default limit.
+    /// </summary>
+    /// <remarks>
+    /// TODO: replace the fixed cap with a real weight estimate driven by the
+    /// server's advertised <c>max_tx_weight</c> (available via GetInfo).
+    /// </remarks>
+    public const int MaxVtxosPerArkTransaction = 50;
+}

--- a/NArk.Core/CoinSelector/DefaultCoinSelector.cs
+++ b/NArk.Core/CoinSelector/DefaultCoinSelector.cs
@@ -16,13 +16,15 @@ public class DefaultCoinSelector : ICoinSelector
     /// <param name="dustThreshold">Dust threshold from operator terms</param>
     /// <param name="currentSubDustOutputs">Whether the user explicitly uses subdust change</param>
     /// <param name="maxOpReturnOutputs">Maximum OP_RETURN outputs allowed per transaction</param>
+    /// <param name="maxInputs">Maximum number of inputs the selection may use, or null for no limit</param>
     /// <returns>Selected coins or null if impossible</returns>
     public IReadOnlyCollection<ArkCoin> SelectCoins(
         List<ArkCoin> availableCoins,
         Money targetAmount,
         Money dustThreshold,
         int currentSubDustOutputs,
-        int maxOpReturnOutputs = 1)
+        int maxOpReturnOutputs = 1,
+        int? maxInputs = null)
     {
         if (availableCoins.Count == 0)
             throw new NotEnoughFundsException("Not enough funds to create transaction", null, targetAmount);
@@ -47,6 +49,15 @@ public class DefaultCoinSelector : ICoinSelector
                     break;
             }
 
+            if (maxInputs is { } cap && selected.Count >= cap)
+            {
+                // Target covered but change is awkward: stop here and let the
+                // strategies below sort out the change instead of adding inputs.
+                if (currentTotal >= targetAmount)
+                    break;
+                throw new TooManyInputsException(cap);
+            }
+
             selected.Add(coin);
             currentTotal += coin.TxOut.Value;
         }
@@ -58,14 +69,17 @@ public class DefaultCoinSelector : ICoinSelector
         if (finalChange > Money.Zero && finalChange < dustThreshold && !canAddSubdust)
         {
             // Strategy 2: Try adding one more coin to push change above dust threshold
-            var remainingCoins = availableCoins.Except(selected).ToList();
-            foreach (var extraCoin in remainingCoins)
+            if (selected.Count < (maxInputs ?? int.MaxValue))
             {
-                var newChange = finalChange + extraCoin.TxOut.Value;
-                if (newChange >= dustThreshold)
+                var remainingCoins = availableCoins.Except(selected).ToList();
+                foreach (var extraCoin in remainingCoins)
                 {
-                    selected.Add(extraCoin);
-                    return selected;
+                    var newChange = finalChange + extraCoin.TxOut.Value;
+                    if (newChange >= dustThreshold)
+                    {
+                        selected.Add(extraCoin);
+                        return selected;
+                    }
                 }
             }
 
@@ -77,6 +91,14 @@ public class DefaultCoinSelector : ICoinSelector
             }
 
             // Strategy 4: If we can't avoid subdust, use all coins to maximize change
+            // (capped to the largest maxInputs coins when a limit applies)
+            if (maxInputs is { } limit && availableCoins.Count > limit)
+            {
+                var capped = availableCoins.OrderByDescending(c => c.TxOut.Value).Take(limit).ToList();
+                if (capped.Sum(c => c.TxOut.Value) < targetAmount)
+                    throw new TooManyInputsException(limit);
+                return capped;
+            }
             return availableCoins;
         }
 
@@ -93,10 +115,11 @@ public class DefaultCoinSelector : ICoinSelector
         IReadOnlyList<AssetRequirement> assetRequirements,
         Money dustThreshold,
         int currentSubDustOutputs,
-        int maxOpReturnOutputs = 1)
+        int maxOpReturnOutputs = 1,
+        int? maxInputs = null)
     {
         if (assetRequirements.Count == 0)
-            return SelectCoins(availableCoins, targetBtcAmount, dustThreshold, currentSubDustOutputs, maxOpReturnOutputs);
+            return SelectCoins(availableCoins, targetBtcAmount, dustThreshold, currentSubDustOutputs, maxOpReturnOutputs, maxInputs);
 
         var selected = new HashSet<ArkCoin>(ReferenceEqualityComparer.Instance);
         var btcFromAssetCoins = Money.Zero;
@@ -114,6 +137,9 @@ public class DefaultCoinSelector : ICoinSelector
             {
                 if (assetTotal >= requirement.Amount)
                     break;
+
+                if (maxInputs is { } cap && selected.Count >= cap)
+                    throw new TooManyInputsException(cap);
 
                 selected.Add(coin);
                 btcFromAssetCoins += coin.TxOut.Value;
@@ -138,7 +164,8 @@ public class DefaultCoinSelector : ICoinSelector
             throw new NotEnoughFundsException("Not enough BTC funds to create transaction", null, remainingBtc);
         }
 
-        var btcSelected = SelectCoins(remainingCoins, remainingBtc, dustThreshold, currentSubDustOutputs, maxOpReturnOutputs);
+        var btcSelected = SelectCoins(remainingCoins, remainingBtc, dustThreshold, currentSubDustOutputs, maxOpReturnOutputs,
+            maxInputs is { } maxTotal ? maxTotal - selected.Count : null);
         foreach (var coin in btcSelected)
             selected.Add(coin);
 

--- a/NArk.Core/CoinSelector/ICoinSelector.cs
+++ b/NArk.Core/CoinSelector/ICoinSelector.cs
@@ -17,18 +17,33 @@ public interface ICoinSelector
     /// <param name="targetAmount">Amount to cover.</param>
     /// <param name="dustThreshold">Minimum value for a change output.</param>
     /// <param name="currentSubDustOutputs">Number of existing sub-dust outputs in the transaction.</param>
+    /// <param name="maxOpReturnOutputs">Maximum OP_RETURN outputs allowed per transaction.</param>
+    /// <param name="maxInputs">
+    /// Maximum number of inputs the selection may use, or <c>null</c> for no limit.
+    /// The Arkade server rejects transactions above its <c>max_tx_weight</c>
+    /// (<c>TX_TOO_LARGE</c>), so spends should bound their input count.
+    /// Implementations throw <see cref="TooManyInputsException"/> when the target
+    /// cannot be covered within the cap.
+    /// </param>
     IReadOnlyCollection<ArkCoin> SelectCoins(
         List<ArkCoin> availableCoins,
         Money targetAmount,
         Money dustThreshold,
         int currentSubDustOutputs,
-        int maxOpReturnOutputs = 1);
+        int maxOpReturnOutputs = 1,
+        int? maxInputs = null);
 
+    /// <summary>
+    /// Asset-aware coin selection: selects coins carrying the required assets first,
+    /// then fills the remaining BTC target. See the BTC-only overload for parameter
+    /// semantics, including <paramref name="maxInputs"/>.
+    /// </summary>
     IReadOnlyCollection<ArkCoin> SelectCoins(
         List<ArkCoin> availableCoins,
         Money targetBtcAmount,
         IReadOnlyList<AssetRequirement> assetRequirements,
         Money dustThreshold,
         int currentSubDustOutputs,
-        int maxOpReturnOutputs = 1);
+        int maxOpReturnOutputs = 1,
+        int? maxInputs = null);
 }

--- a/NArk.Core/CoinSelector/TooManyInputsException.cs
+++ b/NArk.Core/CoinSelector/TooManyInputsException.cs
@@ -1,0 +1,15 @@
+namespace NArk.Core.CoinSelector;
+
+/// <summary>
+/// Thrown when a spend cannot be funded without exceeding the maximum number of
+/// VTXO inputs allowed in a single Arkade transaction. The wallet holds enough
+/// funds overall, but they are fragmented across too many small VTXOs — wait for
+/// the intent scheduler to consolidate them, or send a smaller amount.
+/// </summary>
+public class TooManyInputsException(int maxInputs)
+    : Exception(
+        $"Funding this spend requires more than {maxInputs} VTXO inputs; the Arkade server would reject the transaction as too large (TX_TOO_LARGE). Consolidate VTXOs first or send a smaller amount.")
+{
+    /// <summary>The input cap that could not be satisfied.</summary>
+    public int MaxInputs { get; } = maxInputs;
+}

--- a/NArk.Core/Services/SimpleIntentScheduler.cs
+++ b/NArk.Core/Services/SimpleIntentScheduler.cs
@@ -14,10 +14,6 @@ namespace NArk.Core.Services;
 
 public class SimpleIntentScheduler(IFeeEstimator feeEstimator, IClientTransport clientTransport, IContractService contractService, IBitcoinBlockchain chainTimeProvider, IOptions<SimpleIntentSchedulerOptions> options, ILogger<SimpleIntentScheduler>? logger = null) : IIntentScheduler
 {
-
-    //TODO(11.06.2026): maybe estimate tx size?
-    private const int MaxVtxosPerIntent = 50;
-    
     public async Task<IReadOnlyCollection<ArkIntentSpec>> GetIntentsToSubmit(
         IReadOnlyCollection<ArkCoin> unspentVtxos, CancellationToken cancellationToken = default)
     {
@@ -57,7 +53,7 @@ public class SimpleIntentScheduler(IFeeEstimator feeEstimator, IClientTransport 
             */
             .ToDictionary(
                 g => g.Key,
-                g => g.OrderByDescending(v => v.Amount).Chunk(MaxVtxosPerIntent).ToArray()
+                g => g.OrderByDescending(v => v.Amount).Chunk(ArkTransactionLimits.MaxVtxosPerArkTransaction).ToArray()
             );
 
         List<ArkIntentSpec> intentSpecs = [];
@@ -72,7 +68,7 @@ public class SimpleIntentScheduler(IFeeEstimator feeEstimator, IClientTransport 
                 var inputsSumAfterBeforeFees = chunk.Sum(c => c.Amount);
                 if (inputsSumAfterBeforeFees < serverInfo.Dust)
                 {
-                    logger?.LogWarning("Wallet {WalletId} has inputs below dust threshold - skipping until quota above dust", walletId);
+                    logger?.LogWarning("Skipping a {CoinCount}-input chunk for wallet {WalletId}: chunk sum is below the dust threshold", chunk.Length, walletId);
                     continue;
                 }
                 var specBeforeFees =

--- a/NArk.Core/Services/SimpleIntentScheduler.cs
+++ b/NArk.Core/Services/SimpleIntentScheduler.cs
@@ -6,7 +6,6 @@ using NArk.Abstractions.Contracts;
 using NArk.Abstractions.Fees;
 using NArk.Abstractions.Intents;
 using NArk.Abstractions.Wallets;
-using NArk.Core.Contracts;
 using NArk.Core.Models.Options;
 using NArk.Core.Transport;
 using NBitcoin;
@@ -15,6 +14,10 @@ namespace NArk.Core.Services;
 
 public class SimpleIntentScheduler(IFeeEstimator feeEstimator, IClientTransport clientTransport, IContractService contractService, IBitcoinBlockchain chainTimeProvider, IOptions<SimpleIntentSchedulerOptions> options, ILogger<SimpleIntentScheduler>? logger = null) : IIntentScheduler
 {
+
+    //TODO(11.06.2026): maybe estimate tx size?
+    private const int MaxVtxosPerIntent = 50;
+    
     public async Task<IReadOnlyCollection<ArkIntentSpec>> GetIntentsToSubmit(
         IReadOnlyCollection<ArkCoin> unspentVtxos, CancellationToken cancellationToken = default)
     {
@@ -42,66 +45,79 @@ public class SimpleIntentScheduler(IFeeEstimator feeEstimator, IClientTransport 
                 // Skip unconfirmed boarding UTXOs (no expiry yet) — arkd rejects unconfirmed inputs.
                 (v.Unrolled && v.ExpiresAt is not null) ||
                 v.IsRecoverable(chainTime) ||
-                (v.ExpiresAt is { } exp && options.Value.Threshold is { } thresh && exp - thresh < chainTime.Timestamp) ||
-                (v.ExpiresAtHeight is { } height && options.Value.ThresholdHeight is { } threshHeight && height - threshHeight < chainTime.Height)
+                (v.ExpiresAt is { } exp && options.Value.Threshold is { } thresh &&
+                 exp - thresh < chainTime.Timestamp) ||
+                (v.ExpiresAtHeight is { } height && options.Value.ThresholdHeight is { } threshHeight &&
+                 height - threshHeight < chainTime.Height)
             )
-            .GroupBy(v => v.WalletIdentifier);
+            .GroupBy(v => v.WalletIdentifier)
+            /*
+             TODO(11.06.2026): maybe we could solve tail redistribution problem with remaining sub-dust buckets
+             by swapping bigger vtxos from big buckets to sub-dust buckets 
+            */
+            .ToDictionary(
+                g => g.Key,
+                g => g.OrderByDescending(v => v.Amount).Chunk(MaxVtxosPerIntent).ToArray()
+            );
 
         List<ArkIntentSpec> intentSpecs = [];
 
-        foreach (var g in coins)
+        foreach (var (walletId, chunks) in coins)
         {
-            //TODO: we are reserving many addresses this way needlessly, prob need use a last address here or unreserve somehow?
-            // var outputContract = await contractService.DeriveContract(g.Key,NextContractPurpose.SendToSelf, cancellationToken);
-
-            var inputsSumAfterBeforeFees = g.Sum(c => c.Amount);
-            if (inputsSumAfterBeforeFees < serverInfo.Dust)
+            foreach (var chunk in chunks)
             {
-                logger?.LogWarning("Wallet {WalletId} has inputs below dust threshold - skipping until quota above dust", g.Key);
-                continue;
+                //TODO: we are reserving many addresses this way needlessly, prob need use a last address here or unreserve somehow?
+                // var outputContract = await contractService.DeriveContract(walletId, NextContractPurpose.SendToSelf, cancellationToken);
+
+                var inputsSumAfterBeforeFees = chunk.Sum(c => c.Amount);
+                if (inputsSumAfterBeforeFees < serverInfo.Dust)
+                {
+                    logger?.LogWarning("Wallet {WalletId} has inputs below dust threshold - skipping until quota above dust", walletId);
+                    continue;
+                }
+                var specBeforeFees =
+                    new ArkIntentSpec(
+                        chunk,
+                        [
+                            // new ArkTxOut(
+                            //     ArkTxOutType.Vtxo,
+                            //     inputsSumAfterBeforeFees,
+                            //     outputContract.GetArkAddress()
+                            // )
+                        ],
+                        DateTimeOffset.UtcNow,
+                        DateTimeOffset.UtcNow.AddHours(1)
+                    );
+
+                var fees = await feeEstimator.EstimateFeeAsync(specBeforeFees, cancellationToken);
+
+                var inputsSumAfterAfterFees = inputsSumAfterBeforeFees - fees;
+
+                if (inputsSumAfterAfterFees < Money.Zero)
+                {
+                    logger?.LogDebug("Skipping wallet {WalletId} chunk: inputs sum after fees is negative", walletId);
+                    continue;
+                }
+
+                var inputContracts = chunk.Select(c => c.Contract).ToArray();
+                var outputContract = await contractService.DeriveContract(walletId, NextContractPurpose.SendToSelf, inputContracts, ContractActivityState.Inactive, cancellationToken: cancellationToken);
+                var finalSpec =
+                    new ArkIntentSpec(
+                        chunk,
+                        [
+                            new ArkTxOut(
+                                ArkTxOutType.Vtxo,
+                                inputsSumAfterAfterFees,
+                                outputContract.GetArkAddress()
+                            )
+                        ],
+                        null,
+                        null
+                    );
+
+                intentSpecs.Add(finalSpec);
+                logger?.LogDebug("Created intent spec for wallet {WalletId} with {CoinCount} coins", walletId, chunk.Length);
             }
-            var specBeforeFees =
-                new ArkIntentSpec(
-                    g.ToArray(),
-                    [
-                        // new ArkTxOut(
-                        //     ArkTxOutType.Vtxo,
-                        //     inputsSumAfterBeforeFees,
-                        //     outputContract.GetArkAddress()
-                        // )
-                    ],
-                    DateTimeOffset.UtcNow,
-                    DateTimeOffset.UtcNow.AddHours(1)
-                );
-
-            var fees = await feeEstimator.EstimateFeeAsync(specBeforeFees, cancellationToken);
-
-            var inputsSumAfterAfterFees = inputsSumAfterBeforeFees - fees;
-
-            if (inputsSumAfterAfterFees < Money.Zero)
-            {
-                logger?.LogDebug("Skipping wallet {WalletId}: inputs sum after fees is negative", g.Key);
-                continue;
-            }
-            
-            var inputContracts = g.Select(c => c.Contract).ToArray();
-            var outputContract = await contractService.DeriveContract(g.Key, NextContractPurpose.SendToSelf, inputContracts, ContractActivityState.Inactive, cancellationToken: cancellationToken);
-            var finalSpec =
-                new ArkIntentSpec(
-                    g.ToArray(),
-                    [
-                        new ArkTxOut(
-                            ArkTxOutType.Vtxo,
-                            inputsSumAfterAfterFees,
-                            outputContract.GetArkAddress()
-                        )
-                    ],
-                    null,
-                    null
-                );
-
-            intentSpecs.Add(finalSpec);
-            logger?.LogDebug("Created intent spec for wallet {WalletId} with {CoinCount} coins", g.Key, g.Count());
         }
 
         logger?.LogDebug("Generated {IntentSpecCount} intent specs", intentSpecs.Count);

--- a/NArk.Core/Services/SpendingService.cs
+++ b/NArk.Core/Services/SpendingService.cs
@@ -232,11 +232,14 @@ public class SpendingService(
         Money btcTarget = assetRequirements.Count > 0
             ? Money.Satoshis(outputsSumInSatoshis) + serverInfo.Dust  // extra dust for potential asset change output
             : Money.Satoshis(outputsSumInSatoshis);
+        // Bound the input count so the resulting Arkade transaction stays under the
+        // server's max_tx_weight — arkd rejects oversized offchain transactions with
+        // TX_TOO_LARGE, same as it does for oversized intent proofs.
         var selectedCoins = assetRequirements.Count > 0
             ? coinSelector.SelectCoins([.. coins], btcTarget, assetRequirements, serverInfo.Dust,
-                hasExplicitSubdustOutput, maxOpReturn)
+                hasExplicitSubdustOutput, maxOpReturn, ArkTransactionLimits.MaxVtxosPerArkTransaction)
             : coinSelector.SelectCoins([.. coins], outputsSumInSatoshis, serverInfo.Dust,
-                hasExplicitSubdustOutput, maxOpReturn);
+                hasExplicitSubdustOutput, maxOpReturn, ArkTransactionLimits.MaxVtxosPerArkTransaction);
         logger?.LogDebug("Selected {SelectedCount} coins for spending", selectedCoins.Count);
 
         try

--- a/NArk.Tests/DefaultCoinSelectorTests.cs
+++ b/NArk.Tests/DefaultCoinSelectorTests.cs
@@ -206,6 +206,62 @@ public class DefaultCoinSelectorTests
         Assert.That(result, Has.Count.EqualTo(1));
     }
 
+    [Test]
+    public void RespectsMaxInputs_WhenTargetReachableWithinCap()
+    {
+        var coins = new List<ArkCoin>
+        {
+            CreateCoin(5000),
+            CreateCoin(3000),
+            CreateCoin(2000),
+        };
+
+        var result = _selector.SelectCoins(coins, Money.Satoshis(7000), Money.Satoshis(546),
+            currentSubDustOutputs: 0, maxInputs: 2);
+
+        Assert.That(result, Has.Count.LessThanOrEqualTo(2));
+        Assert.That(result.Sum(c => c.Amount.Satoshi), Is.GreaterThanOrEqualTo(7000L));
+    }
+
+    [Test]
+    public void ThrowsTooManyInputs_WhenTargetNeedsMoreInputsThanCap()
+    {
+        // 10 x 1000 sats; covering 5000 needs 5 inputs but the cap is 4.
+        var coins = Enumerable.Range(0, 10).Select(_ => CreateCoin(1000)).ToList();
+
+        Assert.Throws<TooManyInputsException>(() =>
+            _selector.SelectCoins(coins, Money.Satoshis(5000), Money.Satoshis(546),
+                currentSubDustOutputs: 0, maxInputs: 4));
+    }
+
+    [Test]
+    public void ThrowsNotEnoughFunds_NotTooManyInputs_WhenBalanceInsufficient()
+    {
+        // A genuinely insufficient balance reports NotEnoughFunds even when a cap applies.
+        var coins = new List<ArkCoin> { CreateCoin(1000), CreateCoin(1000) };
+
+        Assert.Throws<NotEnoughFundsException>(() =>
+            _selector.SelectCoins(coins, Money.Satoshis(5000), Money.Satoshis(546),
+                currentSubDustOutputs: 0, maxInputs: 1));
+    }
+
+    [Test]
+    public void AssetSelection_RespectsMaxInputs_AcrossAssetAndBtcCoins()
+    {
+        // The asset requirement consumes the only allowed input; filling the
+        // remaining BTC target would need a second input → throws.
+        var coins = new List<ArkCoin>
+        {
+            CreateCoinWithAssets(500, [new VtxoAsset("asset_x", 100)]),
+            CreateCoin(3000),
+        };
+        var requirements = new List<AssetRequirement> { new("asset_x", 50) };
+
+        Assert.Throws<TooManyInputsException>(() =>
+            _selector.SelectCoins(coins, Money.Satoshis(2000), requirements, Money.Satoshis(546),
+                currentSubDustOutputs: 0, maxInputs: 1));
+    }
+
     private static ArkCoin CreateCoinWithAssets(long satoshis, IReadOnlyList<VtxoAsset> assets)
     {
         var key = new Key();

--- a/NArk.Tests/SimpleIntentSchedulerTests.cs
+++ b/NArk.Tests/SimpleIntentSchedulerTests.cs
@@ -1,0 +1,193 @@
+using Microsoft.Extensions.Options;
+using NArk.Abstractions;
+using NArk.Abstractions.Blockchain;
+using NArk.Abstractions.Contracts;
+using NArk.Abstractions.Extensions;
+using NArk.Abstractions.Fees;
+using NArk.Abstractions.Intents;
+using NArk.Abstractions.Wallets;
+using NArk.Core;
+using NArk.Core.Models.Options;
+using NArk.Core.Services;
+using NArk.Core.Transport;
+using NBitcoin;
+using NBitcoin.Scripting;
+using NBitcoin.Secp256k1;
+using NSubstitute;
+
+namespace NArk.Tests;
+
+[TestFixture]
+public class SimpleIntentSchedulerTests
+{
+    private IFeeEstimator _feeEstimator;
+    private IClientTransport _transport;
+    private IContractService _contractService;
+    private IBitcoinBlockchain _blockchain;
+    private SimpleIntentScheduler _scheduler;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _feeEstimator = Substitute.For<IFeeEstimator>();
+        _feeEstimator.EstimateFeeAsync(Arg.Any<ArkIntentSpec>(), Arg.Any<CancellationToken>())
+            .Returns(0L);
+
+        _transport = Substitute.For<IClientTransport>();
+        _transport.GetServerInfoAsync(Arg.Any<CancellationToken>())
+            .Returns(CreateServerInfo());
+
+        _blockchain = Substitute.For<IBitcoinBlockchain>();
+        _blockchain.GetChainTime(Arg.Any<CancellationToken>())
+            .Returns(new TimeHeight(DateTimeOffset.UtcNow, 100));
+
+        var outputContract = CreateContractSubstitute();
+        var serverKey = ECXOnlyPubKey.Create(new Key().PubKey.TaprootInternalKey.ToBytes());
+        var tweakedKey = ECXOnlyPubKey.Create(new Key().PubKey.TaprootInternalKey.ToBytes());
+        outputContract.GetArkAddress(Arg.Any<OutputDescriptor?>())
+            .Returns(new ArkAddress(tweakedKey, serverKey));
+
+        _contractService = Substitute.For<IContractService>();
+        _contractService.DeriveContract(
+                Arg.Any<string>(), Arg.Any<NextContractPurpose>(), Arg.Any<ArkContract[]>(),
+                Arg.Any<ContractActivityState>(), Arg.Any<Dictionary<string, string>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(outputContract);
+
+        _scheduler = new SimpleIntentScheduler(
+            _feeEstimator, _transport, _contractService, _blockchain,
+            Options.Create(new SimpleIntentSchedulerOptions { Threshold = TimeSpan.FromHours(1) }));
+    }
+
+    [Test]
+    public async Task Chunks_LargeWallet_IntoMultipleIntents()
+    {
+        // 120 eligible VTXOs must split into 50 + 50 + 20, not one oversized intent.
+        var coins = Enumerable.Range(0, 120).Select(_ => CreateCoin(1000)).ToList();
+
+        var intents = await _scheduler.GetIntentsToSubmit(coins);
+
+        Assert.That(intents, Has.Count.EqualTo(3));
+        var sizes = intents.Select(i => i.Coins.Length).OrderByDescending(x => x).ToArray();
+        Assert.That(sizes, Is.EqualTo(new[] { 50, 50, 20 }));
+        Assert.That(intents, Has.All.Matches<ArkIntentSpec>(i =>
+            i.Coins.Length <= ArkTransactionLimits.MaxVtxosPerArkTransaction));
+
+        // Every coin lands in exactly one intent.
+        var allOutpoints = intents.SelectMany(i => i.Coins).Select(c => c.Outpoint).ToList();
+        Assert.That(allOutpoints, Is.Unique);
+        Assert.That(allOutpoints, Has.Count.EqualTo(120));
+    }
+
+    [Test]
+    public async Task Skips_SubDustTailChunk_ButKeepsFullChunks()
+    {
+        // Coins sort descending before chunking, so the lone 100-sat coin lands
+        // in the tail chunk, whose sum is below dust (546) → only the full chunk
+        // becomes an intent.
+        var coins = Enumerable.Range(0, 50).Select(_ => CreateCoin(1000)).ToList();
+        coins.Add(CreateCoin(100));
+
+        var intents = await _scheduler.GetIntentsToSubmit(coins);
+
+        Assert.That(intents, Has.Count.EqualTo(1));
+        Assert.That(intents.First().Coins, Has.Length.EqualTo(50));
+    }
+
+    [Test]
+    public async Task Skips_FeeNegativeChunk_Individually()
+    {
+        // A flat 2000-sat fee per intent: the 2-coin tail chunk (1200 sats, above
+        // dust) goes fee-negative and is skipped; the 50-coin chunk still goes through.
+        _feeEstimator.EstimateFeeAsync(Arg.Any<ArkIntentSpec>(), Arg.Any<CancellationToken>())
+            .Returns(2000L);
+
+        var coins = Enumerable.Range(0, 50).Select(_ => CreateCoin(1000)).ToList();
+        coins.Add(CreateCoin(600));
+        coins.Add(CreateCoin(600));
+
+        var intents = await _scheduler.GetIntentsToSubmit(coins);
+
+        Assert.That(intents, Has.Count.EqualTo(1));
+        Assert.That(intents.First().Coins, Has.Length.EqualTo(50));
+    }
+
+    [Test]
+    public async Task GroupsByWallet_BeforeChunking()
+    {
+        // wallet-a: 60 coins → 50 + 10; wallet-b: 10 coins → 10. No intent mixes wallets.
+        var coins = Enumerable.Range(0, 60).Select(_ => CreateCoin(1000, "wallet-a")).ToList();
+        coins.AddRange(Enumerable.Range(0, 10).Select(_ => CreateCoin(1000, "wallet-b")));
+
+        var intents = await _scheduler.GetIntentsToSubmit(coins);
+
+        Assert.That(intents, Has.Count.EqualTo(3));
+        Assert.That(intents, Has.All.Matches<ArkIntentSpec>(i =>
+            i.Coins.Select(c => c.WalletIdentifier).Distinct().Count() == 1));
+    }
+
+    private static ArkServerInfo CreateServerInfo()
+    {
+        var serverKey = KeyExtensions.ParseOutputDescriptor(
+            "03aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88",
+            Network.RegTest);
+
+        var emptyMultisig = new NArk.Core.Scripts.NofNMultisigTapScript(Array.Empty<ECXOnlyPubKey>());
+
+        return new ArkServerInfo(
+            Dust: Money.Satoshis(546),
+            SignerKey: serverKey,
+            DeprecatedSigners: new Dictionary<ECXOnlyPubKey, long>(),
+            Network: Network.RegTest,
+            UnilateralExit: new Sequence(144),
+            BoardingExit: new Sequence(144),
+            ForfeitAddress: BitcoinAddress.Create("bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080", Network.RegTest),
+            ForfeitPubKey: ECXOnlyPubKey.Create(new Key().PubKey.TaprootInternalKey.ToBytes()),
+            CheckpointTapScript: new NArk.Core.Scripts.UnilateralPathArkTapScript(
+                new Sequence(144), emptyMultisig),
+            FeeTerms: new ArkOperatorFeeTerms("1", "0", "0", "0", "0"),
+            VtxoMinAmount: Money.Zero,
+            VtxoMaxAmount: Money.Coins(21_000_000m),
+            UtxoMinAmount: Money.Zero,
+            UtxoMaxAmount: Money.Coins(21_000_000m));
+    }
+
+    private static ArkContract CreateContractSubstitute()
+    {
+        return Substitute.For<ArkContract>(
+            KeyExtensions.ParseOutputDescriptor(
+                "03aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88",
+                Network.RegTest));
+    }
+
+    private static ArkCoin CreateCoin(long satoshis, string walletId = "test-wallet")
+    {
+        var key = new Key();
+        var script = key.PubKey.GetScriptPubKey(ScriptPubKeyType.TaprootBIP86);
+        var outpoint = new OutPoint(RandomUtils.GetUInt256(), 0);
+        var txOut = new TxOut(Money.Satoshis(satoshis), script);
+
+        var scriptBuilder = Substitute.For<NArk.Abstractions.Scripts.ScriptBuilder>();
+        scriptBuilder.BuildScript().Returns(Enumerable.Empty<Op>());
+        scriptBuilder.Build().Returns(new TapScript(Script.Empty, TapLeafVersion.C0));
+
+        // unrolled + non-null expiry makes the coin eligible via the filter's first
+        // clause, isolating these tests from the threshold/recoverability rules.
+        return new ArkCoin(
+            walletIdentifier: walletId,
+            contract: CreateContractSubstitute(),
+            birth: DateTimeOffset.UtcNow,
+            expiresAt: DateTimeOffset.UtcNow.AddMinutes(10),
+            expiresAtHeight: null,
+            outPoint: outpoint,
+            txOut: txOut,
+            signerDescriptor: null,
+            spendingScriptBuilder: scriptBuilder,
+            spendingConditionWitness: null,
+            lockTime: null,
+            sequence: new Sequence(1),
+            swept: false,
+            unrolled: true,
+            assets: null);
+    }
+}

--- a/docs/articles/spending.md
+++ b/docs/articles/spending.md
@@ -17,6 +17,16 @@ The `DefaultCoinSelector` uses a greedy algorithm that:
 3. Handles sub-dust change as OP_RETURN outputs
 4. Falls back to adding more coins if change is sub-dust and OP_RETURN limit is reached
 
+### Input Limit
+
+The Arkade server rejects transactions whose weight exceeds its configured
+`max_tx_weight` (`TX_TOO_LARGE`), so automatic coin selection is capped at
+`ArkTransactionLimits.MaxVtxosPerArkTransaction` (50) inputs. If the target
+amount cannot be covered within that cap — a wallet fragmented across many
+small VTXOs — `Spend` throws `TooManyInputsException`. Wait for the intent
+scheduler to consolidate the wallet's VTXOs (it batches them in chunks of the
+same size), or send a smaller amount.
+
 ## Manual Coin Selection
 
 For full control, specify inputs explicitly:


### PR DESCRIPTION
Problem

SimpleIntentScheduler submitted all eligible VTXOs for a given wallet in a single ArkIntentSpec, with no upper bound. Arkd rejects intents with too many vtxos (TX_TOO_LARGE) so wallets accumulating many VTXOs would silently produce oversized intents.

Changes

- Added MaxVtxosPerIntent = 50 constant.
- After filtering eligible VTXOs per wallet, coins are sorted descending by amount and split into chunks of at most 50 using Chunk(MaxVtxosPerIntent). Largest VTXOs go first, so early chunks are least likely to fall below the dust threshold.
- The per-wallet loop is now nested: each chunk becomes its own ArkIntentSpec, with independent fee estimation and output contract derivation.

Behaviour

A wallet with 120 eligible VTXOs now produces up to 3 intents (50 + 50 + 20) instead of one rejected oversized intent. Chunks that are sub-dust or net-negative after fees are skipped individually; the rest still go through.

Known gap

The last chunk (tail) holds the lowest-value VTXOs and is the most likely to be skipped for dust. A follow-up could redistribute tail VTXOs across preceding chunks to maximise coverage