### PR TITLE
feat(safety): disable a wallet sweep destination orphaned by a signer rotation

### DIFF
--- a/NArk.Abstractions/Wallets/IDestinationSafetyNotifier.cs
+++ b/NArk.Abstractions/Wallets/IDestinationSafetyNotifier.cs
@@ -1,0 +1,20 @@
+namespace NArk.Abstractions.Wallets;
+
+/// <summary>Raised when a wallet's sweep destination is auto-disabled because an Arkade signer rotation made it stale.</summary>
+public sealed class DestinationDisabledEventArgs : EventArgs
+{
+    public required string WalletId { get; init; }
+    /// <summary>The (now stale) destination address string that was disabled.</summary>
+    public required string Destination { get; init; }
+    /// <summary>The deprecated server key (hex) the destination was pinned to.</summary>
+    public required string DeprecatedServerKey { get; init; }
+}
+
+/// <summary>
+/// Notifies consumers (e.g. a BTCPay plugin) that a wallet's sweep destination was disabled pending
+/// re-confirmation after an Arkade signer rotation. DI-aliased to the same singleton that performs detection.
+/// </summary>
+public interface IDestinationSafetyNotifier
+{
+    event EventHandler<DestinationDisabledEventArgs>? DestinationDisabled;
+}

--- a/NArk.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/NArk.Core/Hosting/ServiceCollectionExtensions.cs
@@ -143,6 +143,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IOnchainService, OnchainService>();
         services.AddSingleton<SweeperService>();
         services.AddSingleton<ContractReconciliationService>();
+        services.AddSingleton<IDestinationSafetyNotifier>(sp => sp.GetRequiredService<ContractReconciliationService>());
         services.AddSingleton<ISweepPolicy, ServerKeyRotationSweepPolicy>();
         services.AddSingleton<PendingArkTransactionRecoveryService>();
         services.AddSingleton<IFeeEstimator, DefaultFeeEstimator>();

--- a/NArk.Core/Services/ContractReconciliationService.cs
+++ b/NArk.Core/Services/ContractReconciliationService.cs
@@ -1,5 +1,6 @@
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
+using NArk.Abstractions;
 using NArk.Abstractions.Contracts;
 using NArk.Abstractions.Wallets;
 using NArk.Core.Recovery;
