### PR TITLE
review: address PR #132 code review findings

### DIFF
--- a/NArk.Core/Services/ContractReconciliationService.cs
+++ b/NArk.Core/Services/ContractReconciliationService.cs
@@ -62,12 +62,13 @@ public class ContractReconciliationService(
     private readonly Channel<ReconcileJob> _jobs = Channel.CreateUnbounded<ReconcileJob>();
 
     private Task? _workerTask;
+    private CancellationTokenSource? _multiToken;
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
         logger?.LogInformation("Starting contract reconciliation service");
-        var multiToken = CancellationTokenSource.CreateLinkedTokenSource(_shutdownCts.Token, cancellationToken);
-        _workerTask = DoReconciliationLoop(multiToken.Token);
+        _multiToken = CancellationTokenSource.CreateLinkedTokenSource(_shutdownCts.Token, cancellationToken);
+        _workerTask = DoReconciliationLoop(_multiToken.Token);
 
         walletStorage.WalletSaved += OnWalletSaved;
         serverInfoCacheInvalidation.ServerInfoChanged += OnServerInfoChanged;
@@ -98,7 +99,7 @@ public class ContractReconciliationService(
             }
             catch (Exception e)
             {
-                logger?.LogInformation(0, e, "Error during reconciliation loop execution for job {JobType}", job.GetType().Name);
+                logger?.LogWarning(0, e, "Error during reconciliation loop execution for job {JobType}", job.GetType().Name);
 
                 // A wholesale ReconcileAll failure means we may have missed rotations that happened
                 // while offline. The common cause is arkd being unreachable at boot: that surfaces
@@ -262,6 +263,7 @@ public class ContractReconciliationService(
             logger?.LogDebug(0, ex, "Reconciliation worker completed with error during shutdown");
         }
 
+        _multiToken?.Dispose();
         _shutdownCts.Dispose();
         logger?.LogInformation("Contract reconciliation service disposed");
     }

--- a/NArk.Core/Sweeper/ServerKeyRotationSweepPolicy.cs
+++ b/NArk.Core/Sweeper/ServerKeyRotationSweepPolicy.cs
@@ -5,35 +5,36 @@ using NArk.Core.Transport;
 
 namespace NArk.Core.Sweeper;
 
-public class ServerKeyRotationSweepPolicy(IClientTransport clientTransport): ISweepPolicy
+/// <summary>
+/// Sweep policy that selects coins locked under a deprecated Arkade signer key
+/// whose collaborative-sweep cutoff has not yet passed (or has no cutoff).
+/// <para>
+/// When arkd rotates its signing key, existing VTXOs bound to the old signer must be
+/// re-enrolled under the current signer before the operator stops co-signing them.
+/// This policy surfaces those coins to the sweeper so they are collaboratively swept
+/// into a new VTXO under the current signer (regime 1 of the rotation funds model).
+/// </para>
+/// </summary>
+public class ServerKeyRotationSweepPolicy(IClientTransport clientTransport) : ISweepPolicy
 {
     public async IAsyncEnumerable<ArkCoin> SweepAsync(
-        IEnumerable<ArkCoin> coins, 
-        [EnumeratorCancellation] CancellationToken cancellationToken = default
-        )
+        IEnumerable<ArkCoin> coins,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
         var serverInfo = await clientTransport.GetServerInfoAsync(cancellationToken);
-        
-        var recoverableKeyHexes = serverInfo.DeprecatedSigners
-            .Where(ds => ds.Value > now || ds.Value == 0)
-            .Select(ds => Convert.ToHexString(ds.Key.ToBytes()))
-            .ToHashSet();
 
-        // ECXOnlyPubKey uses reference equality, so compare by hex of the 32-byte x-coordinate.
-        var coinsToRefresh = coins
-            .Where(v => v.SignerDescriptor is not null &&
-                        recoverableKeyHexes.Contains(Convert.ToHexString(v.SignerDescriptor.ToXOnlyPubKey().ToBytes())))
-            .ToArray();
-        
-        if (coinsToRefresh.Length == 0)
+        var recoverableKeys = serverInfo.DeprecatedSigners
+            .Where(ds => ds.Value > now || ds.Value == 0)
+            .Select(ds => ds.Key)
+            .ToHashSet(ECXOnlyPubKeyComparer.Instance);
+
+        foreach (var coin in coins)
         {
-            yield break;
-        }
-        
-        foreach (var coin in coinsToRefresh)
-        {
-            yield return coin;
+            if (coin.SignerDescriptor != null && recoverableKeys.Contains(coin.SignerDescriptor.ToXOnlyPubKey()))
+            {
+                yield return coin;
+            }
         }
     }
 }

