### PR TITLE
fix(swaps): reverse-swap invoice must equal requested amount (LUD-06)

### DIFF
--- a/NArk.Swaps/Boltz/BoltzSwapProvider.cs
+++ b/NArk.Swaps/Boltz/BoltzSwapProvider.cs
@@ -152,7 +152,7 @@ public partial class BoltzSwapProvider : ISwapProvider
         _intentStorage = intentStorage;
         _intentGenerationService = intentGenerationService;
         _logger = logger;
-        _boltzService = new BoltzSwapService(boltzClient, clientTransport);
+        _boltzService = new BoltzSwapService(boltzClient, clientTransport, limitsValidator);
         _chainSwapMusig = new ChainSwapMusigSession(boltzClient);
         _transactionBuilder = new TransactionHelpers.ArkTransactionBuilder(
             clientTransport, safetyService, walletProvider, intentStorage);

--- a/NArk.Swaps/Boltz/BoltzSwapsService.cs
+++ b/NArk.Swaps/Boltz/BoltzSwapsService.cs
@@ -8,6 +8,7 @@ using NArk.Swaps.Boltz.Models;
 using NArk.Swaps.Boltz.Models.Swaps.Chain;
 using NArk.Swaps.Boltz.Models.Swaps.Reverse;
 using NArk.Swaps.Boltz.Models.Swaps.Submarine;
+using NArk.Swaps.Models;
 using NArk.Core.Transport;
 using NBitcoin;
 using NBitcoin.Crypto;
@@ -17,7 +18,7 @@ using KeyExtensions = NArk.Swaps.Extensions.KeyExtensions;
 
 namespace NArk.Swaps.Boltz;
 
