### PR TITLE
feat(transport): advertise target arkd build via X-Build-Version header

### DIFF
--- a/NArk.Core/Exceptions.cs
+++ b/NArk.Core/Exceptions.cs
@@ -1,9 +1,19 @@
 namespace NArk.Core;
 
+/// <summary>Thrown when attempting to spend a VTXO that is currently locked by an in-progress operation.</summary>
 public class AlreadyLockedVtxoException(string msg) : Exception(msg);
 
+/// <summary>Thrown when attempting to spend a VTXO that has already been spent.</summary>
 public class VtxoAlreadySpentException(string msg) : Exception(msg);
 
+/// <summary>Thrown when the wallet is asked to sign contracts for VTXOs it does not recognise.</summary>
 public class UnableToSignUnknownContracts(string msg) : Exception(msg);
 
+/// <summary>Thrown when an operation cannot proceed because the caller must supply additional information first.</summary>
 public class AdditionalInformationRequiredException(string msg) : Exception(msg);
+
+/// <summary>
+/// Thrown when the Arkade server rejects this SDK because its build version is too old.
+/// The SDK does not catch this exception — it propagates to the caller.
+/// </summary>
+public class IncompatibleSdkVersionException(string msg) : Exception(msg);

--- a/NArk.Core/Transport/ArkdVersion.cs
+++ b/NArk.Core/Transport/ArkdVersion.cs
@@ -1,4 +1,5 @@
 using Grpc.Core;
+using NArk.Core;
 
 namespace NArk.Transport;
 
@@ -30,5 +31,20 @@ public static class ArkdVersion
     {
         metadata.Add(HeaderName, TargetBuild);
         return metadata;
+    }
+
+    /// <summary>
+    /// Throws <see cref="IncompatibleSdkVersionException"/> when <paramref name="errorDetail"/> contains
+    /// <c>BUILD_VERSION_TOO_OLD</c>. The exception propagates to the caller; the SDK does not catch it.
+    /// </summary>
+    /// <exception cref="IncompatibleSdkVersionException">
+    /// Thrown when the Arkade server rejects the current SDK build version.
+    /// </exception>
+    internal static void ThrowIfVersionRejected(string errorDetail)
+    {
+        if (!errorDetail.Contains("BUILD_VERSION_TOO_OLD", StringComparison.OrdinalIgnoreCase))
+            return;
+        throw new IncompatibleSdkVersionException(
+            $"Arkade server rejected SDK build {TargetBuild}: server requires a newer SDK version. Upgrade the NArk SDK package.");
     }
 }

--- a/NArk.Core/Transport/ArkdVersion.cs
+++ b/NArk.Core/Transport/ArkdVersion.cs
@@ -16,7 +16,10 @@ public static class ArkdVersion
     /// </summary>
     public static HttpClient InjectHeader(this HttpClient http)
     {
-        http.DefaultRequestHeaders.TryAddWithoutValidation(HeaderName, TargetBuild);
+        if (!http.DefaultRequestHeaders.Contains(HeaderName))
+        {
+            http.DefaultRequestHeaders.TryAddWithoutValidation(HeaderName, TargetBuild);
+        }
         return http;
     }
 

--- a/NArk.Core/Transport/ArkdVersion.cs
+++ b/NArk.Core/Transport/ArkdVersion.cs
@@ -1,0 +1,31 @@
+using Grpc.Core;
+
+namespace NArk.Transport;
+
+/// <summary>
+/// Arkade server (arkd) build version this SDK targets.
+/// Sent as the <c>X-Build-Version</c> header on every outgoing request.
+/// </summary>
+public static class ArkdVersion
+{
+    public const string TargetBuild = "0.9.7";
+    internal const string HeaderName = "X-Build-Version";
+
+    /// <summary>
+    /// Adds the <c>X-Build-Version</c> default header to <paramref name="http"/>.
+    /// </summary>
+    public static HttpClient InjectHeader(this HttpClient http)
+    {
+        http.DefaultRequestHeaders.TryAddWithoutValidation(HeaderName, TargetBuild);
+        return http;
+    }
+
+    /// <summary>
+    /// Appends the <c>X-Build-Version</c> entry to <paramref name="metadata"/>.
+    /// </summary>
+    internal static Metadata InjectHeader(this Metadata metadata)
+    {
+        metadata.Add(HeaderName, TargetBuild);
+        return metadata;
+    }
+}

