### PR TITLE
fix(intents): IntentSynchronizationService tolerates DI-scope disposal race at teardown

### DIFF
--- a/NArk.Core/Services/IntentSynchronizationService.cs
+++ b/NArk.Core/Services/IntentSynchronizationService.cs
@@ -94,6 +94,14 @@ public class IntentSynchronizationService(
         {
             logger?.LogDebug("Intent submit loop cancelled");
         }
+        catch (ObjectDisposedException) when (token.IsCancellationRequested)
+        {
+            // Shutdown race: the DI scope was disposed (host teardown) while a storage query was in
+            // flight, so an EF/DbContext access threw ObjectDisposedException instead of honouring the
+            // cancellation. Benign during shutdown — stop the loop quietly. Outside shutdown an
+            // ObjectDisposedException is a real fault and still propagates (the `when` guard).
+            logger?.LogDebug("Intent submit loop stopped: service provider disposed during shutdown");
+        }
     }
 
     private async Task SubmitIntent(ArkIntent intentToSubmit, CancellationToken token)
@@ -207,6 +215,12 @@ public class IntentSynchronizationService(
         catch (OperationCanceledException)
         {
             logger?.LogDebug("Intent submit loop cancelled during disposal");
+        }
+        catch (ObjectDisposedException)
+        {
+            // Belt-and-suspenders: an in-flight storage query lost the race with DI-scope disposal at
+            // teardown. Always benign here (DisposeAsync only runs during shutdown).
+            logger?.LogDebug("Intent submit loop observed a disposed service provider during disposal");
         }
 
         logger?.LogInformation("Intent synchronization service disposed");

--- a/NArk.Tests/Services/IntentSynchronizationServiceTests.cs
+++ b/NArk.Tests/Services/IntentSynchronizationServiceTests.cs
@@ -1,0 +1,65 @@
+using NBitcoin;
+using NArk.Abstractions.Intents;
+using NArk.Abstractions.Safety;
+using NArk.Core.Services;
+using NArk.Core.Transport;
+using NSubstitute;
+
+namespace NArk.Tests.Services;
+
+[TestFixture]
+public class IntentSynchronizationServiceTests
+{
+    /// <summary>
+    /// Reproduces the DI-scope disposal race: mock GetIntents signals that the loop
+    /// is parked inside the query, waits until the shutdown token fires, then throws
+    /// ObjectDisposedException (as EF does when its DbContext is disposed by the DI scope).
+    /// Before the fix, this ObjectDisposedException escapes both DoIntentSubmitLoop's
+    /// catch and DisposeAsync's catch (both only catch OperationCanceledException), causing
+    /// DisposeAsync to rethrow — which flakes E2E tests at teardown.
+    /// </summary>
+    [Test, Timeout(10_000)]
+    public async Task DisposeAsync_does_not_throw_when_in_flight_query_races_scope_disposal()
+    {
+        var intentStorage = Substitute.For<IIntentStorage>();
+        var clientTransport = Substitute.For<IClientTransport>();
+        var safetyService = Substitute.For<ISafetyService>();
+
+        var inQueryTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var shutdownRequestedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // When GetIntents is called, signal we're in the query, wait for shutdown to be
+        // requested (simulates the EF cancellation race), then throw ObjectDisposedException.
+        intentStorage.GetIntents(
+                walletIds: Arg.Any<string[]?>(),
+                intentTxIds: Arg.Any<string[]?>(),
+                intentIds: Arg.Any<string[]?>(),
+                containingInputs: Arg.Any<OutPoint[]?>(),
+                states: Arg.Any<ArkIntentState[]?>(),
+                validAt: Arg.Any<DateTimeOffset?>(),
+                searchText: Arg.Any<string?>(),
+                skip: Arg.Any<int?>(),
+                take: Arg.Any<int?>(),
+                cancellationToken: Arg.Any<CancellationToken>())
+            .Returns(async _ =>
+            {
+                inQueryTcs.TrySetResult();
+                await shutdownRequestedTcs.Task;
+                throw new ObjectDisposedException("IServiceProvider");
+                return (IReadOnlyCollection<ArkIntent>)[]; // unreachable, satisfies return type
+            });
+
+        var sut = new IntentSynchronizationService(intentStorage, clientTransport, safetyService);
+        await sut.StartAsync();
+
+        // Wait until the background loop is confirmed inside GetIntents.
+        await inQueryTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Now signal that "scope disposal" happened and unblock the mock.
+        shutdownRequestedTcs.TrySetResult();
+
+        // DisposeAsync must complete without throwing, even though the in-flight
+        // GetIntents task throws ObjectDisposedException after the shutdown token fires.
+        Assert.DoesNotThrowAsync(async () => await sut.DisposeAsync());
+    }
+}


### PR DESCRIPTION
## Problem

At host teardown, `IntentSynchronizationService.DisposeAsync` cancels the shutdown token and awaits the running submit loop. The loop's in-flight `intentStorage.GetIntents(...)` (an EF query) can throw `ObjectDisposedException` when the DI `ServiceProvider`/scope is concurrently disposed — instead of honouring cancellation. The loop and `DisposeAsync` only caught `OperationCanceledException`, so the `ObjectDisposedException` escaped and **failed the whole host disposal**, intermittently reddening E2E tests (whichever test loses the timing race at teardown — observed on `FullRecovery_RestoresContracts_Index_AndFunds`, `DeprecatedSignerVtxo_IsAutomaticallySweptToCurrentSigner`, …).

This is a long-standing flake on `master`, surfaced more often by the rc.1 + deprecated-signer E2E baseline.

## Fix

- `DoIntentSubmitLoop` now also catches `ObjectDisposedException` **when the token is cancelled** (shutdown) — stopping the loop quietly. Outside shutdown an `ObjectDisposedException` is a real fault and still propagates (the `when` guard).
- `DisposeAsync` catches `ObjectDisposedException` as a belt-and-suspenders (it only runs during shutdown, so it is always benign there).

## Test

New `IntentSynchronizationServiceTests` deterministically reproduces the race: a mocked in-flight `GetIntents` throws `ObjectDisposedException` during disposal; the test asserts `DisposeAsync` completes without throwing. RED before the fix (the exception escaped `DisposeAsync` via `DoIntentSubmitLoop` → `await _intentSubmitLoop`), green after. Full unit suite **542 green**.