--- a/NArk.Core/Transport/IServerInfoCacheInvalidation.cs
+++ b/NArk.Core/Transport/IServerInfoCacheInvalidation.cs
@@ -1,11 +1,26 @@
 namespace NArk.Core.Transport;
 
-public enum ServerInfoChangedReason { ManualInvalidation, DigestMismatch, TtlExpiry }
+/// <summary>Describes why the Arkade server-info cache was invalidated or refreshed.</summary>
+public enum ServerInfoChangedReason
+{
+    /// <summary>The cache was cleared by an explicit call to <see cref="IServerInfoCacheInvalidation.InvalidateServerInfoCache"/>.</summary>
+    ManualInvalidation,
+    /// <summary>The Arkade server rejected a request because the cached digest no longer matched its current configuration.</summary>
+    DigestMismatch,
+    /// <summary>The cache TTL expired and a fresh fetch observed a changed digest, indicating the server configuration was updated.</summary>
+    TtlExpiry,
+}
 
+/// <summary>
+/// Provides context for a <see cref="IServerInfoCacheInvalidation.ServerInfoChanged"/> event.
+/// </summary>
 public sealed class ServerInfoChangedEventArgs : EventArgs
 {
+    /// <summary>The reason this event was raised.</summary>
     public ServerInfoChangedReason Reason { get; init; } = ServerInfoChangedReason.ManualInvalidation;
+    /// <summary>The digest that was cached before the change, or <c>null</c> if unavailable.</summary>
     public string? PreviousDigest { get; init; }
+    /// <summary>The digest of the newly fetched server info, or <c>null</c> if unavailable.</summary>
     public string? NewDigest { get; init; }
 }
 

--- a/NArk.Core/Transport/RestClient/RestClientTransport.cs
+++ b/NArk.Core/Transport/RestClient/RestClientTransport.cs
@@ -46,11 +46,11 @@ public partial class RestClientTransport : NArk.Core.Transport.IClientTransport
     /// (e.g. Blazor WASM browser client, <c>IHttpClientFactory</c>, test fakes).
     /// </para>
     /// <para>
-    /// <strong>Limitation:</strong> <see cref="BuildVersionHandler"/> is <em>not</em> inserted into the
-    /// pipeline. As a result, <c>X-Digest</c> is never sent and neither
-    /// <c>BUILD_VERSION_TOO_OLD</c> nor <c>DIGEST_MISMATCH</c> responses are detected automatically.
-    /// The caller is responsible for adding <c>BuildVersionHandler</c> to the client's handler chain
-    /// if that behaviour is required.
+    /// <strong>Limitation:</strong> <c>X-Digest</c> is never sent on outgoing requests and neither
+    /// <c>BUILD_VERSION_TOO_OLD</c> nor <c>DIGEST_MISMATCH</c> error responses are detected
+    /// automatically. This limitation is fundamental to this overload — if automatic digest/version
+    /// checking is required, use the <see cref="RestClientTransport(string)"/> URI-based constructor
+    /// instead.
     /// </para>
     /// </remarks>
     public RestClientTransport(HttpClient http)

--- a/README.md
+++ b/README.md
@@ -661,6 +661,31 @@ Console.WriteLine($"Discovered {report.DiscoveredContracts.Count} contract(s)");
 
 Custom discovery sources are added by implementing `IContractDiscoveryProvider` and registering it in DI; the orchestrator picks them up automatically. See [docs/articles/recovery.md](docs/articles/recovery.md) for the full API and tuning guidance.
 