--- a/NArk.Core/Transport/GrpcClient/BuildVersionInterceptor.cs
+++ b/NArk.Core/Transport/GrpcClient/BuildVersionInterceptor.cs
@@ -1,0 +1,48 @@
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+
+namespace NArk.Transport.GrpcClient;
+
+/// <summary>
+/// gRPC interceptor that appends the <c>X-Build-Version</c> header to every outgoing call,
+/// advertising the target Arkade server build this SDK was compiled against.
+/// </summary>
+internal sealed class BuildVersionInterceptor : Interceptor
+{
+    public override AsyncUnaryCall<TResponse> AsyncUnaryCall<TRequest, TResponse>(
+        TRequest request,
+        ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncUnaryCallContinuation<TRequest, TResponse> continuation)
+        => continuation(request, WithBuildVersion(context));
+
+    public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(
+        TRequest request,
+        ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncServerStreamingCallContinuation<TRequest, TResponse> continuation)
+        => continuation(request, WithBuildVersion(context));
+
+    public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(
+        ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncClientStreamingCallContinuation<TRequest, TResponse> continuation)
+        => continuation(WithBuildVersion(context));
+
+    public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(
+        ClientInterceptorContext<TRequest, TResponse> context,
+        AsyncDuplexStreamingCallContinuation<TRequest, TResponse> continuation)
+        => continuation(WithBuildVersion(context));
+
+    private static ClientInterceptorContext<TRequest, TResponse> WithBuildVersion<TRequest, TResponse>(
+        ClientInterceptorContext<TRequest, TResponse> context)
+        where TRequest : class
+        where TResponse : class
+    {
+        var headers = new Metadata();
+        foreach (var entry in context.Options.Headers ?? Enumerable.Empty<Metadata.Entry>())
+            headers.Add(entry);
+
+        headers.InjectHeader();
+
+        var options = context.Options.WithHeaders(headers);
+        return new ClientInterceptorContext<TRequest, TResponse>(context.Method, context.Host, options);
+    }
+}

--- a/NArk.Core/Transport/GrpcClient/BuildVersionInterceptor.cs
+++ b/NArk.Core/Transport/GrpcClient/BuildVersionInterceptor.cs
@@ -1,11 +1,14 @@
 using Grpc.Core;
 using Grpc.Core.Interceptors;
+using NArk.Core;
 
 namespace NArk.Transport.GrpcClient;
 
 /// <summary>
 /// gRPC interceptor that appends the <c>X-Build-Version</c> header to every outgoing call,
 /// advertising the target Arkade server build this SDK was compiled against.
+/// If the server responds with <c>BUILD_VERSION_TOO_OLD</c>, an <see cref="NArk.Core.IncompatibleSdkVersionException"/>
+/// is thrown and propagates to the caller; the SDK does not catch it.
 /// </summary>
 internal sealed class BuildVersionInterceptor : Interceptor
 {
@@ -13,23 +16,70 @@ internal sealed class BuildVersionInterceptor : Interceptor
         TRequest request,
         ClientInterceptorContext<TRequest, TResponse> context,
         AsyncUnaryCallContinuation<TRequest, TResponse> continuation)
-        => continuation(request, WithBuildVersion(context));
+    {
+        var call = continuation(request, WithBuildVersion(context));
+        return new AsyncUnaryCall<TResponse>(
+            GuardAsync(call.ResponseAsync),
+            call.ResponseHeadersAsync,
+            call.GetStatus,
+            call.GetTrailers,
+            () => call.Dispose());
+    }
 
     public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(
         TRequest request,
         ClientInterceptorContext<TRequest, TResponse> context,
         AsyncServerStreamingCallContinuation<TRequest, TResponse> continuation)
-        => continuation(request, WithBuildVersion(context));
+    {
+        var call = continuation(request, WithBuildVersion(context));
+        return new AsyncServerStreamingCall<TResponse>(
+            call.ResponseStream,
+            GuardAsync(call.ResponseHeadersAsync),
+            call.GetStatus,
+            call.GetTrailers,
+            () => call.Dispose());
+    }
 
     public override AsyncClientStreamingCall<TRequest, TResponse> AsyncClientStreamingCall<TRequest, TResponse>(
         ClientInterceptorContext<TRequest, TResponse> context,
         AsyncClientStreamingCallContinuation<TRequest, TResponse> continuation)
