### PR TITLE
fix(transport): address signer-rotation review findings

### DIFF
--- a/NArk.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/NArk.Core/Hosting/ServiceCollectionExtensions.cs
@@ -187,15 +187,14 @@ public static class ServiceCollectionExtensions
         // Register the raw gRPC transport
         services.AddSingleton(_ => new GrpcClientTransport(config.ArkUri));
 
-        // Register IClientTransport with caching wrapper as the default
-        services.AddSingleton<IClientTransport>(sp =>
-        {
-            var inner = sp.GetRequiredService<GrpcClientTransport>();
-            var logger = sp.GetService<ILogger<CachingClientTransport>>();
-            return new CachingClientTransport(inner, logger);
-        });
-        services.AddSingleton<IServerInfoCacheInvalidation>(sp =>
-            (IServerInfoCacheInvalidation)sp.GetRequiredService<IClientTransport>());
+        // Register the caching wrapper as the concrete singleton so both IClientTransport and
+        // IServerInfoCacheInvalidation alias the same instance without an unsafe cast.
+        services.AddSingleton<CachingClientTransport>(sp =>
+            new CachingClientTransport(
+                sp.GetRequiredService<GrpcClientTransport>(),
+                sp.GetService<ILogger<CachingClientTransport>>()));
+        services.AddSingleton<IClientTransport>(sp => sp.GetRequiredService<CachingClientTransport>());
+        services.AddSingleton<IServerInfoCacheInvalidation>(sp => sp.GetRequiredService<CachingClientTransport>());
 
         return services;
     }
@@ -214,15 +213,14 @@ public static class ServiceCollectionExtensions
         // Register the REST transport
         services.AddSingleton(_ => new RestClientTransport(config.ArkUri));
 
-        // Register IClientTransport with caching wrapper as the default
-        services.AddSingleton<IClientTransport>(sp =>
-        {
-            var inner = sp.GetRequiredService<RestClientTransport>();
-            var logger = sp.GetService<ILogger<CachingClientTransport>>();
-            return new CachingClientTransport(inner, logger);
-        });
-        services.AddSingleton<IServerInfoCacheInvalidation>(sp =>
-            (IServerInfoCacheInvalidation)sp.GetRequiredService<IClientTransport>());
+        // Register the caching wrapper as the concrete singleton so both IClientTransport and
+        // IServerInfoCacheInvalidation alias the same instance without an unsafe cast.
+        services.AddSingleton<CachingClientTransport>(sp =>
+            new CachingClientTransport(
+                sp.GetRequiredService<RestClientTransport>(),
+                sp.GetService<ILogger<CachingClientTransport>>()));
+        services.AddSingleton<IClientTransport>(sp => sp.GetRequiredService<CachingClientTransport>());
+        services.AddSingleton<IServerInfoCacheInvalidation>(sp => sp.GetRequiredService<CachingClientTransport>());
 
         return services;
     }

--- a/NArk.Core/Transport/CachingClientTransport.cs
+++ b/NArk.Core/Transport/CachingClientTransport.cs
@@ -53,6 +53,9 @@ public class CachingClientTransport : IClientTransport, IServerInfoCacheInvalida
         }
 
         await _lock.WaitAsync(cancellationToken);
+        // Captured under the lock, fired AFTER release to prevent deadlock if a handler
+        // calls GetServerInfoAsync (SemaphoreSlim(1,1) is not reentrant).
+        ServerInfoChangedEventArgs? postLockEvent = null;
         try
         {
             // Double-check after acquiring lock
@@ -81,28 +84,29 @@ public class CachingClientTransport : IClientTransport, IServerInfoCacheInvalida
                 serverInfo.Network.Name, serverInfo.Dust);
 
             // Refresh-path rotation detection: if we had a previous value and the digest changed,
-            // raise ServerInfoChanged WITHOUT invalidating — this is a normal refresh, the fresh
-            // value is already cached and valid. Handlers only enqueue, so raising under the lock
-            // doesn't deadlock. The DigestMismatchException path handles the mid-request case and
-            // doesn't overlap (that throws before reaching here).
+            // schedule ServerInfoChanged for after the lock is released.
             if (previousDigest is not null && previousDigest != serverInfo.Digest)
             {
                 _logger?.LogInformation(
                     "Server info digest changed on TTL refresh ({Previous} -> {New}); raising ServerInfoChanged",
                     previousDigest, serverInfo.Digest);
-                ServerInfoChanged?.Invoke(this, new ServerInfoChangedEventArgs
+                postLockEvent = new ServerInfoChangedEventArgs
                 {
                     Reason = ServerInfoChangedReason.TtlExpiry,
                     PreviousDigest = previousDigest,
                     NewDigest = serverInfo.Digest,
-                });
+                };
             }
 
             return serverInfo;
         }
         catch (DigestMismatchException)
         {
-            InvalidateServerInfoCache(new ServerInfoChangedEventArgs { Reason = ServerInfoChangedReason.DigestMismatch });
+            // Clear cache state under the lock for consistency; the event fires after release
+            // via postLockEvent so handlers can safely call GetServerInfoAsync without deadlocking.
+            ClearCacheCore();
+            _logger?.LogDebug("Server info cache invalidated ({Reason})", ServerInfoChangedReason.DigestMismatch);
+            postLockEvent = new ServerInfoChangedEventArgs { Reason = ServerInfoChangedReason.DigestMismatch };
             throw;
         }
         catch (Exception ex)