-internal class BoltzSwapService(BoltzClient boltzClient, IClientTransport clientTransport)
+internal class BoltzSwapService(BoltzClient boltzClient, IClientTransport clientTransport, BoltzLimitsValidator limitsValidator)
 {
     private static Sequence ParseSequence(long val)
     {
@@ -74,6 +75,7 @@ internal class BoltzSwapService(BoltzClient boltzClient, IClientTransport client
     public async Task<ReverseSwapResult> CreateReverseSwap(CreateInvoiceParams createInvoiceRequest,
         OutputDescriptor receiver,
         byte[]? preimage = null,
+        ReverseSwapFeePayer feePayer = ReverseSwapFeePayer.Recipient,
         CancellationToken cancellationToken = default)
     {
         var extractedReceiver = receiver.Extract();
@@ -87,14 +89,18 @@ internal class BoltzSwapService(BoltzClient boltzClient, IClientTransport client
         preimage ??= RandomUtils.GetBytes(32);
         var preimageHash = Hashes.SHA256(preimage);
 
-        // First make the Boltz request to get the swap details including timeout block heights
-        // Use InvoiceAmount so the Lightning invoice is for exactly the requested amount
-        // The receiver absorbs the Boltz reverse-swap fee, netting OnchainAmount = InvoiceAmount - fee
+        var requestedAmountSats = (long)createInvoiceRequest.Amount.ToUnit(LightMoneyUnit.Satoshi);
+
+        // The fee payer decides which amount we pin: Recipient pins InvoiceAmount (invoice == requested,
+        // receiver nets requested − fee); Sender pins OnchainAmount (receiver gets
+        // exactly requested, invoice == requested + fee).
+        var (invoiceAmount, onchainAmount) = BuildReverseAmounts(feePayer, requestedAmountSats);
         var request = new ReverseRequest
         {
             From = "BTC",
             To = "ARK",
-            InvoiceAmount = (long)createInvoiceRequest.Amount.ToUnit(LightMoneyUnit.Satoshi),
+            InvoiceAmount = invoiceAmount,
+            OnchainAmount = onchainAmount,
             ClaimPublicKey =
                 (extractedReceiver.PubKey?.ToBytes() ??
                                          extractedReceiver.XOnlyPubKey.ToBytes()).ToHexStringLower(), // Receiver will claim the VTXO
@@ -125,21 +131,14 @@ internal class BoltzSwapService(BoltzClient boltzClient, IClientTransport client
             throw new InvalidOperationException("Boltz did not provide the correct preimage hash");
         }
 
-        // Verify the invoice amount equals exactly the requested amount
-        var invoiceAmountSats = bolt11.MinimumAmount.ToUnit(LightMoneyUnit.Satoshi);
-        var requestedAmountSats = createInvoiceRequest.Amount.ToUnit(LightMoneyUnit.Satoshi);
-        if (invoiceAmountSats != requestedAmountSats)
-        {
-            throw new InvalidOperationException(
-                $"Invoice amount ({invoiceAmountSats} sats) does not match the requested amount ({requestedAmountSats} sats)");
-        }
+        var invoiceAmountSats = (long)bolt11.MinimumAmount.ToUnit(LightMoneyUnit.Satoshi);
+        ValidateReverseAmounts(feePayer, requestedAmountSats, invoiceAmountSats, response.OnchainAmount);
 
-        // The receiver claims OnchainAmount (invoice minus the Boltz fee).
-        if (response.OnchainAmount <= 0 || response.OnchainAmount > invoiceAmountSats)
-        {
-            throw new InvalidOperationException(
-                $"Onchain amount ({response.OnchainAmount} sats) must be greater than zero and not exceed invoice amount ({invoiceAmountSats} sats)");
-        }
+        var receiverOnchainSats = ResolveExpectedOnchainAmount(feePayer, requestedAmountSats, response.OnchainAmount);
+        var (feesValid, feeError) = await limitsValidator.ValidateFeesAsync(
+            invoiceAmountSats, receiverOnchainSats, isReverse: true, cancellationToken);
+        if (!feesValid)
+            throw new InvalidOperationException(feeError);
 
         var vhtlcContract = new VHTLCContract(
             server: operatorTerms.SignerKey,
@@ -167,6 +166,58 @@ internal class BoltzSwapService(BoltzClient boltzClient, IClientTransport client
 
         return new ReverseSwapResult(vhtlcContract, response, preimageHash);
     }
+
+    // Maps the fee payer to the single Boltz amount field we pin
+    internal static (long? InvoiceAmount, long? OnchainAmount) BuildReverseAmounts(
+        ReverseSwapFeePayer feePayer, long requestedAmountSats) => feePayer switch
+    {
+        ReverseSwapFeePayer.Recipient => (requestedAmountSats, (long?)null),
+        ReverseSwapFeePayer.Sender => ((long?)null, requestedAmountSats),
+        _ => throw new ArgumentOutOfRangeException(nameof(feePayer), feePayer, "Unknown reverse-swap fee payer")
+    };
+
+    // Validates the amounts Boltz returned against what the fee payer requires
+    internal static void ValidateReverseAmounts(
+        ReverseSwapFeePayer feePayer, long requestedAmountSats, long invoiceAmountSats, long? responseOnchainSats)
+    {
+        switch (feePayer)
+        {
+            case ReverseSwapFeePayer.Recipient:
+                if (invoiceAmountSats != requestedAmountSats)
+                    throw new InvalidOperationException(
+                        $"Invoice amount ({invoiceAmountSats} sats) does not match the requested amount ({requestedAmountSats} sats)");
+                if (responseOnchainSats is not { } onchain)
+                    throw new InvalidOperationException(
+                        "Boltz did not return an onchain amount for a recipient-pays reverse swap");
+                if (onchain <= 0 || onchain > invoiceAmountSats)
+                    throw new InvalidOperationException(
+                        $"Onchain amount ({onchain} sats) must be greater than zero and not exceed invoice amount ({invoiceAmountSats} sats)");
+                break;
+
+            case ReverseSwapFeePayer.Sender:
+                if (invoiceAmountSats < requestedAmountSats)
+                    throw new InvalidOperationException(
+                        $"Invoice amount ({invoiceAmountSats} sats) must be greater than or equal to the requested amount ({requestedAmountSats} sats) to cover swap fees");
+                
+                if (responseOnchainSats is { } senderOnchain && senderOnchain != requestedAmountSats)
+                    throw new InvalidOperationException(
+                        $"Onchain amount ({senderOnchain} sats) returned by Boltz does not match the pinned requested amount ({requestedAmountSats} sats)");
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(feePayer), feePayer, "Unknown reverse-swap fee payer");
+        }
+    }
+
+    // The on-chain amount receiver will actually claim, stored as ArkSwap.ExpectedAmount
+    internal static long ResolveExpectedOnchainAmount(
+        ReverseSwapFeePayer feePayer, long requestedAmountSats, long? responseOnchainSats) => feePayer switch
+    {
+        ReverseSwapFeePayer.Recipient => responseOnchainSats
+            ?? throw new InvalidOperationException("Boltz did not return an onchain amount for a recipient-pays reverse swap"),
+        ReverseSwapFeePayer.Sender => requestedAmountSats,
+        _ => throw new ArgumentOutOfRangeException(nameof(feePayer), feePayer, "Unknown reverse-swap fee payer")
+    };
 
     // Chain Swaps
 

--- a/NArk.Swaps/Boltz/BoltzSwapsService.cs
+++ b/NArk.Swaps/Boltz/BoltzSwapsService.cs
@@ -88,12 +88,13 @@ internal class BoltzSwapService(BoltzClient boltzClient, IClientTransport client
         var preimageHash = Hashes.SHA256(preimage);
 
         // First make the Boltz request to get the swap details including timeout block heights
-        // Use OnchainAmount so the merchant receives the full requested amount (user pays swap fees)
+        // Use InvoiceAmount so the Lightning invoice is for exactly the requested amount
+        // The receiver absorbs the Boltz reverse-swap fee, netting OnchainAmount = InvoiceAmount - fee
         var request = new ReverseRequest
         {
             From = "BTC",
             To = "ARK",
-            OnchainAmount = (long)createInvoiceRequest.Amount.ToUnit(LightMoneyUnit.Satoshi),
+            InvoiceAmount = (long)createInvoiceRequest.Amount.ToUnit(LightMoneyUnit.Satoshi),
             ClaimPublicKey =
                 (extractedReceiver.PubKey?.ToBytes() ??
                                          extractedReceiver.XOnlyPubKey.ToBytes()).ToHexStringLower(), // Receiver will claim the VTXO
@@ -124,13 +125,20 @@ internal class BoltzSwapService(BoltzClient boltzClient, IClientTransport client
             throw new InvalidOperationException("Boltz did not provide the correct preimage hash");
         }
 
-        // Verify the invoice amount is greater than onchain amount (includes fees)
+        // Verify the invoice amount equals exactly the requested amount
         var invoiceAmountSats = bolt11.MinimumAmount.ToUnit(LightMoneyUnit.Satoshi);
-        var onchainAmountSats = createInvoiceRequest.Amount.ToUnit(LightMoneyUnit.Satoshi);
-        if (invoiceAmountSats < onchainAmountSats)
+        var requestedAmountSats = createInvoiceRequest.Amount.ToUnit(LightMoneyUnit.Satoshi);
+        if (invoiceAmountSats != requestedAmountSats)
         {
             throw new InvalidOperationException(
-                $"Invoice amount ({invoiceAmountSats} sats) must be greater than onchain amount ({onchainAmountSats} sats) to cover swap fees");
+                $"Invoice amount ({invoiceAmountSats} sats) does not match the requested amount ({requestedAmountSats} sats)");
+        }
+
+        // The receiver claims OnchainAmount (invoice minus the Boltz fee).
+        if (response.OnchainAmount <= 0 || response.OnchainAmount > invoiceAmountSats)
+        {
+            throw new InvalidOperationException(
+                $"Onchain amount ({response.OnchainAmount} sats) must be greater than zero and not exceed invoice amount ({invoiceAmountSats} sats)");
         }
 
         var vhtlcContract = new VHTLCContract(

--- a/NArk.Swaps/Boltz/Models/Swaps/Reverse/ReverseResponse.cs
+++ b/NArk.Swaps/Boltz/Models/Swaps/Reverse/ReverseResponse.cs
@@ -20,5 +20,5 @@ public class ReverseResponse
     public required string Invoice { get; set; }
 
     [JsonPropertyName("onchainAmount")]
-    public long OnchainAmount { get; set; }
+    public long? OnchainAmount { get; set; }
 }

--- a/NArk.Swaps/Boltz/Models/Swaps/Reverse/ReverseResponse.cs
+++ b/NArk.Swaps/Boltz/Models/Swaps/Reverse/ReverseResponse.cs
@@ -19,5 +19,6 @@ public class ReverseResponse
     [JsonPropertyName("invoice")]
     public required string Invoice { get; set; }
 
-
+    [JsonPropertyName("onchainAmount")]
+    public long OnchainAmount { get; set; }
 }

--- a/NArk.Swaps/Models/ReverseSwapFeePayer.cs
+++ b/NArk.Swaps/Models/ReverseSwapFeePayer.cs
@@ -1,0 +1,23 @@
+namespace NArk.Swaps.Models;
+
+/// <summary>
+/// Determines who absorbs the Boltz reverse-swap service fee.
+/// </summary>
+public enum ReverseSwapFeePayer
+{
+    /// <summary>
+    /// The receiver absorbs the fee. The Lightning invoice is for <em>exactly</em> the requested
+    /// amount (Boltz <c>invoiceAmount</c>), so payer wallets that verify the invoice against the
+    /// amount they chose to pay (LNURL-pay / LUD-06) accept it. The receiver nets
+    /// <c>requested − fee</c> on-chain. This is the default and the only LUD-06-compliant option.
+    /// </summary>
+    Recipient,
+
+    /// <summary>
+    /// The sender absorbs the fee. The receiver gets <em>exactly</em> the requested amount on-chain
+    /// (Boltz <c>onchainAmount</c>), so the Lightning invoice is inflated to <c>requested + fee</c>.
+    /// Use only where the payer is shown the invoice directly (e.g. a manual BOLT11 scan); this
+    /// breaks LNURL-pay / LUD-06 because the invoice no longer matches the requested amount.
+    /// </summary>
+    Sender
+}

--- a/NArk.Swaps/Services/SwapsManagementService.cs
+++ b/NArk.Swaps/Services/SwapsManagementService.cs
@@ -350,7 +350,7 @@ public class SwapsManagementService : IAsyncDisposable
                 walletId,
                 ArkSwapType.ReverseSubmarine,
                 revSwap.Swap.Invoice,
-                (long)invoiceParams.Amount.ToUnit(LightMoneyUnit.Satoshi),
+                revSwap.Swap.OnchainAmount,
                 revSwap.Contract.GetArkAddress().ScriptPubKey.ToHex(),
                 revSwap.Swap.LockupAddress,
                 ArkSwapStatus.Pending,

--- a/NArk.Swaps/Services/SwapsManagementService.cs
+++ b/NArk.Swaps/Services/SwapsManagementService.cs
@@ -321,7 +321,26 @@ public class SwapsManagementService : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Initiates a reverse swap (Lightning → Arkade): creates a Boltz reverse swap and returns the
+    /// BOLT11 invoice to hand to the payer. The recipient absorbs the Boltz fee, so the invoice equals
+    /// the requested amount (LUD-06-safe). Use the <see cref="ReverseSwapFeePayer"/> overload to change
+    /// who pays the fee.
+    /// </summary>
+    public Task<string> InitiateReverseSwap(string walletId, CreateInvoiceParams invoiceParams,
+        CancellationToken cancellationToken = default) =>
+        InitiateReverseSwap(walletId, invoiceParams, ReverseSwapFeePayer.Recipient, cancellationToken);
+
+    /// <summary>
+    /// Initiates a reverse swap (Lightning → Arkade) with an explicit fee payer.
+    /// </summary>
+    /// <param name="feePayer">
+    /// Who absorbs the Boltz reverse-swap fee. <see cref="ReverseSwapFeePayer.Recipient"/> keeps the
+    /// invoice equal to the requested amount (LUD-06-safe); <see cref="ReverseSwapFeePayer.Sender"/>
+    /// inflates the invoice so the receiver nets the exact amount but breaks LNURL/checkout wallets.
+    /// </param>
     public async Task<string> InitiateReverseSwap(string walletId, CreateInvoiceParams invoiceParams,
+        ReverseSwapFeePayer feePayer,
         CancellationToken cancellationToken = default)
     {
         using var _walletScope = _logger?.BeginScope(("WalletId", walletId));
@@ -337,8 +356,15 @@ public class SwapsManagementService : IAsyncDisposable
                 invoiceParams,
                 destinationDescriptor,
                 preimage,
+                feePayer,
                 cancellationToken
             );
+
+        var expectedOnchainSats = BoltzSwapService.ResolveExpectedOnchainAmount(
+            feePayer,
+            (long)invoiceParams.Amount.ToUnit(LightMoneyUnit.Satoshi),
+            revSwap.Swap.OnchainAmount);
+
         await _contractService.ImportContract(walletId, revSwap.Contract,
             ContractActivityState.AwaitingFundsBeforeDeactivate,
             metadata: new Dictionary<string, string> { ["Source"] = $"swap:{revSwap.Swap.Id}" },
@@ -350,7 +376,7 @@ public class SwapsManagementService : IAsyncDisposable
                 walletId,
                 ArkSwapType.ReverseSubmarine,
                 revSwap.Swap.Invoice,
-                revSwap.Swap.OnchainAmount,
+                expectedOnchainSats,
                 revSwap.Contract.GetArkAddress().ScriptPubKey.ToHex(),
                 revSwap.Swap.LockupAddress,
                 ArkSwapStatus.Pending,

--- a/NArk.Tests.End2End/ReverseSwapAmountTests.cs
+++ b/NArk.Tests.End2End/ReverseSwapAmountTests.cs
@@ -1,0 +1,143 @@
+using BTCPayServer.Lightning;
+using Microsoft.Extensions.Options;
+using NArk.Abstractions.Contracts;
+using NArk.Abstractions.Safety;
+using NArk.Abstractions.VTXOs;
+using NArk.Blockchain;
+using NArk.Core.Services;
+using NArk.Core.Transport;
+using NArk.Swaps.Abstractions;
+using NArk.Swaps.Boltz;
+using NArk.Swaps.Boltz.Client;
+using NArk.Swaps.Boltz.Models;
+using NArk.Swaps.Models;
+using NArk.Swaps.Services;
+using NArk.Swaps.Transformers;
+using NArk.Tests.End2End.Common;
+using NArk.Tests.End2End.Core;
+using NArk.Tests.End2End.TestPersistance;
+using NArk.Core.Transformers;
+using NBitcoin;
+
+using CoinSelector = NArk.Core.CoinSelector.DefaultCoinSelector;
+
+namespace NArk.Tests.End2End.Swaps;
+
+/// <summary>
+/// Integration counterpart to <c>NArk.Tests.ReverseSwapAmountTests</c>:
+/// verifies that <see cref="ReverseSwapFeePayer.Recipient"/> and
+/// <see cref="ReverseSwapFeePayer.Sender"/> produce the correct amount
+/// semantics on the real Boltz wire — invoice pinning, onchain pinning,
+/// and the stored <see cref="ArkSwap.ExpectedAmount"/> in both modes.
+/// </summary>
+public class ReverseSwapAmountTests
+{
+    /// <summary>
+    /// <see cref="ReverseSwapFeePayer.Recipient"/> mode: Boltz sets
+    /// <c>invoiceAmount = requested</c> so payer wallets that verify the
+    /// invoice (LNURL/LUD-06) accept it. The receiver nets
+    /// <c>requested − fee</c> onchain, reflected in
+    /// <see cref="ArkSwap.ExpectedAmount"/>.
+    /// </summary>
+    [Test]
+    [CancelAfter(120_000)]
+    public async Task ReverseSwap_RecipientFeePayer_InvoiceEqualsRequested_OnchainIsLess(CancellationToken token)
+    {
+        const long requestedSats = 50_000;
+
+        var prereq = await FundedWalletHelper.GetFundedWallet();
+        var swapStorage = TestStorage.CreateSwapStorage();
+        await using var swapMgr = BuildSwapManager(prereq, swapStorage);
+        await swapMgr.StartAsync(token);
+
+        var invoice = await FulmineLiquidityHelper.RetryWithSettle(() =>
+            swapMgr.InitiateReverseSwap(
+                prereq.walletIdentifier,
+                new CreateInvoiceParams(LightMoney.Satoshis(requestedSats), "Amount test Recipient", TimeSpan.FromHours(1)),
+                ReverseSwapFeePayer.Recipient,
+                token));
+
+        var bolt11 = BOLT11PaymentRequest.Parse(invoice, Network.RegTest);
+        var invoiceSats = (long)bolt11.MinimumAmount.ToUnit(LightMoneyUnit.Satoshi);
+
+        Assert.That(invoiceSats, Is.EqualTo(requestedSats),
+            "Recipient mode: invoice must equal the requested amount (LUD-06 compliant)");
+
+        var swaps = await swapStorage.GetSwaps(walletIds: [prereq.walletIdentifier]);
+        var swap = swaps.Single();
+        Assert.That(swap.ExpectedAmount, Is.LessThan(requestedSats),
+            "Recipient mode: expected onchain amount must be less than requested (Boltz fee deducted)");
+        Assert.That(swap.ExpectedAmount, Is.GreaterThan(0),
+            "Recipient mode: expected onchain amount must be positive");
+    }
+
+    /// <summary>
+    /// <see cref="ReverseSwapFeePayer.Sender"/> mode: Boltz sets
+    /// <c>onchainAmount = requested</c> so the receiver gets the exact
+    /// amount, stored as <see cref="ArkSwap.ExpectedAmount"/>. The
+    /// invoice is inflated by the fee — i.e. the payer absorbs it.
+    /// </summary>
+    [Test]
+    [CancelAfter(120_000)]
+    public async Task ReverseSwap_SenderFeePayer_OnchainEqualsRequested_InvoiceIsInflated(CancellationToken token)
+    {
+        const long requestedSats = 50_000;
+
+        var prereq = await FundedWalletHelper.GetFundedWallet();
+        var swapStorage = TestStorage.CreateSwapStorage();
+        await using var swapMgr = BuildSwapManager(prereq, swapStorage);
+        await swapMgr.StartAsync(token);
+
+        var invoice = await FulmineLiquidityHelper.RetryWithSettle(() =>
+            swapMgr.InitiateReverseSwap(
+                prereq.walletIdentifier,
+                new CreateInvoiceParams(LightMoney.Satoshis(requestedSats), "Amount test Sender", TimeSpan.FromHours(1)),
+                ReverseSwapFeePayer.Sender,
+                token));
+
+        var bolt11 = BOLT11PaymentRequest.Parse(invoice, Network.RegTest);
+        var invoiceSats = (long)bolt11.MinimumAmount.ToUnit(LightMoneyUnit.Satoshi);
+
+        Assert.That(invoiceSats, Is.GreaterThan(requestedSats),
+            "Sender mode: invoice must be inflated above requested (fee absorbed by payer)");
+
+        var swaps = await swapStorage.GetSwaps(walletIds: [prereq.walletIdentifier]);
+        var swap = swaps.Single();
+        Assert.That(swap.ExpectedAmount, Is.EqualTo(requestedSats),
+            "Sender mode: expected onchain amount must equal the requested amount exactly");
+    }
+
+    private static SwapsManagementService BuildSwapManager(
+        (ISafetyService safetyService, InMemoryWalletProvider walletProvider, string walletIdentifier,
+            IVtxoStorage vtxoStorage, ContractService contractService, IContractStorage contracts,
+            IClientTransport clientTransport, VtxoSynchronizationService vtxoSync) prereq,
+        ISwapStorage swapStorage)
+    {
+        var chainTimeProvider = new NBXplorerBlockchain(Network.RegTest, SharedArkInfrastructure.NbxplorerEndpoint);
+        var intentStorage = TestStorage.CreateIntentStorage();
+        var coinService = new CoinService(prereq.clientTransport, prereq.contracts,
+        [
+            new PaymentContractTransformer(prereq.walletProvider),
+            new HashLockedContractTransformer(prereq.walletProvider),
+            new VHTLCContractTransformer(prereq.walletProvider, chainTimeProvider)
+        ]);
+        var spendingService = new SpendingService(prereq.vtxoStorage, prereq.contracts,
+            prereq.walletProvider, coinService, prereq.contractService, prereq.clientTransport,
+            new CoinSelector(), prereq.safetyService, intentStorage);
+        var boltzOpts = new OptionsWrapper<BoltzClientOptions>(new BoltzClientOptions
+        {
+            BoltzUrl = SharedSwapInfrastructure.BoltzEndpoint.ToString(),
+            WebsocketUrl = SharedSwapInfrastructure.BoltzWsEndpoint.ToString()
+        });
+        var boltzClient = new BoltzClient(new HttpClient(), boltzOpts);
+        var cachedClient = new CachedBoltzClient(new HttpClient(), boltzOpts);
+        var boltzProvider = new BoltzSwapProvider(boltzClient, new BoltzLimitsValidator(cachedClient),
+            prereq.clientTransport, prereq.vtxoStorage, prereq.walletProvider, swapStorage,
+            prereq.contractService, prereq.contracts, prereq.safetyService, intentStorage, chainTimeProvider);
+        return new SwapsManagementService(
+            new ISwapProvider[] { boltzProvider },
+            spendingService, prereq.clientTransport, prereq.vtxoStorage, prereq.walletProvider,
+            swapStorage, prereq.contractService, prereq.contracts, prereq.safetyService, intentStorage,
+            chainTimeProvider);
+    }
+}

--- a/NArk.Tests.End2End/Swaps/ReverseSwapAmountTests.cs
+++ b/NArk.Tests.End2End/Swaps/ReverseSwapAmountTests.cs
@@ -17,6 +17,7 @@ using NArk.Tests.End2End.Common;
 using NArk.Tests.End2End.Core;
 using NArk.Tests.End2End.TestPersistance;
 using NArk.Core.Transformers;
+using NArk.Tests.Common;
 using NBitcoin;
 
 using CoinSelector = NArk.Core.CoinSelector.DefaultCoinSelector;

--- a/NArk.Tests/ReverseSwapAmountTests.cs
+++ b/NArk.Tests/ReverseSwapAmountTests.cs
@@ -1,0 +1,124 @@
+using NArk.Swaps.Boltz;
+using NArk.Swaps.Models;
+
+namespace NArk.Tests;
+
+public class ReverseSwapAmountTests
+{
+    [Test]
+    public void BuildReverseAmounts_Recipient_PinsInvoiceAmount()
+    {
+        var (invoice, onchain) = BoltzSwapService.BuildReverseAmounts(ReverseSwapFeePayer.Recipient, 75_000);
+        Assert.That(invoice, Is.EqualTo(75_000));
+        Assert.That(onchain, Is.Null);
+    }
+
+    [Test]
+    public void BuildReverseAmounts_Sender_PinsOnchainAmount()
+    {
+        var (invoice, onchain) = BoltzSwapService.BuildReverseAmounts(ReverseSwapFeePayer.Sender, 75_000);
+        Assert.That(invoice, Is.Null);
+        Assert.That(onchain, Is.EqualTo(75_000));
+    }
+
+    [Test]
+    public void ValidateReverseAmounts_Recipient_ExactInvoiceAndFeeDeducted_DoesNotThrow()
+    {
+        // 75_000 requested, invoice == 75_000, Boltz reports receiver nets 74_700 (0.4% fee)
+        Assert.DoesNotThrow(() =>
+            BoltzSwapService.ValidateReverseAmounts(ReverseSwapFeePayer.Recipient, 75_000, 75_000, 74_700));
+    }
+
+    [Test]
+    public void ValidateReverseAmounts_Recipient_InflatedInvoice_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            BoltzSwapService.ValidateReverseAmounts(ReverseSwapFeePayer.Recipient, 75_000, 75_302, 75_000));
+    }
+
+    [Test]
+    public void ValidateReverseAmounts_Recipient_InvoiceBelowRequested_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            BoltzSwapService.ValidateReverseAmounts(ReverseSwapFeePayer.Recipient, 75_000, 74_999, 74_700));
+    }
+
+    [Test]
+    public void ValidateReverseAmounts_Recipient_MissingOnchain_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            BoltzSwapService.ValidateReverseAmounts(ReverseSwapFeePayer.Recipient, 75_000, 75_000, null));
+    }
+
+    [Test]
+    public void ValidateReverseAmounts_Recipient_NonPositiveOnchain_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            BoltzSwapService.ValidateReverseAmounts(ReverseSwapFeePayer.Recipient, 75_000, 75_000, 0));
+    }
+
+    [Test]
+    public void ValidateReverseAmounts_Recipient_OnchainExceedsInvoice_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            BoltzSwapService.ValidateReverseAmounts(ReverseSwapFeePayer.Recipient, 75_000, 75_000, 75_001));
+    }
+
+    [Test]
+    public void ValidateReverseAmounts_Sender_InflatedInvoiceAndNoOnchain_DoesNotThrow()
+    {
+        Assert.DoesNotThrow(() =>
+            BoltzSwapService.ValidateReverseAmounts(ReverseSwapFeePayer.Sender, 75_000, 75_302, null));
+    }
+
+    [Test]
+    public void ValidateReverseAmounts_Sender_ZeroFeeInvoiceEqualsRequested_DoesNotThrow()
+    {
+        Assert.DoesNotThrow(() =>
+            BoltzSwapService.ValidateReverseAmounts(ReverseSwapFeePayer.Sender, 75_000, 75_000, null));
+    }
+
+    [Test]
+    public void ValidateReverseAmounts_Sender_InvoiceBelowRequested_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            BoltzSwapService.ValidateReverseAmounts(ReverseSwapFeePayer.Sender, 75_000, 74_999, null));
+    }
+
+    [Test]
+    public void ValidateReverseAmounts_Sender_EchoedOnchainMatchesPin_DoesNotThrow()
+    {
+        Assert.DoesNotThrow(() =>
+            BoltzSwapService.ValidateReverseAmounts(ReverseSwapFeePayer.Sender, 75_000, 75_302, 75_000));
+    }
+
+    [Test]
+    public void ValidateReverseAmounts_Sender_EchoedOnchainDiffersFromPin_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            BoltzSwapService.ValidateReverseAmounts(ReverseSwapFeePayer.Sender, 75_000, 75_302, 74_000));
+    }
+
+    [Test]
+    public void ResolveExpectedOnchainAmount_Recipient_UsesBoltzReportedAmount()
+    {
+        Assert.That(
+            BoltzSwapService.ResolveExpectedOnchainAmount(ReverseSwapFeePayer.Recipient, 75_000, 74_700),
+            Is.EqualTo(74_700));
+    }
+
+    [Test]
+    public void ResolveExpectedOnchainAmount_Recipient_MissingAmount_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            BoltzSwapService.ResolveExpectedOnchainAmount(ReverseSwapFeePayer.Recipient, 75_000, null));
+    }
+
+    [Test]
+    public void ResolveExpectedOnchainAmount_Sender_UsesRequestedAmount()
+    {
+        Assert.That(
+            BoltzSwapService.ResolveExpectedOnchainAmount(ReverseSwapFeePayer.Sender, 75_000, null),
+            Is.EqualTo(75_000));
+    }
+}

