### PR TITLE
fix: add ECXOnlyPubKeyComparer

### DIFF
--- a/NArk.Abstractions/Extensions/ECXOnlyPubKeyComparer.cs
+++ b/NArk.Abstractions/Extensions/ECXOnlyPubKeyComparer.cs
@@ -1,0 +1,26 @@
+using NBitcoin.Secp256k1;
+
+namespace NArk.Abstractions.Extensions;
+
+/// <summary>
+/// Value-equality comparer for <see cref="ECXOnlyPubKey"/>.
+/// NBitcoin's <see cref="ECXOnlyPubKey"/> overrides <see cref="object.GetHashCode"/> by byte value
+/// but not <see cref="object.Equals(object)"/>, so <c>Equals</c> falls back to reference equality.
+/// Pass this comparer to any <see cref="System.Collections.Generic.HashSet{T}"/> or
+/// <see cref="System.Collections.Generic.Dictionary{TKey,TValue}"/> keyed on <see cref="ECXOnlyPubKey"/>.
+/// </summary>
+public sealed class ECXOnlyPubKeyComparer : IEqualityComparer<ECXOnlyPubKey>
+{
+    public static readonly ECXOnlyPubKeyComparer Instance = new();
+    private ECXOnlyPubKeyComparer() { }
+
+    public bool Equals(ECXOnlyPubKey? x, ECXOnlyPubKey? y)
+    {
+        if (ReferenceEquals(x, y)) return true;
+        if (x is null || y is null) return false;
+        return x.ToBytes().SequenceEqual(y.ToBytes());
+    }
+
+    // GetHashCode is already overridden by NBitcoin to be byte-based — reuse it.
+    public int GetHashCode(ECXOnlyPubKey obj) => obj.GetHashCode();
+}

--- a/NArk.Core/Scripts/NofNMultisigTapScript.cs
+++ b/NArk.Core/Scripts/NofNMultisigTapScript.cs
@@ -1,3 +1,4 @@
+using NArk.Abstractions.Extensions;
 using NArk.Abstractions.Scripts;
 using NBitcoin;
 using NBitcoin.Secp256k1;