@@ -121,7 +125,15 @@ public class CachingClientTransport : IClientTransport, IServerInfoCacheInvalida
         finally
         {
             _lock.Release();
+            if (postLockEvent is not null)
+                ServerInfoChanged?.Invoke(this, postLockEvent);
         }
+    }
+
+    private void ClearCacheCore()
+    {
+        _cachedServerInfo = null;
+        _serverInfoExpiresAt = DateTimeOffset.MinValue;
     }
 
     /// <summary>
@@ -131,8 +143,7 @@ public class CachingClientTransport : IClientTransport, IServerInfoCacheInvalida
     /// </summary>
     public void InvalidateServerInfoCache(ServerInfoChangedEventArgs? args = null)
     {
-        _cachedServerInfo = null;
-        _serverInfoExpiresAt = DateTimeOffset.MinValue;
+        ClearCacheCore();
         var eventArgs = args ?? new ServerInfoChangedEventArgs();
         _logger?.LogDebug("Server info cache invalidated ({Reason})", eventArgs.Reason);
         ServerInfoChanged?.Invoke(this, eventArgs);

--- a/NArk.Core/Transport/GrpcClient/BuildVersionInterceptor.cs
+++ b/NArk.Core/Transport/GrpcClient/BuildVersionInterceptor.cs
@@ -36,7 +36,7 @@ internal sealed class BuildVersionInterceptor(DigestHolder digestHolder) : Inter
     {
         var call = continuation(request, WithHeaders(context));
         return new AsyncServerStreamingCall<TResponse>(
-            call.ResponseStream,
+            new GuardedStreamReader<TResponse>(call.ResponseStream, digestHolder),
             GuardAsync(call.ResponseHeadersAsync),
             call.GetStatus,
             call.GetTrailers,
@@ -64,7 +64,7 @@ internal sealed class BuildVersionInterceptor(DigestHolder digestHolder) : Inter
         var call = continuation(WithHeaders(context));
         return new AsyncDuplexStreamingCall<TRequest, TResponse>(
             call.RequestStream,
-            call.ResponseStream,
+            new GuardedStreamReader<TResponse>(call.ResponseStream, digestHolder),
             GuardAsync(call.ResponseHeadersAsync),
             call.GetStatus,
             call.GetTrailers,
@@ -87,6 +87,35 @@ internal sealed class BuildVersionInterceptor(DigestHolder digestHolder) : Inter
             digestHolder.Clear();
             throw new DigestMismatchException(
                 "Arkade server reported a configuration digest mismatch. Server info cache has been cleared; retry after calling GetServerInfoAsync.");
+        }
+    }
+
+    /// <summary>
+    /// Wraps an <see cref="IAsyncStreamReader{T}"/> so that <c>DIGEST_MISMATCH</c> and
+    /// <c>BUILD_VERSION_TOO_OLD</c> gRPC trailing-status errors are translated to the
+    /// typed SDK exceptions on every <see cref="MoveNext"/> call, not just on response headers.
+    /// </summary>
+    private sealed class GuardedStreamReader<T>(IAsyncStreamReader<T> inner, DigestHolder digestHolder) : IAsyncStreamReader<T>
+    {
+        public T Current => inner.Current;
+
+        public async Task<bool> MoveNext(CancellationToken cancellationToken)
+        {
+            try
+            {
+                return await inner.MoveNext(cancellationToken).ConfigureAwait(false);
+            }
+            catch (RpcException ex) when (ex.Status.Detail.Contains("BUILD_VERSION_TOO_OLD", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new IncompatibleSdkVersionException(
+                    $"Arkade server rejected SDK build {ArkdVersion.TargetBuild}: server requires a newer SDK version. Upgrade the NArk SDK package.");
+            }
+            catch (RpcException ex) when (ex.Status.Detail.Contains("DIGEST_MISMATCH", StringComparison.OrdinalIgnoreCase))
+            {
+                digestHolder.Clear();
+                throw new DigestMismatchException(
+                    "Arkade server reported a configuration digest mismatch. Server info cache has been cleared; retry after calling GetServerInfoAsync.");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- **fix(grpc):** `BuildVersionInterceptor` — add `GuardedStreamReader<T>` that
  translates `RpcException(DIGEST_MISMATCH / BUILD_VERSION_TOO_OLD)` on every
  `MoveNext` call for server-streaming and duplex-streaming RPCs. Previously only
  `ResponseHeadersAsync` was guarded, so mid-stream digest mismatches propagated
  as raw `RpcException` and never invalidated the server-info cache.

- **fix(transport):** `CachingClientTransport` — defer `ServerInfoChanged` event
  dispatch to after `_lock.Release()` (captured via `postLockEvent` in `finally`).
  Previously the event fired while the lock was held on both the TTL-refresh path
  and the `DigestMismatchException` catch path, allowing a blocking handler to
  deadlock on a re-entrant `GetServerInfoAsync` call.

- **fix(di):** `ServiceCollectionExtensions` — register `CachingClientTransport`
  as the concrete singleton and alias both `IClientTransport` and
  `IServerInfoCacheInvalidation` to it. Previously `IServerInfoCacheInvalidation`
  was wired by casting `IClientTransport`, which throws `InvalidCastException` at
  runtime if the caller replaces `IClientTransport` with a custom transport.