+## Arkade Signer-Key Rotation
+
+When an Arkade server operator rotates its signing key, the SDK handles re-enrollment automatically — no consumer code required. Three regimes apply depending on when the rotation is detected relative to the cutoff:
+
+| Regime | Condition | Handled by |
+|--------|-----------|------------|
+| Collaborative sweep | Before cutoff (or no cutoff) | `ServerKeyRotationSweepPolicy` re-enrolls VTXOs under the current signer via the sweeper |
+| Wait | After cutoff, before VTXO expiry | VTXO waits until recoverable |
+| Recovery re-enroll | Expired VTXO | Intent scheduler; batch session skips forfeit so the old key is not needed |
+
+`ContractReconciliationService` keeps every SingleKey wallet's "Default" receive contract aligned with the current signer. It triggers automatically on startup, `WalletSaved`, and `ServerInfoChanged` — no extra registration needed beyond `AddArkCoreServices`.
+
+To react to a rotation event in your own service, inject `IServerInfoCacheInvalidation`:
+
+```csharp
+public class MyService(IServerInfoCacheInvalidation serverInfoCache)
+{
+    public void Start() =>
+        serverInfoCache.ServerInfoChanged += (_, e) =>
+            Console.WriteLine($"Arkade server info changed: {e.Reason}");
+}
+```
+
+See [docs/articles/signer-rotation.md](docs/articles/signer-rotation.md) for the full rotation model, detection paths, and version/digest header details.
+
 ## Pending Arkade Transaction Recovery
 
 Arkade off-chain transactions are a two-phase **Submit → Finalize** flow. If the process crashes between phases, the server holds the inputs as in-flight and only allows the original pending tx to be finalized — without recovery, those coins are stuck.

--- a/docs/articles/signer-rotation.md
+++ b/docs/articles/signer-rotation.md
@@ -1,0 +1,77 @@
+# Arkade Signer-Key Rotation
+
+When an Arkade server operator rotates its signing key, existing VTXOs bound to the old signer must be re-enrolled under the current signer before the operator stops co-signing on behalf of the old key. The SDK handles this automatically for both SingleKey and HD wallets.
+
+## How Rotation Works
+
+When arkd rotates its signer, the old key moves into `ArkServerInfo.DeprecatedSigners` with a cutoff timestamp. Depending on where a VTXO stands relative to that cutoff, the SDK applies one of three strategies:
+
+| Regime | Condition | Action |
+|--------|-----------|--------|
+| 1 — Collaborative sweep | Before cutoff (or no cutoff) | `ServerKeyRotationSweepPolicy` sweeps the VTXO into a new one under the current signer |
+| 2 — Wait | After cutoff, before VTXO expiry | Operator refuses to co-sign; the VTXO waits until it becomes recoverable |
+| 3 — Recovery re-enroll | After VTXO expiry (`IsRecoverable`) | Wallet re-enrolls via the intent scheduler; the batch session skips forfeit so the old key is not needed |
+
+Coin gathering is keyed on VTXO **script**, not contract `Active` state, so deactivating a stale default contract never strands its funds.
+
+## Detection
+
+The SDK detects a rotation through two paths:
+
+- **Mid-request** (`DIGEST_MISMATCH`): if arkd rejects a request because the cached server-info digest no longer matches, `CachingClientTransport` clears the cache and raises `IServerInfoCacheInvalidation.ServerInfoChanged` before re-throwing `DigestMismatchException`.
+- **TTL refresh**: when the 5-minute server-info cache expires and the fresh fetch returns a different digest, `ServerInfoChanged` is raised with `Reason = TtlExpiry`.
+
+Both paths funnel through the same event so consumers need only one subscription.
+
+## SingleKey Wallet Reconciliation
+
+A SingleKey wallet's "Default" receive contract is derived from `ArkServerInfo.SignerKey`. After rotation the old-signer default becomes stale. `ContractReconciliationService` keeps defaults aligned automatically:
+
+- On **startup** — reconciles all SingleKey wallets (catches rotations that happened while the app was offline).
+- On **`WalletSaved`** — reconciles the newly created or updated wallet.
+- On **`ServerInfoChanged`** — reconciles all SingleKey wallets.
+
+Reconciliation calls `ISingleKeyDefaultEnsurer.EnsureDefaultAsync` to upsert the current-signer default, then deactivates any `Source="Default"` row whose script no longer matches. This is wired up automatically by `AddArkCoreServices`; no extra registration is needed.
+
+## SingleKey Discovery After Rotation
+
+`SingleKeyVtxoRecoveryService.DiscoverAsync` probes every registered `IContractDiscoveryProvider` with the wallet's flat `tr(pubkey)` descriptor. `IndexerVtxoDiscoveryProvider` internally cross-products `{current signer ∪ deprecated signers}`, so VTXOs stranded under a rotated signer are re-discovered automatically and persisted as `Active` contracts.
+
+## Version and Digest Headers
+
+Every outgoing gRPC and REST request carries two headers:
+
+| Header | Value | Purpose |
+|--------|-------|---------|
+| `X-Build-Version` | `ArkdVersion.TargetBuild` (e.g. `0.9.7`) | Lets arkd reject SDKs that are too old (`BUILD_VERSION_TOO_OLD`) |
+| `X-Digest` | Current server-info digest | Lets arkd detect stale cached configuration (`DIGEST_MISMATCH`) |
+
+The headers are injected by `BuildVersionInterceptor` (gRPC) and `BuildVersionHandler` (REST). Both throw typed exceptions on rejection:
+
+- `IncompatibleSdkVersionException` — SDK build version too old; upgrade the NArk SDK package.
+- `DigestMismatchException` — Server configuration changed mid-session; call `GetServerInfoAsync` to refresh then retry.
+
+> **Note:** The `RestClientTransport(HttpClient)` constructor overload (for Blazor WASM / `IHttpClientFactory`) does not insert `BuildVersionHandler` into the pipeline. Use the `RestClientTransport(string uri)` URI-based constructor if automatic digest/version checking is required.
+
+## Listening for Rotation Events
+
+Inject `IServerInfoCacheInvalidation` to react to a rotation in your own services:
+
+```csharp
+public class MyRotationAwareService(IServerInfoCacheInvalidation serverInfoCache)
+{
+    public void Start()
+    {
+        serverInfoCache.ServerInfoChanged += OnServerInfoChanged;
+    }
+
+    private void OnServerInfoChanged(object? sender, ServerInfoChangedEventArgs e)
+    {
+        // e.Reason: ManualInvalidation | DigestMismatch | TtlExpiry
+        // e.PreviousDigest / e.NewDigest available when Reason == TtlExpiry
+        Console.WriteLine($"Arkade server info changed: {e.Reason}");
+    }
+}
+```
+
+`IServerInfoCacheInvalidation` is DI-aliased to the same `CachingClientTransport` singleton that `IClientTransport` resolves to, so no extra registration is needed — just inject the interface.

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -16,5 +16,7 @@
   href: recovery.md
 - name: Pending Tx Recovery
   href: pending-tx-recovery.md