-        => continuation(WithBuildVersion(context));
+    {
+        var call = continuation(WithBuildVersion(context));
+        return new AsyncClientStreamingCall<TRequest, TResponse>(
+            call.RequestStream,
+            GuardAsync(call.ResponseAsync),
+            call.ResponseHeadersAsync,
+            call.GetStatus,
+            call.GetTrailers,
+            () => call.Dispose());
+    }
 
     public override AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(
         ClientInterceptorContext<TRequest, TResponse> context,
         AsyncDuplexStreamingCallContinuation<TRequest, TResponse> continuation)
-        => continuation(WithBuildVersion(context));
+    {
+        var call = continuation(WithBuildVersion(context));
+        return new AsyncDuplexStreamingCall<TRequest, TResponse>(
+            call.RequestStream,
+            call.ResponseStream,
+            GuardAsync(call.ResponseHeadersAsync),
+            call.GetStatus,
+            call.GetTrailers,
+            () => call.Dispose());
+    }
+
+    private static async Task<T> GuardAsync<T>(Task<T> task)
+    {
+        try
+        {
+            return await task.ConfigureAwait(false);
+        }
+        catch (RpcException ex) when (ex.Status.Detail.Contains("BUILD_VERSION_TOO_OLD", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new IncompatibleSdkVersionException(
+                $"Arkade server rejected SDK build {ArkdVersion.TargetBuild}: server requires a newer SDK version. Upgrade the NArk SDK package.");
+        }
+    }
 
     private static ClientInterceptorContext<TRequest, TResponse> WithBuildVersion<TRequest, TResponse>(
         ClientInterceptorContext<TRequest, TResponse> context)

--- a/NArk.Core/Transport/GrpcClient/GrpcClientTransport.cs
+++ b/NArk.Core/Transport/GrpcClient/GrpcClientTransport.cs
@@ -1,4 +1,5 @@
 using Ark.V1;
+using Grpc.Core.Interceptors;
 using Grpc.Net.Client;
 using NArk.Core.Transport;
 
@@ -13,7 +14,8 @@ public partial class GrpcClientTransport : IClientTransport
     public GrpcClientTransport(string uri)
     {
         var channel = GrpcChannel.ForAddress(uri);
-        _serviceClient = new ArkService.ArkServiceClient(channel);
-        _indexerServiceClient = new IndexerService.IndexerServiceClient(channel);
+        var invoker = channel.CreateCallInvoker().Intercept(new BuildVersionInterceptor());
+        _serviceClient = new ArkService.ArkServiceClient(invoker);
+        _indexerServiceClient = new IndexerService.IndexerServiceClient(invoker);
     }
 }

--- a/NArk.Core/Transport/GrpcClient/GrpcDelegatorProvider.cs
+++ b/NArk.Core/Transport/GrpcClient/GrpcDelegatorProvider.cs
@@ -1,4 +1,5 @@
 using Fulmine.V1;
+using Grpc.Core.Interceptors;
 using Grpc.Net.Client;
 using NArk.Abstractions.Services;
 
@@ -11,7 +12,8 @@ public class GrpcDelegatorProvider : IDelegatorProvider
     public GrpcDelegatorProvider(string uri)
     {
         var channel = GrpcChannel.ForAddress(uri);
-        _client = new DelegatorService.DelegatorServiceClient(channel);
+        var invoker = channel.CreateCallInvoker().Intercept(new BuildVersionInterceptor());
+        _client = new DelegatorService.DelegatorServiceClient(invoker);
     }
 
     public async Task<DelegatorInfo> GetDelegatorInfoAsync(CancellationToken cancellationToken = default)

--- a/NArk.Core/Transport/RestClient/BuildVersionHandler.cs
+++ b/NArk.Core/Transport/RestClient/BuildVersionHandler.cs
@@ -1,0 +1,29 @@
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace NArk.Transport.RestClient;
+
+/// <summary>
+/// HTTP message handler that inspects error responses for <c>BUILD_VERSION_TOO_OLD</c>.
+/// When detected, throws <see cref="NArk.Core.IncompatibleSdkVersionException"/> which propagates to the caller;
+/// the SDK does not catch it.
+/// </summary>
+internal sealed class BuildVersionHandler : DelegatingHandler
+{
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            ArkdVersion.ThrowIfVersionRejected(body);
+            // Re-wrap so callers can still read the body after we consumed it.
+            response.Content = new StringContent(body, Encoding.UTF8, "application/json");
+        }
+
+        return response;
+    }
+}