--- a/README.md
+++ b/README.md
@@ -993,6 +993,37 @@ var quote = await swaps.GetQuoteAsync(route, amount: 100_000, ct);
 // quote.SourceAmount, quote.DestinationAmount, quote.TotalFees, quote.ExchangeRate
 ```
 
+### Executing a Reverse Swap (receive Lightning into Arkade)
+
+`InitiateReverseSwap` creates the Boltz reverse swap and returns the BOLT11 invoice to hand to the payer. The SDK watches the swap and materializes the VTXO automatically.
+
+```csharp
+var invoice = await swaps.InitiateReverseSwap(
+    walletId,
+    new CreateInvoiceParams(LightMoney.Satoshis(50_000), "Order #1234", TimeSpan.FromHours(1)),
+    cancellationToken: ct);
+```
+
+#### Who pays the swap fee
+
+An optional `ReverseSwapFeePayer` decides who absorbs the Boltz reverse-swap fee:
+
+| Mode | Invoice amount | Receiver nets | Use when |
+|------|----------------|---------------|----------|
+| `Recipient` (default) | `requested` | `requested − fee` | The payer's wallet verifies the invoice equals the amount it chose to pay (LNURL-pay / LUD-06). The **only** compliant option for lightning-address / checkout flows. |
+| `Sender` | `requested + fee` | `requested` | The payer is shown the invoice directly (e.g. a manual BOLT11 scan) and you want to receive an exact amount. **Not LUD-06-compliant** — the invoice no longer matches the requested amount, so LNURL/checkout wallets reject it. |
+
+```csharp
+// Merchant receives the exact amount; the payer covers the fee.
+var invoice = await swaps.InitiateReverseSwap(
+    walletId,
+    new CreateInvoiceParams(LightMoney.Satoshis(50_000), "Top up", TimeSpan.FromHours(1)),
+    ReverseSwapFeePayer.Sender,
+    ct);
+```
+
+Either way the SDK stores the actual on-chain amount Boltz delivers as `ArkSwap.ExpectedAmount`, so claim, refund, and payment tracking match the VTXO that arrives.
+
 ### Providers
 
 | Provider | Routes | Features |


### PR DESCRIPTION
Fixes the LNURL-pay amount mismatch reported in ArkLabsHQ/btcpay-arkade#73.

Reverse swaps now request `InvoiceAmount` (not `OnchainAmount`), so the returned BOLT11 equals the requested
amount and LUD-06-compliant wallets accept it. The receiver absorbs the Boltz reverse-swap fee.

`ExpectedAmount` is stored as the actual on-chain amount Boltz delivers (deserialized from `ReverseResponse.onchainAmount).

Verified on regtest 