+- name: Signer-Key Rotation
+  href: signer-rotation.md
 - name: Development
   href: development.md


### PR DESCRIPTION
   ## Fixed
   - fix(reconcile): store linked CTS as field (_multiToken) and dispose it in DisposeAsync — previously it was a local var leaking CTS registrations on each StartAsync call
   - fix(reconcile): LogWarning (not LogInformation) for exceptions in the worker loop — they represent real background job failures
   - fix(transport): clarify RestClientTransport(HttpClient) doc comment — BuildVersionHandler is internal so "caller is responsible for adding it" is impossible; explain the limitation and point to the URI constructor
  ## Refractored
   - refactor(sweeper): remove unnecessary ToArray() materialization in ServerKeyRotationSweepPolicy.SweepAsync — GetServerInfoAsync is awaited before the yield loop so no async/yield conflict exists
   - refractor(sweeper): use ECXOnlyPubkeyComparer (temporary solution until NBitcoin PR gets merged)
   - test(reconcile): remove Task.Delay(200) timing assumption from WalletSaved_Hd_does_not_ensure — OnWalletSaved pre-filters HD wallets before enqueuing so the assertion is deterministic without any delay
  ## Documented
   - docs: add signer-rotation.md article covering rotation regimes, detection paths, reconciliation, and version/digest headers; wire into toc.yml and add README section
   - docs(transport): add XML doc comments to ServerInfoChangedReason enum values and ServerInfoChangedEventArgs properties (CLAUDE.md requirement)
   - docs(sweeper): add XML `<summary>` to ServerKeyRotationSweepPolicy class