@@ -20,7 +21,7 @@ public class NofNMultisigTapScript(ECXOnlyPubKey[] owners) : ScriptBuilder
 
     public static NofNMultisigTapScript Parse(ScriptReader scriptReader)
     {
-        HashSet<ECXOnlyPubKey> owners = [];
+        HashSet<ECXOnlyPubKey> owners = new(ECXOnlyPubKeyComparer.Instance);
         Op lastOp = Op.GetPushOp(0);
         while (lastOp.Code != OpcodeType.OP_CHECKSIG)
         {

--- a/NArk.Core/Transformers/DelegateContractDelegationTransformer.cs
+++ b/NArk.Core/Transformers/DelegateContractDelegationTransformer.cs
@@ -18,7 +18,7 @@ public class DelegateContractDelegationTransformer(
             return false;
 
         // Verify the delegator's pubkey matches the contract's delegate key
-        if (!delegateContract.Delegate.ToXOnlyPubKey().Equals(delegatePubkey.ToXOnlyPubKey()))
+        if (!ECXOnlyPubKeyComparer.Instance.Equals(delegateContract.Delegate.ToXOnlyPubKey(), delegatePubkey.ToXOnlyPubKey()))
         {
             logger?.LogDebug(
                 "Delegator pubkey mismatch: contract={ContractDelegate}, delegator={DelegatorPubkey}",

--- a/NArk.Core/Transport/GrpcClient/GrpcClientTransport.Info.cs
+++ b/NArk.Core/Transport/GrpcClient/GrpcClientTransport.Info.cs
@@ -1,8 +1,10 @@
 using Ark.V1;
+using NArk.Abstractions.Extensions;
 using NArk.Core;
 using NArk.Core.Scripts;
 using NArk.Transport.GrpcClient.Extensions;
 using NBitcoin;
+using KeyExtensions = NArk.Transport.GrpcClient.Extensions.KeyExtensions;
 
 namespace NArk.Transport.GrpcClient;
 
@@ -32,7 +34,7 @@ public partial class GrpcClientTransport
             Dust: Money.Satoshis(response.Dust),
             SignerKey: KeyExtensions.ParseOutputDescriptor(response.SignerPubkey, network),
             DeprecatedSigners: response.DeprecatedSigners.ToDictionary(signer => signer.Pubkey.ToECXOnlyPubKey(),
-                signer => signer.CutoffDate),
+                signer => signer.CutoffDate, ECXOnlyPubKeyComparer.Instance),
             Network: network,
             UnilateralExit: ParseSequence(response.UnilateralExitDelay),
             BoardingExit: ParseSequence(response.BoardingExitDelay),

--- a/NArk.Core/Transport/RestClient/RestClientTransport.Info.cs
+++ b/NArk.Core/Transport/RestClient/RestClientTransport.Info.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using System.Text.Json;
+using NArk.Abstractions.Extensions;
 using NArk.Core;
 using NArk.Core.Scripts;
 using NArk.Core.Transport.Extensions;
@@ -28,7 +29,7 @@ public partial class RestClientTransport
         var forfeitPubkey = GetString(json, "forfeit_pubkey", "forfeitPubkey");
         var fPubKey = forfeitPubkey.ToECXOnlyPubKey();
 
-        var deprecatedSigners = new Dictionary<NBitcoin.Secp256k1.ECXOnlyPubKey, long>();
+        var deprecatedSigners = new Dictionary<NBitcoin.Secp256k1.ECXOnlyPubKey, long>(ECXOnlyPubKeyComparer.Instance);
         if (TryGetProp(json, "deprecated_signers", "deprecatedSigners", out var ds) && ds.ValueKind == JsonValueKind.Array)
         {
             foreach (var signer in ds.EnumerateArray())

--- a/NArk.Tests/BoardingUtxoSyncServiceTests.cs
+++ b/NArk.Tests/BoardingUtxoSyncServiceTests.cs
@@ -354,7 +354,7 @@ public class BoardingUtxoSyncServiceTests
         return new ArkServerInfo(
             Dust: Money.Satoshis(546),
             SignerKey: serverKey,
-            DeprecatedSigners: new Dictionary<ECXOnlyPubKey, long>(),
+            DeprecatedSigners: new Dictionary<ECXOnlyPubKey, long>(ECXOnlyPubKeyComparer.Instance),
             Network: Network.RegTest,
             UnilateralExit: new Sequence(144),
             BoardingExit: BoardingExitDelay,

--- a/NArk.Tests/CachingClientTransportTests.cs
+++ b/NArk.Tests/CachingClientTransportTests.cs
@@ -308,7 +308,7 @@ public class CachingClientTransportTests
         return new ArkServerInfo(
             Dust: Money.Satoshis(546),
             SignerKey: serverKey,
-            DeprecatedSigners: new Dictionary<ECXOnlyPubKey, long>(),
+            DeprecatedSigners: new Dictionary<ECXOnlyPubKey, long>(ECXOnlyPubKeyComparer.Instance),
             Network: Network.RegTest,
             UnilateralExit: new Sequence(144),
             BoardingExit: new Sequence(144),

--- a/NArk.Tests/ContractServiceTests.cs
+++ b/NArk.Tests/ContractServiceTests.cs
@@ -182,7 +182,7 @@ public class ContractServiceTests
         return new ArkServerInfo(
             Dust: Money.Satoshis(546),
             SignerKey: signerKey,
-            DeprecatedSigners: new Dictionary<ECXOnlyPubKey, long>(),
+            DeprecatedSigners: new Dictionary<ECXOnlyPubKey, long>(ECXOnlyPubKeyComparer.Instance),
             Network: Network.RegTest,
             UnilateralExit: new Sequence(144),
             BoardingExit: new Sequence(144),

--- a/NArk.Tests/DelegatingWalletProviderTests.cs
+++ b/NArk.Tests/DelegatingWalletProviderTests.cs
@@ -36,7 +36,7 @@ public class DelegatingWalletProviderTests
     private static ArkServerInfo CreateServerInfo() => new(
         Dust: Money.Satoshis(1000),
         SignerKey: ServerKey,
-        DeprecatedSigners: new Dictionary<NBitcoin.Secp256k1.ECXOnlyPubKey, long>(),
+        DeprecatedSigners: new Dictionary<NBitcoin.Secp256k1.ECXOnlyPubKey, long>(ECXOnlyPubKeyComparer.Instance),
         Network: Network.RegTest,
         UnilateralExit: ExitDelay,
         BoardingExit: new Sequence(1008),

--- a/NArk.Tests/Recovery/HdWalletRecoveryServiceTests.cs
+++ b/NArk.Tests/Recovery/HdWalletRecoveryServiceTests.cs
@@ -30,7 +30,7 @@ public class HdWalletRecoveryServiceTests
     private static readonly ArkServerInfo TestServerInfo = new(
         Dust: Money.Satoshis(330),
         SignerKey: TestServerKey,
-        DeprecatedSigners: new Dictionary<ECXOnlyPubKey, long>(),
+        DeprecatedSigners: new Dictionary<ECXOnlyPubKey, long>(ECXOnlyPubKeyComparer.Instance),
         Network: Network.RegTest,
         UnilateralExit: new Sequence(144),
         BoardingExit: new Sequence(144),

--- a/NArk.Tests/Recovery/IndexerVtxoDiscoveryProviderTests.cs
+++ b/NArk.Tests/Recovery/IndexerVtxoDiscoveryProviderTests.cs
@@ -35,7 +35,7 @@ public class IndexerVtxoDiscoveryProviderTests
         new(
             Dust: Money.Satoshis(330),
             SignerKey: signer,
-            DeprecatedSigners: deprecated.ToDictionary(k => k, _ => 1_700_000_000L),
+            DeprecatedSigners: deprecated.ToDictionary(k => k, _ => 1_700_000_000L, ECXOnlyPubKeyComparer.Instance),
             Network: Net,
             UnilateralExit: new Sequence(144),
             BoardingExit: new Sequence(144),
@@ -123,7 +123,7 @@ public class IndexerVtxoDiscoveryProviderTests
         var serverInfo = new ArkServerInfo(
             Dust: Money.Satoshis(330),
             SignerKey: current,
-            DeprecatedSigners: new Dictionary<ECXOnlyPubKey, long>(),
+            DeprecatedSigners: new Dictionary<ECXOnlyPubKey, long>(ECXOnlyPubKeyComparer.Instance),
             Network: Network.Main,
             UnilateralExit: new Sequence(144),
             BoardingExit: new Sequence(144),


### PR DESCRIPTION
# Summary

ECXOnlyPubKey in NBitcoin implements IComparable<T> and overrides GetHashCode (by byte value), but does not implement IEquatable<T> or override Equals/== — so equality falls back to reference identity. Several places in the SDK were silently broken as a result.

- DelegateContractDelegationTransformer — used .Equals() to match a contract's delegate key against the signer's public key; always returned false for distinct instances with the same bytes, causing valid delegates to be rejected
- NofNMultisigTapScript.Parse — used HashSet<ECXOnlyPubKey> to deduplicate owners; reference equality meant duplicate keys in malformed scripts would pass through undetected
- Transport layer — Dictionary<ECXOnlyPubKey, long> for DeprecatedSigners was created without a comparer; key lookups by value would never match

# Fix

Adds ECXOnlyPubKeyComparer — a sealed singleton IEqualityComparer<ECXOnlyPubKey> that compares by the 32-byte x-coordinate and delegates GetHashCode to the existing NBitcoin override. All Dictionary and HashSet constructions keyed on ECXOnlyPubKey now pass ECXOnlyPubKeyComparer.Instance explicitly.