### PR TITLE
test(e2e): close boarding-confirmation flake in settle pipeline tests

### DIFF
--- a/NArk.Tests.End2End/BoardingTests.cs
+++ b/NArk.Tests.End2End/BoardingTests.cs
@@ -62,19 +62,27 @@ public class BoardingTests
         var syncService = new BoardingUtxoSyncService(
             contracts, vtxoStorage, clientTransport, utxoProvider);
 
-        // Chopsticks may need a moment to index — retry until the UTXO appears
+        // The Esplora backend may need a moment to index the just-mined blocks —
+        // retry until the UTXO appears *confirmed* (ExpiresAt set). A row synced
+        // while the funding tx still looked unconfirmed has ExpiresAt=null, which
+        // SimpleIntentScheduler silently filters out (arkd rejects unconfirmed
+        // inputs); since the generation cycle below runs only once per
+        // PollInterval, that would stall the whole test. SyncAsync re-reads
+        // Esplora and upserts each iteration, so the row flips to confirmed as
+        // soon as the indexer catches up.
         ArkVtxo? syncedVtxo = null;
         for (var i = 0; i < 10; i++)
         {
             await syncService.SyncAsync();
             var vtxos = await vtxoStorage.GetVtxos();
-            syncedVtxo = vtxos.FirstOrDefault(v => v.TransactionId == fundingTxid);
+            syncedVtxo = vtxos.FirstOrDefault(v => v.TransactionId == fundingTxid && v.ExpiresAt is not null);
             if (syncedVtxo is not null)
                 break;
             await Task.Delay(TimeSpan.FromSeconds(2));
         }
 
-        Assert.That(syncedVtxo, Is.Not.Null, "BoardingUtxoSyncService should find the funded UTXO via Esplora");
+        Assert.That(syncedVtxo, Is.Not.Null,
+            "BoardingUtxoSyncService should find the funded UTXO via Esplora as confirmed (ExpiresAt set)");
         Assert.That(syncedVtxo!.Unrolled, Is.True);
         Assert.That(syncedVtxo.Amount, Is.EqualTo((ulong)boardingAmountSats));
         Console.WriteLine($"[Boarding] Synced VTXO: {syncedVtxo.TransactionId[..8]}..:{syncedVtxo.TransactionOutputIndex}");
@@ -119,6 +127,17 @@ public class BoardingTests
                     break;
                 case ArkIntentState.BatchSucceeded:
                     newSuccessBatch.TrySetResult();
+                    break;
+                // Surface terminal failures immediately instead of letting the
+                // staged waits below time out blind — the recorded reason makes
+                // intermittent failures attributable from CI output alone.
+                case ArkIntentState.BatchFailed:
+                case ArkIntentState.Cancelled:
+                    var failure = new InvalidOperationException(
+                        $"Intent {intent.IntentTxId} ended in {intent.State}: {intent.CancellationReason ?? "no reason recorded"}");
+                    newIntentTcs.TrySetException(failure);
+                    newSubmittedIntentTcs.TrySetException(failure);
+                    newSuccessBatch.TrySetException(failure);
                     break;
             }
         };

--- a/NArk.Tests.End2End/UnilateralExitTests.cs
+++ b/NArk.Tests.End2End/UnilateralExitTests.cs
@@ -350,6 +350,13 @@ public class UnilateralExitTests
             if (!vtxo.IsSpent() && !vtxo.Unrolled) settledVtxoTcs.TrySetResult();
         };
 
+        // Logger used across the settle + exit pipeline services so failures
+        // surface in CI test output instead of being swallowed. Timestamps
+        // make the output correlatable with arkd/bitcoind container logs.
+        var loggerFactory = LoggerFactory.Create(b => b
+            .AddSimpleConsole(o => o.TimestampFormat = "HH:mm:ss.fff ")
+            .SetMinimumLevel(LogLevel.Debug));
+
         var clientTransport = new GrpcClientTransport(SharedArkInfrastructure.ArkdEndpoint.ToString());
         var info = await clientTransport.GetServerInfoAsync();
 
@@ -375,21 +382,28 @@ public class UnilateralExitTests
 
         var utxoProvider = new EsploraBlockchain(SharedArkInfrastructure.ChopsticksEndpoint);
         var boardingSync = new BoardingUtxoSyncService(
-            contractStorage, vtxoStorage, clientTransport, utxoProvider);
+            contractStorage, vtxoStorage, clientTransport, utxoProvider,
+            loggerFactory.CreateLogger<BoardingUtxoSyncService>());
 
+        // Poll until the boarding UTXO syncs as *confirmed* (ExpiresAt set), not
+        // merely present. The Esplora backend (mempool API) can lag the 6 blocks
+        // we just mined; BoardingUtxoSyncService stores a still-unconfirmed UTXO
+        // with ExpiresAt=null, and SimpleIntentScheduler silently skips such
+        // coins (arkd rejects unconfirmed inputs). Since the intent generation
+        // cycle below runs only once per PollInterval, a row synced while the
+        // funding tx looked unconfirmed would never settle within the test
+        // budget. SyncAsync re-reads Esplora and upserts on every iteration, so
+        // the row flips to confirmed as soon as the indexer catches up.
         ArkVtxo? syncedBoarding = null;
         for (var i = 0; i < 10 && syncedBoarding is null; i++)
         {
             await boardingSync.SyncAsync();
             syncedBoarding = (await vtxoStorage.GetVtxos())
-                .FirstOrDefault(v => v.TransactionId == fundingTxid);
+                .FirstOrDefault(v => v.TransactionId == fundingTxid && v.ExpiresAt is not null);
             if (syncedBoarding is null) await Task.Delay(TimeSpan.FromSeconds(2));
         }