@@ -42,8 +43,11 @@ public class ContractReconciliationService(
     IServerInfoCacheInvalidation serverInfoCacheInvalidation,
     IClientTransport clientTransport,
     ILogger<ContractReconciliationService>? logger = null,
-    TimeSpan? reconcileAllRetryDelay = null) : IAsyncDisposable
+    TimeSpan? reconcileAllRetryDelay = null) : IAsyncDisposable, IDestinationSafetyNotifier
 {
+    /// <inheritdoc/>
+    public event EventHandler<DestinationDisabledEventArgs>? DestinationDisabled;
+
     private const string SourceMetadataKey = "Source";
     private const string DefaultSourceValue = "Default";
 
@@ -164,8 +168,6 @@ public class ContractReconciliationService(
         var wallets = await walletStorage.LoadAllWallets(cancellationToken);
         foreach (var wallet in wallets)
         {
-            if (wallet.WalletType != WalletType.SingleKey)
-                continue;
             cancellationToken.ThrowIfCancellationRequested();
             try
             {
@@ -195,6 +197,41 @@ public class ContractReconciliationService(
             logger?.LogDebug("Reconciliation skipped: wallet {WalletId} not found", walletId);
             return;
         }
+
+        // Destination-safety check: runs for any wallet type that has an Arkade destination.
+        ArkAddress.TryParse(wallet.Destination ?? string.Empty, out var dest);
+        if (dest is not null)
+        {
+            var serverInfo = await clientTransport.GetServerInfoAsync(cancellationToken);
+            var isStale = DestinationSafety.IsStale(dest, serverInfo);
+            var alreadyFlagged = wallet.Metadata?.ContainsKey(DestinationSafety.PendingConfirmationMetadataKey) == true;
+
+            if (isStale && !alreadyFlagged)
+            {
+                var deprecatedHex = Convert.ToHexString(dest.ServerKey.ToBytes()).ToLowerInvariant();
+                await walletStorage.SetMetadataValue(
+                    walletId, DestinationSafety.PendingConfirmationMetadataKey, deprecatedHex, cancellationToken);
+                DestinationDisabled?.Invoke(this, new DestinationDisabledEventArgs
+                {
+                    WalletId = wallet.Id,
+                    Destination = wallet.Destination!,
+                    DeprecatedServerKey = deprecatedHex,
+                });
+                logger?.LogWarning(
+                    "Arkade sweep destination for wallet {WalletId} is stale (deprecated server key {Key}); destination disabled pending re-confirmation",
+                    walletId, deprecatedHex);
+            }
+            else if (!isStale && alreadyFlagged)
+            {
+                await walletStorage.SetMetadataValue(
+                    walletId, DestinationSafety.PendingConfirmationMetadataKey, null, cancellationToken);
+                logger?.LogInformation(
+                    "Arkade sweep destination for wallet {WalletId} is no longer stale; cleared pending-confirmation flag",
+                    walletId);
+            }
+            // stale && alreadyFlagged → no-op (no duplicate event, no redundant write)
+        }
+
         if (wallet.WalletType != WalletType.SingleKey)
             return;
 
@@ -229,8 +266,9 @@ public class ContractReconciliationService(
 
     private void OnWalletSaved(object? sender, ArkWalletInfo wallet)
     {
-        // Cheap pre-filter so we don't enqueue work for HD wallets; the worker re-checks.
-        if (wallet.WalletType != WalletType.SingleKey)
+        // Enqueue for SingleKey wallets (default-contract reconciliation) and for any
+        // wallet with a non-empty Destination (destination-safety re-check on re-save).
+        if (wallet.WalletType != WalletType.SingleKey && string.IsNullOrEmpty(wallet.Destination))
             return;
         _jobs.Writer.TryWrite(new ReconcileWalletJob(wallet.Id));
     }

--- a/NArk.Core/Services/ContractReconciliationService.cs
+++ b/NArk.Core/Services/ContractReconciliationService.cs
@@ -10,7 +10,8 @@ namespace NArk.Core.Services;
 
 /// <summary>
 /// Keeps every SingleKey wallet's advertised "Default" contract aligned with the
-/// CURRENT arkd signer.
+/// CURRENT arkd signer, and flags any wallet whose Arkade sweep destination was
+/// orphaned by a signer rotation.
 /// <para>
 /// A SingleKey wallet's Default contract is derived from <c>ArkServerInfo.SignerKey</c>.
 /// When arkd rotates its signer, the old-signer Default becomes stale: the new-signer
@@ -24,6 +25,15 @@ namespace NArk.Core.Services;
 /// <item><see cref="IServerInfoCacheInvalidation.ServerInfoChanged"/> (signer rotated) → reconcile ALL SingleKey wallets.</item>
 /// <item>Startup pass on <see cref="StartAsync"/> → reconcile ALL SingleKey wallets (covers wallets rotated while offline).</item>
 /// </list>
+/// </para>
+/// <para>
+/// <b>Destination safety:</b> on the same triggers, for ANY wallet (SingleKey or HD) that has a
+/// sweep destination, if the destination's <see cref="ArkAddress"/> server key is now a deprecated
+/// signer the destination is flagged pending re-confirmation (a Metadata marker via
+/// <see cref="DestinationSafety"/>) and <see cref="IDestinationSafetyNotifier.DestinationDisabled"/>
+/// is raised once (on the set transition); a destination that is no longer stale clears the flag.
+/// <see cref="IWalletStorage.WalletSaved"/> therefore also enqueues HD wallets that carry a
+/// destination, so a re-save clears the flag.
 /// </para>
 /// <para>
 /// <b>Supersede semantics:</b> funds safety does NOT depend on the deactivation — the sweeper

--- a/NArk.Core/Services/DestinationSafety.cs
+++ b/NArk.Core/Services/DestinationSafety.cs
@@ -1,0 +1,25 @@
+using NArk.Abstractions;
+using NArk.Abstractions.Extensions;
+using NBitcoin.Secp256k1;
+
+namespace NArk.Core.Services;
+
+/// <summary>Detects when a wallet's sweep destination has been orphaned by an Arkade signer rotation.</summary>
+public static class DestinationSafety
+{
+    /// <summary>Metadata key marking a destination disabled pending user re-confirmation. Value = deprecated server key (hex).</summary>
+    public const string PendingConfirmationMetadataKey = "destination:pendingConfirmation";
+
+    /// <summary>
+    /// True when <paramref name="destination"/> points at a server signer key that was ours and is now
+    /// deprecated (literally targets the rotated-away signer). External keys never in our deprecated
+    /// set, and the current signer, are not stale.
+    /// </summary>
+    public static bool IsStale(ArkAddress? destination, ArkServerInfo serverInfo)
+    {
+        if (destination is null || serverInfo.DeprecatedSigners.Count == 0) return false;
+        foreach (var deprecated in serverInfo.DeprecatedSigners.Keys)
+            if (ECXOnlyPubKeyComparer.Instance.Equals(deprecated, destination.ServerKey)) return true;
+        return false;
+    }
+}

--- a/NArk.Core/Wallet/DefaultWalletProvider.cs
+++ b/NArk.Core/Wallet/DefaultWalletProvider.cs
@@ -4,6 +4,7 @@ using NArk.Abstractions;
 using NArk.Abstractions.Contracts;
 using NArk.Abstractions.Safety;
 using NArk.Abstractions.Wallets;
+using NArk.Core.Services;
 using NArk.Core.Transport;
 using NArk.Core.Wallet.SigningSources;
 using NBitcoin;
@@ -104,9 +105,9 @@ public class DefaultWalletProvider(
                 infoMs, swLoad.ElapsedMilliseconds);
 
             ArkAddress? sweepDestination = null;
-            if (!string.IsNullOrEmpty(wallet.Destination))
+            if (ShouldUseDestination(wallet))
             {
-                sweepDestination = ArkAddress.Parse(wallet.Destination);
+                sweepDestination = ArkAddress.Parse(wallet.Destination!);
             }
 
             // Cross-check the stored descriptor against the one derived from the local nsec —
@@ -138,4 +139,13 @@ public class DefaultWalletProvider(
             return null;
         }
     }
+
+    /// <summary>
+    /// Returns <c>true</c> when the wallet's destination is present and not flagged pending
+    /// re-confirmation after an Arkade signer rotation. When <c>false</c>, the sweep destination
+    /// is suppressed and funds sweep to self-output instead.
+    /// </summary>
+    internal static bool ShouldUseDestination(ArkWalletInfo wallet)
+        => !string.IsNullOrEmpty(wallet.Destination)
+           && wallet.Metadata?.ContainsKey(DestinationSafety.PendingConfirmationMetadataKey) != true;
 }

--- a/NArk.Tests/Services/ContractReconciliationServiceTests.cs
+++ b/NArk.Tests/Services/ContractReconciliationServiceTests.cs
@@ -1,9 +1,15 @@
+using NArk.Abstractions;
 using NArk.Abstractions.Contracts;
+using NArk.Abstractions.Extensions;
 using NArk.Abstractions.Wallets;
 using NArk.Core;
 using NArk.Core.Recovery;
+using NArk.Core.Scripts;
 using NArk.Core.Services;
 using NArk.Core.Transport;
+using NBitcoin;
+using NBitcoin.Scripting;
+using NBitcoin.Secp256k1;
 using NSubstitute;
 
 namespace NArk.Tests.Services;
@@ -267,5 +273,130 @@ public class ContractReconciliationServiceTests
                 return;
             await Task.Delay(20);
         }
+    }
+
+    // ── Destination-safety tests ──────────────────────────────────────────────
+
+    [Test]
+    public async Task ReconcileWallet_flags_and_raises_when_destination_is_stale()
+    {
+        var deprecated = NewKey();
+        var serverInfo = MakeServerInfo(currentSigner: NewKey(), deprecated: [deprecated]);
+        _clientTransport.GetServerInfoAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(serverInfo));
+
+        var address = MakeAddress(serverKey: deprecated);
+        var wallet = new ArkWalletInfo("w1", null, address.ToString(isMainnet: false), WalletType.SingleKey,
+            "tr(0000000000000000000000000000000000000000000000000000000000000001)", 0, Metadata: null);
+        _walletStorage.GetWalletById("w1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ArkWalletInfo?>(wallet));
+
+        DestinationDisabledEventArgs? raised = null;
+        var sut = CreateService();
+        ((IDestinationSafetyNotifier)sut).DestinationDisabled += (_, e) => raised = e;
+
+        await sut.ReconcileWalletAsync("w1", CancellationToken.None);
+
+        await _walletStorage.Received(1).SetMetadataValue(
+            "w1",
+            DestinationSafety.PendingConfirmationMetadataKey,
+            Arg.Is<string?>(v => v != null),
+            Arg.Any<CancellationToken>());
+
+        Assert.That(raised, Is.Not.Null, "DestinationDisabled event should have fired");
+        Assert.That(raised!.WalletId, Is.EqualTo("w1"));
+    }
+
+    [Test]
+    public async Task ReconcileWallet_clears_flag_when_destination_not_stale()
+    {
+        var current = NewKey();
+        var serverInfo = MakeServerInfo(currentSigner: current, deprecated: [NewKey()]);
+        _clientTransport.GetServerInfoAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(serverInfo));
+
+        var address = MakeAddress(serverKey: current);
+        var metadata = new Dictionary<string, string>
+        {
+            [DestinationSafety.PendingConfirmationMetadataKey] = "some-old-hex"
+        };
+        var wallet = new ArkWalletInfo("w1", null, address.ToString(isMainnet: false), WalletType.SingleKey,
+            "tr(0000000000000000000000000000000000000000000000000000000000000001)", 0, Metadata: metadata);
+        _walletStorage.GetWalletById("w1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ArkWalletInfo?>(wallet));
+
+        var sut = CreateService();
+        await sut.ReconcileWalletAsync("w1", CancellationToken.None);
+
+        await _walletStorage.Received(1).SetMetadataValue(
+            "w1",
+            DestinationSafety.PendingConfirmationMetadataKey,
+            null,
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ReconcileWallet_no_duplicate_event_when_already_flagged()
+    {
+        var deprecated = NewKey();
+        var deprecatedHex = Convert.ToHexString(deprecated.ToBytes()).ToLowerInvariant();
+        var serverInfo = MakeServerInfo(currentSigner: NewKey(), deprecated: [deprecated]);
+        _clientTransport.GetServerInfoAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(serverInfo));
+
+        var address = MakeAddress(serverKey: deprecated);
+        var metadata = new Dictionary<string, string>
+        {
+            [DestinationSafety.PendingConfirmationMetadataKey] = deprecatedHex
+        };
+        var wallet = new ArkWalletInfo("w1", null, address.ToString(isMainnet: false), WalletType.SingleKey,
+            "tr(0000000000000000000000000000000000000000000000000000000000000001)", 0, Metadata: metadata);
+        _walletStorage.GetWalletById("w1", Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ArkWalletInfo?>(wallet));
+
+        var eventFired = false;
+        var sut = CreateService();
+        ((IDestinationSafetyNotifier)sut).DestinationDisabled += (_, _) => eventFired = true;
+
+        await sut.ReconcileWalletAsync("w1", CancellationToken.None);
+
+        Assert.That(eventFired, Is.False, "DestinationDisabled event must NOT fire when already flagged");
+        await _walletStorage.DidNotReceive().SetMetadataValue(
+            "w1",
+            DestinationSafety.PendingConfirmationMetadataKey,
+            Arg.Any<string?>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    // ── Test helpers ─────────────────────────────────────────────────────────
+
+    private static ECXOnlyPubKey NewKey()
+        => ECXOnlyPubKey.Create(new NBitcoin.Key().PubKey.TaprootInternalKey.ToBytes());
+
+    private static ArkServerInfo MakeServerInfo(ECXOnlyPubKey currentSigner, ECXOnlyPubKey[] deprecated)
+    {
+        var deprecatedDict = new Dictionary<ECXOnlyPubKey, long>(ECXOnlyPubKeyComparer.Instance);
+        foreach (var key in deprecated)
+            deprecatedDict[key] = 0;
+
+        var emptyMultisig = new NofNMultisigTapScript(Array.Empty<ECXOnlyPubKey>());
+        return new ArkServerInfo(
+            Dust: Money.Satoshis(546),
+            SignerKey: currentSigner.ToOutputDescriptor(Network.RegTest),
+            DeprecatedSigners: deprecatedDict,
+            Network: Network.RegTest,
+            UnilateralExit: new Sequence(144),
+            BoardingExit: new Sequence(144),
+            ForfeitAddress: BitcoinAddress.Create("bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080", Network.RegTest),
+            ForfeitPubKey: currentSigner,
+            CheckpointTapScript: new UnilateralPathArkTapScript(new Sequence(144), emptyMultisig),
+            FeeTerms: new ArkOperatorFeeTerms("1", "0", "0", "0", "0"),
+            Digest: "test-digest");
+    }
+
+    private static ArkAddress MakeAddress(ECXOnlyPubKey serverKey)
+    {
+        var tweakedKey = NewKey();
+        return new ArkAddress(tweakedKey, serverKey, version: 0, isMainnet: false);
     }
 }

--- a/NArk.Tests/Services/ContractReconciliationServiceTests.cs
+++ b/NArk.Tests/Services/ContractReconciliationServiceTests.cs
@@ -224,6 +224,36 @@ public class ContractReconciliationServiceTests
     }
 
     [Test]
+    public async Task WalletSaved_Hd_with_stale_destination_enqueues_and_flags()
+    {
+        // OnWalletSaved is broadened to enqueue HD wallets that carry a destination (so a re-save
+        // clears the flag). Here an HD wallet with a stale destination must be reconciled and flagged
+        // — but still NOT get a default ensured (that path stays SingleKey-only).
+        var deprecated = NewKey();
+        _clientTransport.GetServerInfoAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(MakeServerInfo(currentSigner: NewKey(), deprecated: [deprecated])));
+
+        var hd = HdWallet() with { Destination = MakeAddress(serverKey: deprecated).ToString(isMainnet: false) };
+        _walletStorage.GetWalletById(hd.Id, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ArkWalletInfo?>(hd));
+        _walletStorage.LoadAllWallets(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlySet<ArkWalletInfo>>(new HashSet<ArkWalletInfo>()));
+
+        await using var sut = CreateService();
+        await sut.StartAsync(CancellationToken.None);
+
+        _walletStorage.WalletSaved += Raise.Event<EventHandler<ArkWalletInfo>>(_walletStorage, hd);
+
+        await WaitForAsync(() => _walletStorage.ReceivedCalls()
+            .Any(c => c.GetMethodInfo().Name == nameof(IWalletStorage.SetMetadataValue)));
+
+        await _walletStorage.Received().SetMetadataValue(
+            hd.Id, DestinationSafety.PendingConfirmationMetadataKey,
+            Arg.Is<string?>(v => v != null), Arg.Any<CancellationToken>());
+        await _ensurer.DidNotReceive().EnsureDefaultAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
     public async Task StartupPass_BackendUnavailable_isRetried_thenReconciles()
     {
         // I1 follow-up: "arkd down at boot" does NOT surface as LoadAllWallets throwing

--- a/NArk.Tests/Services/DestinationSafetyTests.cs
+++ b/NArk.Tests/Services/DestinationSafetyTests.cs
@@ -1,0 +1,78 @@
+using NArk.Abstractions;
+using NArk.Abstractions.Extensions;
+using NArk.Core;
+using NArk.Core.Scripts;
+using NArk.Core.Services;
+using NBitcoin;
+using NBitcoin.Scripting;
+using NBitcoin.Secp256k1;
+
+namespace NArk.Tests.Services;
+
+[TestFixture]
+public class DestinationSafetyTests
+{
+    [Test]
+    public void IsStale_true_when_destination_server_key_is_deprecated()
+    {
+        var deprecated = NewKey();
+        var info = MakeServerInfo(currentSigner: NewKey(), deprecated: [deprecated]);
+        var dest = MakeAddress(serverKey: deprecated);
+        Assert.That(DestinationSafety.IsStale(dest, info), Is.True);
+    }
+
+    [Test]
+    public void IsStale_false_when_destination_server_key_is_current()
+    {
+        var current = NewKey();
+        var info = MakeServerInfo(currentSigner: current, deprecated: [NewKey()]);
+        var dest = MakeAddress(serverKey: current);
+        Assert.That(DestinationSafety.IsStale(dest, info), Is.False);
+    }
+
+    [Test]
+    public void IsStale_false_for_external_key_not_in_deprecated_set()
+    {
+        var info = MakeServerInfo(currentSigner: NewKey(), deprecated: [NewKey()]);
+        var dest = MakeAddress(serverKey: NewKey());
+        Assert.That(DestinationSafety.IsStale(dest, info), Is.False);
+    }
+
+    [Test]
+    public void IsStale_false_when_destination_null()
+        => Assert.That(DestinationSafety.IsStale(null, MakeServerInfo(NewKey(), [])), Is.False);
+
+    private static ECXOnlyPubKey NewKey()
+        => ECXOnlyPubKey.Create(new NBitcoin.Key().PubKey.TaprootInternalKey.ToBytes());
+
+    private static OutputDescriptor MakeDescriptor(ECXOnlyPubKey key)
+        => key.ToOutputDescriptor(Network.RegTest);
+
+    private static ArkServerInfo MakeServerInfo(ECXOnlyPubKey currentSigner, ECXOnlyPubKey[] deprecated)
+    {
+        var deprecatedDict = new Dictionary<ECXOnlyPubKey, long>(ECXOnlyPubKeyComparer.Instance);
+        foreach (var key in deprecated)
+            deprecatedDict[key] = 0;
+
+        var emptyMultisig = new NofNMultisigTapScript(Array.Empty<ECXOnlyPubKey>());
+        return new ArkServerInfo(
+            Dust: Money.Satoshis(546),
+            SignerKey: MakeDescriptor(currentSigner),
+            DeprecatedSigners: deprecatedDict,
+            Network: Network.RegTest,
+            UnilateralExit: new Sequence(144),
+            BoardingExit: new Sequence(144),
+            ForfeitAddress: BitcoinAddress.Create("bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080", Network.RegTest),
+            ForfeitPubKey: currentSigner,
+            CheckpointTapScript: new UnilateralPathArkTapScript(new Sequence(144), emptyMultisig),
+            FeeTerms: new ArkOperatorFeeTerms("1", "0", "0", "0", "0"),
+            Digest: "test-digest");
+    }
+
+    private static ArkAddress MakeAddress(ECXOnlyPubKey serverKey)
+    {
+        // tweakedKey is the user-side key — use a fresh key so it's distinct from serverKey
+        var tweakedKey = NewKey();
+        return new ArkAddress(tweakedKey, serverKey, version: 0, isMainnet: false);
+    }
+}

--- a/NArk.Tests/Wallet/DefaultWalletProviderDestinationSkipTests.cs
+++ b/NArk.Tests/Wallet/DefaultWalletProviderDestinationSkipTests.cs
@@ -1,0 +1,61 @@
+using NArk.Abstractions.Wallets;
+using NArk.Core.Services;
+using NArk.Core.Wallet;
+
+namespace NArk.Tests.Wallet;
+
+/// <summary>
+/// Tests the predicate that gates whether a wallet's sweep destination is used.
+/// When a destination is flagged pending re-confirmation after an Arkade signer rotation,
+/// <see cref="DefaultWalletProvider.ShouldUseDestination"/> must return <c>false</c> so
+/// the provider falls back to self-output (null sweepDestination).
+/// </summary>
+[TestFixture]
+public class DefaultWalletProviderDestinationSkipTests
+{
+    private static ArkWalletInfo MakeWallet(string? destination, Dictionary<string, string>? metadata)
+        => new(
+            Id: "test-wallet-id",
+            Secret: null,
+            Destination: destination,
+            WalletType: WalletType.SingleKey,
+            AccountDescriptor: "tr(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)",
+            LastUsedIndex: 0,
+            Metadata: metadata);
+
+    [Test]
+    public void ShouldUseDestination_false_when_pending_confirmation_flag_set()
+    {
+        var w = MakeWallet(
+            destination: "ark1...",
+            metadata: new Dictionary<string, string> { [DestinationSafety.PendingConfirmationMetadataKey] = "deadbeef" });
+
+        Assert.That(DefaultWalletProvider.ShouldUseDestination(w), Is.False);
+    }
+
+    [Test]
+    public void ShouldUseDestination_true_when_no_flag_and_destination_present()
+    {
+        var w = MakeWallet(destination: "ark1...", metadata: null);
+
+        Assert.That(DefaultWalletProvider.ShouldUseDestination(w), Is.True);
+    }
+
+    [Test]
+    public void ShouldUseDestination_false_when_destination_empty()
+    {
+        var w = MakeWallet(destination: null, metadata: null);
+
+        Assert.That(DefaultWalletProvider.ShouldUseDestination(w), Is.False);
+    }
+
+    [Test]
+    public void ShouldUseDestination_true_when_other_metadata_keys_present_but_not_flag()
+    {
+        var w = MakeWallet(
+            destination: "ark1...",
+            metadata: new Dictionary<string, string> { ["vtxo.lastFullPollAt"] = "2024-01-01T00:00:00Z" });
+
+        Assert.That(DefaultWalletProvider.ShouldUseDestination(w), Is.True);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -684,6 +684,21 @@ public class MyService(IServerInfoCacheInvalidation serverInfoCache)
 }
 ```
 
+To react when a wallet's sweep destination is auto-disabled because the signer it was keyed to was rotated away, inject `IDestinationSafetyNotifier`:
+
+```csharp
+public class MyService(IDestinationSafetyNotifier destinationSafety)
+{
+    public void Start() =>
+        destinationSafety.DestinationDisabled += (_, e) =>
+            Console.WriteLine($"Destination disabled for wallet {e.WalletId}: " +
+                $"address {e.Destination} was keyed to deprecated signer {e.DeprecatedServerKey}. " +
+                "Ask the user to confirm a new sweep destination.");
+}
+```
+
+`IDestinationSafetyNotifier` is DI-aliased to the same `ContractReconciliationService` singleton that performs detection, so no extra registration is needed — just inject the interface. While the destination is flagged the SDK automatically routes swept funds to a self-output instead of the stale address; the destination resumes once the user re-confirms a fresh one.
+
 See [docs/articles/signer-rotation.md](docs/articles/signer-rotation.md) for the full rotation model, detection paths, and version/digest header details.
 
 ## Pending Arkade Transaction Recovery

--- a/docs/articles/signer-rotation.md
+++ b/docs/articles/signer-rotation.md
@@ -57,6 +57,27 @@ The headers are injected by `BuildVersionInterceptor` (gRPC) and `BuildVersionHa
 
 > **Note:** The `RestClientTransport(HttpClient)` constructor overload (for Blazor WASM / `IHttpClientFactory`) does not insert `BuildVersionHandler` into the pipeline. Use the `RestClientTransport(string uri)` URI-based constructor if automatic digest/version checking is required.
 
+## Destination Safety
+
+A wallet can carry a sweep **destination** (`ArkWalletInfo.Destination`), an `ArkAddress` that encodes a server signer key. When a recipient sweeps funds offchain, `DefaultWalletProvider` routes them to that destination instead of a self-output. If the destination was derived from the now-rotated signer, the swept funds would land on a key the operator no longer co-signs with — which would leave them stranded.
+
+`ContractReconciliationService` guards against this on every check point where a stale destination could appear:
+
+- **Startup** — checks every wallet's destination after loading.
+- **`ServerInfoChanged`** — re-checks all wallets whenever the server info (and thus the deprecated-signer set) changes.
+- **`WalletSaved`** — re-checks the newly saved wallet immediately.
+
+On each check, `DestinationSafety.IsStale` tests whether the destination's `ServerKey` is in `ArkServerInfo.DeprecatedSigners`. Only server keys that were previously the active signer and are now deprecated are considered stale; a destination keyed to the current signer or any external key that was never in the deprecated set is left untouched.
+
+When a destination transitions from not-stale to stale the service:
+
+1. Writes `DestinationSafety.PendingConfirmationMetadataKey` (`"destination:pendingConfirmation"`) into the wallet `Metadata` to flag it.
+2. Raises `IDestinationSafetyNotifier.DestinationDisabled` once (on the set transition, not on every subsequent check).
+
+While the flag is set, `DefaultWalletProvider` skips the destination: swept funds go to a self-output instead of the stale address. This protection is entirely in the SDK layer — it is independent of any UI or confirmation flow, so funds are never swept onto a rotated-away signer even if the user has not reacted yet.
+
+The flag clears automatically when the wallet is saved with a destination whose server key is no longer stale — i.e. the user re-confirms a fresh destination keyed to the current signer.
+
 ## Listening for Rotation Events
 
 Inject `IServerInfoCacheInvalidation` to react to a rotation in your own services:


### PR DESCRIPTION
## Summary

When the Arkade operator rotates its signer, a wallet's configured **sweep destination** (an `ArkAddress`, which encodes a server signer key) can become stale — it points at the now-deprecated former signer, so sweeping there would land funds back under a key the operator no longer co-signs with.

This adds **destination signer-change safety**, entirely in the SDK:

- **`DestinationSafety.IsStale`** — surgical check: a destination is stale iff its `ServerKey` is in `ServerInfo.DeprecatedSigners` (a key that was ours and rotated away). Current-signer and externally-keyed destinations are untouched.
- **`ContractReconciliationService`** (extended) — on startup / `ServerInfoChanged` / `WalletSaved`, for **any** wallet with a destination (SingleKey or HD): flags a stale one in wallet `Metadata` (`destination:pendingConfirmation`) and raises `IDestinationSafetyNotifier.DestinationDisabled` once (on the set transition); clears the flag when the destination is no longer stale.
- **`DefaultWalletProvider`** — skips a flagged destination, so swept funds go to a self-output instead of the stale address. The protection is in the SDK layer and effective regardless of any UI/confirmation flow.
- **`IDestinationSafetyNotifier`** — new event seam, DI-aliased to the reconciliation singleton (mirrors `IServerInfoCacheInvalidation`); consumers subscribe to react (e.g. notify the user).

Re-confirmation: saving the wallet with a destination that is no longer stale fires `WalletSaved` → reconcile clears the flag.

## Tests

TDD throughout; **553 unit tests green**. New coverage: `DestinationSafetyTests` (stale/current/external/null), `DefaultWalletProviderDestinationSkipTests` (flagged → self-output), and reconciliation flag / clear / no-duplicate-event + HD-destination-enqueue tests.

## Docs

New "Destination Safety" section in `docs/articles/signer-rotation.md` + an `IDestinationSafetyNotifier` usage note in the README, per the SDK doc conventions.