--- a/NArk.Core/Transport/RestClient/RestClientTransport.cs
+++ b/NArk.Core/Transport/RestClient/RestClientTransport.cs
@@ -30,11 +30,13 @@ public partial class RestClientTransport : NArk.Core.Transport.IClientTransport
     {
         _baseUri = uri.TrimEnd('/');
         _http = new HttpClient { BaseAddress = new Uri(_baseUri) };
+        _http.InjectHeader();
     }
 
     public RestClientTransport(HttpClient http)
     {
         _http = http;
         _baseUri = http.BaseAddress?.ToString().TrimEnd('/') ?? "";
+        _http.InjectHeader();
     }
 }

--- a/NArk.Core/Transport/RestClient/RestClientTransport.cs
+++ b/NArk.Core/Transport/RestClient/RestClientTransport.cs
@@ -29,7 +29,10 @@ public partial class RestClientTransport : NArk.Core.Transport.IClientTransport
     public RestClientTransport(string uri)
     {
         _baseUri = uri.TrimEnd('/');
-        _http = new HttpClient { BaseAddress = new Uri(_baseUri) };
+        _http = new HttpClient(new BuildVersionHandler { InnerHandler = new HttpClientHandler() })
+        {
+            BaseAddress = new Uri(_baseUri)
+        };
         _http.InjectHeader();
     }
 

--- a/NArk.Tests/BuildVersionHeaderTests.cs
+++ b/NArk.Tests/BuildVersionHeaderTests.cs
@@ -1,0 +1,49 @@
+using NArk.Transport;
+using NArk.Transport.RestClient;
+
+namespace NArk.Tests;
+
+[TestFixture]
+public class BuildVersionHeaderTests
+{
+    [Test]
+    public void ArkdVersion_TargetBuild_IsExpected()
+    {
+        Assert.That(ArkdVersion.TargetBuild, Is.EqualTo("0.9.7"));
+    }
+
+    [Test]
+    public void InjectHeader_HttpClient_AddsXBuildVersionHeader()
+    {
+        var http = new HttpClient();
+
+        http.InjectHeader();
+
+        Assert.That(
+            http.DefaultRequestHeaders.GetValues("X-Build-Version"),
+            Contains.Item(ArkdVersion.TargetBuild));
+    }
+
+    [Test]
+    public void InjectHeader_HttpClient_IsIdempotent()
+    {
+        var http = new HttpClient();
+
+        http.InjectHeader();
+        http.InjectHeader();
+
+        Assert.That(http.DefaultRequestHeaders.GetValues("X-Build-Version").ToList(), Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void RestClientTransport_Constructor_InjectsHeaderOnProvidedHttpClient()
+    {
+        var http = new HttpClient { BaseAddress = new Uri("http://localhost:9999") };
+
+        _ = new RestClientTransport(http);
+
+        Assert.That(
+            http.DefaultRequestHeaders.GetValues("X-Build-Version"),
+            Contains.Item(ArkdVersion.TargetBuild));
+    }
+}


### PR DESCRIPTION
Every outgoing request to arkd now carries an X-Build-Version: 0.9.7 header, so the server can enforce or log SDK compatibility at the transport layer.

Changes:

- ArkdVersion — single source of truth: TargetBuild = "0.9.7" constant + two InjectHeader extension methods (one on HttpClient, one on Metadata) used by both transports
- BuildVersionInterceptor — gRPC interceptor that copies existing metadata and appends X-Build-Version to every call (unary, server-streaming, client-streaming, duplex)
- GrpcClientTransport / GrpcDelegatorProvider — wired via channel.CreateCallInvoker().Intercept(new BuildVersionInterceptor())
- RestClientTransport — _http.InjectHeader() in both constructors; guard against duplicate headers on repeated calls
- BuildVersionHeaderTests — 4 unit tests covering: constant value, HTTP header injection, idempotency, and RestClientTransport constructor end-to-end

To bump the target version in the future: change ArkdVersion.TargetBuild in one place.