-        Assert.That(syncedBoarding, Is.Not.Null, "Boarding UTXO should sync via Esplora");
-
-        // Logger used across exit-pipeline services so failures surface
-        // in CI test output instead of being swallowed.
-        var loggerFactory = LoggerFactory.Create(b => b.AddConsole().SetMinimumLevel(LogLevel.Debug));
+        Assert.That(syncedBoarding, Is.Not.Null,
+            "Boarding UTXO should sync via Esplora as confirmed (ExpiresAt set)");
 
         // ---- settle: intent gen + submit + batch session ----
         var chainTimeProvider = new NBXplorerBlockchain(info.Network, SharedArkInfrastructure.NbxplorerEndpoint);
@@ -404,6 +418,13 @@ public class UnilateralExitTests
         {
             if (intent.State == ArkIntentState.BatchSucceeded)
                 newSuccessBatch.TrySetResult();
+            // Surface terminal failures immediately. Waiting only for
+            // BatchSucceeded turns any BatchFailed/Cancelled intent into a
+            // silent 2-minute TimeoutException with no diagnostics; failing
+            // fast with the recorded reason makes flakes attributable.
+            else if (intent.State is ArkIntentState.BatchFailed or ArkIntentState.Cancelled)
+                newSuccessBatch.TrySetException(new InvalidOperationException(
+                    $"Intent {intent.IntentTxId} ended in {intent.State}: {intent.CancellationReason ?? "no reason recorded"}"));
         };
 
         var scheduler = new SimpleIntentScheduler(
@@ -415,7 +436,8 @@ public class UnilateralExitTests
             {
                 Threshold = TimeSpan.FromHours(25),
                 ThresholdHeight = 200,
-            }));
+            }),
+            loggerFactory.CreateLogger<SimpleIntentScheduler>());
 
         var intentGeneration = new IntentGenerationService(
             clientTransport,
@@ -428,10 +450,12 @@ public class UnilateralExitTests
             vtxoStorage,
             scheduler,
             new OptionsWrapper<IntentGenerationServiceOptions>(
-                new IntentGenerationServiceOptions { PollInterval = TimeSpan.FromHours(5) }));
+                new IntentGenerationServiceOptions { PollInterval = TimeSpan.FromHours(5) }),
+            loggerFactory.CreateLogger<IntentGenerationService>());
         await intentGeneration.StartAsync(CancellationToken.None);
 
-        var intentSync = new IntentSynchronizationService(intentStorage, clientTransport, safetyService);
+        var intentSync = new IntentSynchronizationService(intentStorage, clientTransport, safetyService,
+            loggerFactory.CreateLogger<IntentSynchronizationService>());
         await intentSync.StartAsync(CancellationToken.None);
 
         // SimpleIntentScheduler derives the SendToSelf output contract as
@@ -468,7 +492,8 @@ public class UnilateralExitTests
         var batchManager = new BatchManagementService(
             intentStorage, clientTransport, vtxoStorage, contractStorage,
             walletProvider, coinService, safetyService,
-            new IEventHandler<PostBatchSessionEvent>[] { postBatchHandler });
+            new IEventHandler<PostBatchSessionEvent>[] { postBatchHandler },
+            loggerFactory.CreateLogger<BatchManagementService>());
         await batchManager.StartAsync(CancellationToken.None);
 
         // Auto-fetch the virtual-tx chain on every VTXO arrival. This is


### PR DESCRIPTION
## Summary

`UnilateralExitTests.StartExit_IsIdempotentForSameVtxo` (and its siblings sharing `SettleAVtxoAsync`, plus `BoardingTests.CanBoardFromOnchainToVtxo`) failed intermittently with a bare 2-minute `TimeoutException` and zero diagnostics — locally 2 stalls in the first 7 runs.

**Root cause:** the boarding-sync poll declared success as soon as a VTXO row with the funding txid appeared, regardless of confirmation state. The regtest Esplora backend (mempool API) can lag the six just-mined blocks by a few seconds; in that window `BoardingUtxoSyncService` stores the UTXO *unconfirmed* (`ExpiresAt=null`), and `SimpleIntentScheduler` silently filters such coins out (arkd rejects unconfirmed inputs). With the tests' one-shot intent generation cycle (`PollInterval=5h`) nothing ever retried, so the settle stalled until the batch wait timed out.

**Fix:** poll until the boarding VTXO is stored *confirmed* (`ExpiresAt` set). `SyncAsync` re-reads Esplora and upserts on every iteration, so the row flips as soon as the indexer catches up.

**Diagnosability hardening** in the same tests, so the next intermittent failure is attributable from CI output alone:
- fail fast (with the recorded reason) when the intent ends in `BatchFailed`/`Cancelled` instead of timing out blind
- wire timestamped loggers into every settle-pipeline service (intent generation/sync, batch management, boarding sync, scheduler)

A second failure shape was observed once locally (intent registered, round completed server-side per the arkd-wallet broadcast trace, but `BatchSucceeded` never landed client-side). It did not reproduce in 42 instrumented runs; if it recurs, the fail-fast + logging above will surface the terminal state and reason immediately instead of a blind timeout.

## Test plan

- [x] 42 consecutive local green runs of `StartExit_IsIdempotentForSameVtxo` after the fix (was ~2 failures in 7 runs before)
- [x] Full `UnilateralExitTests` file green (4/4)
- [x] `BoardingTests.CanBoardFromOnchainToVtxo` green
- [x] E2E CI on this PR
