### PR TITLE
feat: Arkade delegator server — VTXO-refresh delegation intake

### DIFF
--- a/NArk.Abstractions/Intents/ArkIntent.cs
+++ b/NArk.Abstractions/Intents/ArkIntent.cs
@@ -22,6 +22,13 @@ public record ArkIntent(
     string SignerDescriptor
 )
 {
+    /// <summary>
+    /// Partially-signed forfeit transactions (base64), one per input VTXO. Populated for delegated
+    /// intents (the client's pre-signed forfeit co-signed by the delegator); empty for owner-generated
+    /// intents, whose forfeits are constructed at batch time.
+    /// </summary>
+    public string[] PartialForfeits { get; init; } = [];
+
     private sealed class IntentTxIdEqualityComparer : IEqualityComparer<ArkIntent>
     {
         public bool Equals(ArkIntent? x, ArkIntent? y)

--- a/NArk.Core/Models/Options/DelegatorOptions.cs
+++ b/NArk.Core/Models/Options/DelegatorOptions.cs
@@ -1,0 +1,30 @@
+using NBitcoin.Scripting;
+
+namespace NArk.Core.Models.Options;
+
+/// <summary>
+/// Configuration for the Arkade delegator (the server side of the VTXO-refresh delegation service).
+/// </summary>
+public class DelegatorOptions
+{
+    /// <summary>Wallet identifier whose signer the delegator co-signs and joins batches with.</summary>
+    public required string WalletId { get; set; }
+
+    /// <summary>
+    /// The delegator's signing descriptor. Its key appears in the delegate leaf of each delegate
+    /// contract, and is what clients embed after calling GetDelegatorInfo.
+    /// </summary>
+    public required OutputDescriptor DelegateDescriptor { get; set; }
+
+    /// <summary>Service fee advertised via GetDelegatorInfo, as a plain-text amount string (sats).</summary>
+    public string Fee { get; set; } = "0";
+
+    /// <summary>The Arkade address the service fee is paid to. Empty when no fee is charged.</summary>
+    public string DelegatorAddress { get; set; } = "";
+
+    /// <summary>How long before a VTXO's expiry the refresh batch should fire (time-based).</summary>
+    public TimeSpan RefreshThreshold { get; set; } = TimeSpan.FromHours(2);
+
+    /// <summary>How many blocks before a VTXO's height-expiry the refresh should fire.</summary>
+    public uint RefreshThresholdHeight { get; set; } = 144;
+}

--- a/NArk.Core/NArk.Core.csproj
+++ b/NArk.Core/NArk.Core.csproj
@@ -30,7 +30,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Protobuf Include="Transport\GrpcClient\Protos\**\*.proto" GrpcServices="Client" ProtoRoot="Transport\GrpcClient\Protos" AdditionalImportDirs="$(PkgGoogle_Api_CommonProtos)/content/protos" />
+        <!-- Client stubs for every proto EXCEPT the fulmine delegator service, which we also implement server-side. -->
+        <Protobuf Include="Transport\GrpcClient\Protos\**\*.proto" Exclude="Transport\GrpcClient\Protos\fulmine\v1\delegator.proto" GrpcServices="Client" ProtoRoot="Transport\GrpcClient\Protos" AdditionalImportDirs="$(PkgGoogle_Api_CommonProtos)/content/protos" />
+        <!-- Delegator service: generate BOTH client and server so NArk.Delegator can implement the server base. -->
+        <Protobuf Include="Transport\GrpcClient\Protos\fulmine\v1\delegator.proto" GrpcServices="Both" ProtoRoot="Transport\GrpcClient\Protos" AdditionalImportDirs="$(PkgGoogle_Api_CommonProtos)/content/protos" />
     </ItemGroup>
 
     <ItemGroup>

--- a/NArk.Core/Services/DelegateeService.cs
+++ b/NArk.Core/Services/DelegateeService.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Options;
+using NArk.Abstractions.Services;
+using NArk.Abstractions.Wallets;
+using NArk.Core.Models.Options;
+
+namespace NArk.Core.Services;
+
+/// <summary>
+/// Server-side handler for the Arkade VTXO-refresh delegation service (the delegatee). Implements the
+/// behaviour behind <c>fulmine.v1.DelegatorService</c>: advertises the delegator's identity and fee,
+/// and (from Task 6) accepts delegations, co-signs them, and writes them into the intent pipeline for
+/// refresh before expiry.
+/// </summary>
+public class DelegateeService(
+    IWalletProvider walletProvider,
+    IOptions<DelegatorOptions> options)
+{
+    private readonly DelegatorOptions _options = options.Value;
+
+    /// <summary>
+    /// Returns the delegator's public key (hex), advertised fee, and fee address. The pubkey is what
+    /// clients embed in the delegate leaf of their delegate contract.
+    /// </summary>
+    public async Task<DelegatorInfo> GetInfoAsync(CancellationToken cancellationToken = default)
+    {
+        var signer = await walletProvider.GetSignerAsync(_options.WalletId, cancellationToken)
+            ?? throw new InvalidOperationException($"No signer for delegator wallet {_options.WalletId}");
+        var pubkey = await signer.GetPubKey(_options.DelegateDescriptor, cancellationToken);
+        var pubkeyHex = Convert.ToHexString(pubkey.ToBytes()).ToLowerInvariant();
+        return new DelegatorInfo(pubkeyHex, _options.Fee, _options.DelegatorAddress);
+    }
+}

--- a/NArk.Core/Services/DelegateeService.cs
+++ b/NArk.Core/Services/DelegateeService.cs
@@ -1,18 +1,39 @@
+using System.Text.Json;
 using Microsoft.Extensions.Options;
+using NArk.Abstractions;
+using NArk.Abstractions.Contracts;
+using NArk.Abstractions.Extensions;
+using NArk.Abstractions.Helpers;
+using NArk.Abstractions.Intents;
 using NArk.Abstractions.Services;
+using NArk.Abstractions.VTXOs;
 using NArk.Abstractions.Wallets;
+using NArk.Core.Contracts;
+using NArk.Core.Models;
 using NArk.Core.Models.Options;
+using NArk.Core.Transport;
+using NBitcoin;
+using NBitcoin.Secp256k1;
 
 namespace NArk.Core.Services;
 
 /// <summary>
+/// Thrown when a delegation request fails validation and must be rejected.
+/// </summary>
+public sealed class DelegationRejectedException(string message) : Exception(message);
+
+/// <summary>
 /// Server-side handler for the Arkade VTXO-refresh delegation service (the delegatee). Implements the
 /// behaviour behind <c>fulmine.v1.DelegatorService</c>: advertises the delegator's identity and fee,
-/// and (from Task 6) accepts delegations, co-signs them, and writes them into the intent pipeline for
-/// refresh before expiry.
+/// accepts delegations, co-signs the forfeit's delegate path with the delegator's signer, and writes
+/// them into the intent pipeline for refresh before expiry.
 /// </summary>
 public class DelegateeService(
     IWalletProvider walletProvider,
+    IClientTransport clientTransport,
+    IIntentStorage intentStorage,
+    IContractStorage contractStorage,
+    IVtxoStorage vtxoStorage,
     IOptions<DelegatorOptions> options)
 {
     private readonly DelegatorOptions _options = options.Value;
@@ -23,10 +44,184 @@ public class DelegateeService(
     /// </summary>
     public async Task<DelegatorInfo> GetInfoAsync(CancellationToken cancellationToken = default)
     {
-        var signer = await walletProvider.GetSignerAsync(_options.WalletId, cancellationToken)
-            ?? throw new InvalidOperationException($"No signer for delegator wallet {_options.WalletId}");
+        var signer = await Signer(cancellationToken);
         var pubkey = await signer.GetPubKey(_options.DelegateDescriptor, cancellationToken);
         var pubkeyHex = Convert.ToHexString(pubkey.ToBytes()).ToLowerInvariant();
         return new DelegatorInfo(pubkeyHex, _options.Fee, _options.DelegatorAddress);
     }
+
+    /// <summary>
+    /// Accepts a delegation: validates the intent proof + forfeit txs, co-signs each forfeit's delegate
+    /// leaf with the delegator's signer, and writes an Arkade intent into the pipeline with a future
+    /// <see cref="ArkIntent.ValidFrom"/> so it is refreshed shortly before the underlying VTXOs expire.
+    /// </summary>
+    /// <param name="intentMessage">The intent message in plain-text (stringified JSON).</param>
+    /// <param name="intentProof">The intent proof tx (PSBT in base64 format).</param>
+    /// <param name="forfeitTxs">Partially-signed forfeit transactions (base64), one per VTXO.</param>
+    /// <param name="rejectReplace">If true, reject when an overlapping active delegation already exists.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task AcceptAsync(
+        string intentMessage, string intentProof, string[] forfeitTxs,
+        bool rejectReplace, CancellationToken cancellationToken = default)
+    {
+        if (forfeitTxs.Length == 0)
+            throw new DelegationRejectedException("at least one forfeit tx is required");
+
+        var serverInfo = await clientTransport.GetServerInfoAsync(cancellationToken);
+        var network = serverInfo.Network;
+
+        PSBT intentPsbt;
+        try { intentPsbt = PSBT.Parse(intentProof, network); }
+        catch { throw new DelegationRejectedException("intent proof is not a valid PSBT"); }
+
+        var signer = await Signer(cancellationToken);
+        var delegateXOnly = (await signer.GetPubKey(_options.DelegateDescriptor, cancellationToken)).ToXOnlyPubKey();
+        var serverXOnly = serverInfo.SignerKey.ToXOnlyPubKey();
+
+        // Co-sign each forfeit's delegate leaf and collect the referenced VTXO outpoints.
+        var outpoints = new List<OutPoint>();
+        var cosignedForfeits = new List<string>();
+        foreach (var forfeitB64 in forfeitTxs)
+        {
+            PSBT forfeitPsbt;
+            try { forfeitPsbt = PSBT.Parse(forfeitB64, network); }
+            catch { throw new DelegationRejectedException("forfeit tx is not a valid PSBT"); }
+
+            var input = forfeitPsbt.Inputs[0];
+            var vtxoTxOut = input.GetTxOut()
+                ?? throw new DelegationRejectedException("forfeit input is missing its witness UTXO");
+            var outpoint = input.PrevOut;
+
+            var contract = ReconstructDelegateContract(forfeitPsbt, serverInfo, delegateXOnly, serverXOnly, network);
+
+            // Parity check: the reconstructed contract must produce exactly the VTXO being spent.
+            if (contract.GetScriptPubKey() != vtxoTxOut.ScriptPubKey)
+                throw new DelegationRejectedException("forfeit does not reference a delegate contract bearing this delegator's key");
+
+            var forfeitCoin = new ArkCoin(
+                _options.WalletId, contract, DateTimeOffset.UtcNow, null, null,
+                outpoint, vtxoTxOut, _options.DelegateDescriptor, contract.DelegatePath(),
+                null, null, null, swept: false, unrolled: false);
+
+            var precomputed = forfeitPsbt.GetGlobalTransaction().PrecomputeTransactionData([vtxoTxOut]);
+            await PsbtHelpers.SignAndFillPsbt(signer, forfeitCoin, forfeitPsbt, precomputed,
+                TaprootSigHash.All | TaprootSigHash.AnyoneCanPay, cancellationToken);
+
+            outpoints.Add(outpoint);
+            cosignedForfeits.Add(forfeitPsbt.ToBase64());
+        }
+
+        ValidateFee(intentPsbt, network);
+
+        // reject_replace / supersede any active intent overlapping these VTXOs.
+        var overlapping = await intentStorage.GetIntents(
+            containingInputs: outpoints.ToArray(),
+            states: [ArkIntentState.WaitingToSubmit, ArkIntentState.WaitingForBatch, ArkIntentState.BatchInProgress],
+            cancellationToken: cancellationToken);
+        if (overlapping.Count > 0)
+        {
+            if (rejectReplace)
+                throw new DelegationRejectedException("an overlapping delegation already exists and reject_replace is set");
+            foreach (var o in overlapping)
+                await intentStorage.SaveIntent(o.WalletId, o with
+                {
+                    State = ArkIntentState.Cancelled,
+                    CancellationReason = "Superseded by a new delegation",
+                    UpdatedAt = DateTimeOffset.UtcNow
+                }, cancellationToken);
+        }
+
+        var (validFrom, validUntil) = await ComputeRefreshWindowAsync(outpoints, cancellationToken);
+
+        var intentTxId = intentPsbt.GetGlobalTransaction().GetHash().ToString();
+        await intentStorage.SaveIntent(_options.WalletId, new ArkIntent(
+            intentTxId, null, _options.WalletId, ArkIntentState.WaitingToSubmit,
+            validFrom, validUntil, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow,
+            intentProof, intentMessage, /*DeleteProof*/ "", /*DeleteProofMessage*/ "",
+            null, null, null, outpoints.ToArray(), _options.DelegateDescriptor.ToString())
+        {
+            PartialForfeits = cosignedForfeits.ToArray()
+        }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Rebuilds the delegate contract from the forfeit's delegate leaf. The leaf carries three x-only
+    /// keys (user, delegate, server); the user key is the one that is neither this delegator's key nor
+    /// the Arkade server key. Reconstruction is deterministic and parity-safe (the taproot tree uses a
+    /// fixed unspendable internal key and x-only leaf keys), and is verified by the caller against the
+    /// VTXO scriptPubKey.
+    /// </summary>
+    private ArkDelegateContract ReconstructDelegateContract(
+        PSBT forfeitPsbt, ArkServerInfo serverInfo, ECXOnlyPubKey delegateXOnly, ECXOnlyPubKey serverXOnly, Network network)
+    {
+        var leafScript = ReadSpendingLeafScript(forfeitPsbt.Inputs[0])
+            ?? throw new DelegationRejectedException("forfeit input is missing its tapscript leaf");
+
+        var keys = ExtractXOnlyKeys(leafScript);
+        var comparer = ECXOnlyPubKeyComparer.Instance;
+        var userKey = keys.FirstOrDefault(k => !comparer.Equals(k, delegateXOnly) && !comparer.Equals(k, serverXOnly))
+            ?? throw new DelegationRejectedException("forfeit delegate leaf does not contain a distinct user key");
+        if (!keys.Any(k => comparer.Equals(k, delegateXOnly)))
+            throw new DelegationRejectedException("forfeit delegate leaf does not carry this delegator's key");
+
+        var userDescriptor = KeyExtensions.ParseOutputDescriptor(
+            Convert.ToHexString(userKey.ToBytes()).ToLowerInvariant(), network);
+
+        return new ArkDelegateContract(
+            serverInfo.SignerKey, serverInfo.UnilateralExit, userDescriptor, _options.DelegateDescriptor);
+    }
+
+    /// <summary>Reads the spending tapscript leaf (PSBT_IN_TAP_LEAF_SCRIPT, key type 0x15) from a PSBT input.</summary>
+    private static Script? ReadSpendingLeafScript(PSBTInput input)
+    {
+        foreach (var (key, value) in input.Unknown)
+        {
+            // key = [0x15, <control block>]; value = [<script bytes>, <leaf version byte>].
+            if (key.Length > 0 && key[0] == 0x15 && value.Length >= 1)
+                return new Script(value[..^1]);
+        }
+        return null;
+    }
+
+    private static List<ECXOnlyPubKey> ExtractXOnlyKeys(Script script)
+    {
+        var keys = new List<ECXOnlyPubKey>();
+        foreach (var op in script.ToOps())
+            if (op.PushData is { Length: 32 } push)
+                keys.Add(ECXOnlyPubKey.Create(push));
+        return keys;
+    }
+
+    private void ValidateFee(PSBT intentPsbt, Network network)
+    {
+        if (!ulong.TryParse(_options.Fee, out var fee) || fee == 0)
+            return;
+        if (string.IsNullOrEmpty(_options.DelegatorAddress))
+            throw new DelegationRejectedException("delegator fee is configured but no fee address is set");
+
+        var feeScript = ArkAddress.Parse(_options.DelegatorAddress).ScriptPubKey;
+        var paid = (ulong)intentPsbt.GetGlobalTransaction().Outputs
+            .Where(o => o.ScriptPubKey == feeScript)
+            .Sum(o => o.Value.Satoshi);
+        if (paid < fee)
+            throw new DelegationRejectedException($"delegation does not pay the {fee}-sat service fee to the delegator");
+    }
+
+    private async Task<(DateTimeOffset? validFrom, DateTimeOffset? validUntil)> ComputeRefreshWindowAsync(
+        IReadOnlyCollection<OutPoint> outpoints, CancellationToken cancellationToken)
+    {
+        DateTimeOffset? earliestExpiry = null;
+        await foreach (var vtxo in clientTransport.GetVtxosByOutpoints(outpoints, spentOnly: false, cancellationToken))
+            if (vtxo.ExpiresAt is { } e && (earliestExpiry is null || e < earliestExpiry))
+                earliestExpiry = e;
+
+        if (earliestExpiry is null)
+            return (DateTimeOffset.UtcNow, null);
+
+        return (earliestExpiry.Value - _options.RefreshThreshold, earliestExpiry);
+    }
+
+    private async Task<IArkadeWalletSigner> Signer(CancellationToken cancellationToken) =>
+        await walletProvider.GetSignerAsync(_options.WalletId, cancellationToken)
+        ?? throw new InvalidOperationException($"No signer for delegator wallet {_options.WalletId}");
 }

--- a/NArk.Core/Services/DelegationMonitorService.cs
+++ b/NArk.Core/Services/DelegationMonitorService.cs
@@ -181,7 +181,7 @@ public class DelegationMonitorService(
             outpoint, vtxo.TxOut, signerDescriptor, forfeitScriptBuilder,
             null, null, null, vtxo.Swept, vtxo.Unrolled, assets: vtxo.Assets);
 
-        var forfeitTx = CreateForfeitTransaction(serverInfo.Network, forfeitCoin);
+        var forfeitTx = CreateForfeitTransaction(serverInfo, forfeitCoin);
         var forfeitPrecomputed = forfeitTx.GetGlobalTransaction()
             .PrecomputeTransactionData([forfeitCoin.TxOut]);
 
@@ -194,13 +194,19 @@ public class DelegationMonitorService(
             [forfeitTx.ToBase64()]);
     }
 
-    private static PSBT CreateForfeitTransaction(Network network, ArkCoin coin)
+    // Builds the partial forfeit the delegator co-signs and later submits in a batch: a TRUC (v3) tx
+    // spending the VTXO to the operator's forfeit address (VTXO amount + Dust) plus a P2A anchor, with a
+    // single input. The delegator appends the connector input at batch time — signing the VTXO input
+    // with ANYONECANPAY|ALL (done by the caller) keeps this signature valid when that happens.
+    private static PSBT CreateForfeitTransaction(ArkServerInfo serverInfo, ArkCoin coin)
     {
+        var network = serverInfo.Network;
         var tx = network.CreateTransaction();
-        tx.Version = 2;
-        tx.LockTime = 0;
-        tx.Inputs.Add(new TxIn(coin.Outpoint) { Sequence = 0 });
-        tx.Outputs.Add(new TxOut(Money.Zero, new Script(OpcodeType.OP_RETURN)));
+        tx.Version = 3;
+        tx.LockTime = coin.LockTime ?? LockTime.Zero;
+        tx.Inputs.Add(new TxIn(coin.Outpoint) { Sequence = coin.Sequence ?? Sequence.Final });
+        tx.Outputs.Add(new TxOut(coin.Amount + serverInfo.Dust, serverInfo.ForfeitAddress.ScriptPubKey));
+        tx.Outputs.Add(new TxOut(Money.Zero, Script.FromHex("51024e73")));
 
         var psbt = PSBT.FromTransaction(tx, network);
         psbt.Settings.AutomaticUTXOTrimming = false;

--- a/NArk.Core/Services/DelegationMonitorService.cs
+++ b/NArk.Core/Services/DelegationMonitorService.cs
@@ -136,13 +136,16 @@ public class DelegationMonitorService(
             _ => throw new InvalidOperationException($"Unsupported contract type for delegation: {contract.Type}")
         };
 
-        var signerPubKey = await signer.GetPubKey(signerDescriptor);
+        // The DELEGATOR cosigns the refreshed VTXO tree on the owner's behalf (the owner is offline by
+        // the time of the batch), so the delegator's key — not the owner's — must be the declared
+        // cosigner. Otherwise the batch tree signing would require the absent owner.
+        var delegatePubkey = await GetDelegatePubkeyAsync();
 
         // Build the intent message
         var intentMessage = JsonSerializer.Serialize(new
         {
             type = "register",
-            cosignersPublicKeys = new[] { Convert.ToHexString(signerPubKey.ToBytes()).ToLowerInvariant() },
+            cosignersPublicKeys = new[] { Convert.ToHexString(delegatePubkey.ToBytes()).ToLowerInvariant() },
             validAt = 0,
             expireAt = 0
         });

--- a/NArk.Delegator/DelegatorGrpcService.cs
+++ b/NArk.Delegator/DelegatorGrpcService.cs
@@ -1,0 +1,29 @@
+using Fulmine.V1;
+using Grpc.Core;
+using NArk.Core.Services;
+
+namespace NArk.Delegator;
+
+/// <summary>
+/// gRPC + REST endpoint for the Arkade delegator service. Translates wire requests onto
+/// <see cref="DelegateeService"/> and maps domain failures to gRPC status codes.
+/// </summary>
+public class DelegatorGrpcService(DelegateeService delegatee) : DelegatorService.DelegatorServiceBase
+{
+    /// <inheritdoc />
+    public override async Task<GetDelegatorInfoResponse> GetDelegatorInfo(
+        GetDelegatorInfoRequest request, ServerCallContext context)
+    {
+        var info = await delegatee.GetInfoAsync(context.CancellationToken);
+        return new GetDelegatorInfoResponse
+        {
+            Pubkey = info.Pubkey,
+            Fee = info.Fee,
+            DelegatorAddress = info.DelegatorAddress
+        };
+    }
+
+    /// <inheritdoc />
+    public override Task<DelegateResponse> Delegate(DelegateRequest request, ServerCallContext context)
+        => throw new RpcException(new Status(StatusCode.Unimplemented, "Delegate intake lands in Task 7"));
+}

--- a/NArk.Delegator/DelegatorGrpcService.cs
+++ b/NArk.Delegator/DelegatorGrpcService.cs
@@ -24,6 +24,18 @@ public class DelegatorGrpcService(DelegateeService delegatee) : DelegatorService
     }
 
     /// <inheritdoc />
-    public override Task<DelegateResponse> Delegate(DelegateRequest request, ServerCallContext context)
-        => throw new RpcException(new Status(StatusCode.Unimplemented, "Delegate intake lands in Task 7"));
+    public override async Task<DelegateResponse> Delegate(DelegateRequest request, ServerCallContext context)
+    {
+        try
+        {
+            await delegatee.AcceptAsync(
+                request.Intent.Message, request.Intent.Proof,
+                request.ForfeitTxs.ToArray(), request.RejectReplace, context.CancellationToken);
+            return new DelegateResponse();
+        }
+        catch (DelegationRejectedException ex)
+        {
+            throw new RpcException(new Status(StatusCode.FailedPrecondition, ex.Message));
+        }
+    }
 }

--- a/NArk.Delegator/NArk.Delegator.csproj
+++ b/NArk.Delegator/NArk.Delegator.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <PackageDescription>Arkade delegator server for the NArk .NET SDK. Hosts the VTXO-refresh delegation service (gRPC + REST) so a host can refresh clients' VTXOs before expiry.</PackageDescription>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NArk.Core\NArk.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore" Version="2.76.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Grpc.JsonTranscoding" Version="8.0.16" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>NArk.Tests</_Parameter1>
+    </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>NArk.Tests.End2End</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+</Project>

--- a/NArk.Delegator/ServiceCollectionExtensions.cs
+++ b/NArk.Delegator/ServiceCollectionExtensions.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using NArk.Core.Models.Options;
+using NArk.Core.Services;
+
+namespace NArk.Delegator;
+
+/// <summary>DI + endpoint helpers for hosting the Arkade delegator service in any ASP.NET Core app.</summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the delegator service handler and options, plus gRPC with JSON transcoding so the
+    /// REST endpoints (from the proto's google.api.http annotations) are exposed alongside gRPC. Call
+    /// <see cref="MapNArkDelegator"/> on the app to map the endpoints. The host must also register the
+    /// NArk wallet, transport, and intent storage, and (for refresh execution) the intent-sync and
+    /// batch-management hosted services.
+    /// </summary>
+    public static IServiceCollection AddNArkDelegator(
+        this IServiceCollection services, Action<DelegatorOptions> configure)
+    {
+        services.Configure(configure);
+        services.AddSingleton<DelegateeService>();
+        services.AddGrpc().AddJsonTranscoding();
+        return services;
+    }
+
+    /// <summary>Maps the delegator gRPC service (REST is exposed automatically via JSON transcoding).</summary>
+    public static IEndpointRouteBuilder MapNArkDelegator(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGrpcService<DelegatorGrpcService>();
+        return endpoints;
+    }
+}

--- a/NArk.Delegator/_Placeholder.cs
+++ b/NArk.Delegator/_Placeholder.cs
@@ -1,0 +1,4 @@
+namespace NArk.Delegator;
+
+// Temporary anchor so the project builds before Task 3 adds real types. Removed in Task 3.
+internal static class _Placeholder { }

--- a/NArk.Delegator/_Placeholder.cs
+++ b/NArk.Delegator/_Placeholder.cs
@@ -1,4 +1,0 @@
-namespace NArk.Delegator;
-
-// Temporary anchor so the project builds before Task 3 adds real types. Removed in Task 3.
-internal static class _Placeholder { }

--- a/NArk.Storage.EfCore/Storage/EfCoreIntentStorage.cs
+++ b/NArk.Storage.EfCore/Storage/EfCoreIntentStorage.cs
@@ -46,6 +46,7 @@ public class EfCoreIntentStorage : IIntentStorage
             existing.CommitmentTransactionId = intent.CommitmentTransactionId;
             existing.CancellationReason = intent.CancellationReason;
             existing.SignerDescriptor = intent.SignerDescriptor;
+            existing.PartialForfeits = intent.PartialForfeits;
         }
         else
         {
@@ -67,6 +68,7 @@ public class EfCoreIntentStorage : IIntentStorage
                 CommitmentTransactionId = intent.CommitmentTransactionId,
                 CancellationReason = intent.CancellationReason,
                 SignerDescriptor = intent.SignerDescriptor,
+                PartialForfeits = intent.PartialForfeits,
                 IntentVtxos = intent.IntentVtxos.Select(op => new ArkIntentVtxoEntity
                 {
                     VtxoTransactionId = op.Hash.ToString(),
@@ -201,6 +203,9 @@ public class EfCoreIntentStorage : IIntentStorage
                 new OutPoint(new uint256(iv.VtxoTransactionId), (uint)iv.VtxoTransactionOutputIndex)
             ).ToArray() ?? [],
             SignerDescriptor: entity.SignerDescriptor ?? ""
-        );
+        )
+        {
+            PartialForfeits = entity.PartialForfeits ?? []
+        };
     }
 }

--- a/NArk.Tests.End2End/DelegatorServer/DelegatingClientHarness.cs
+++ b/NArk.Tests.End2End/DelegatorServer/DelegatingClientHarness.cs
@@ -1,0 +1,93 @@
+using NArk.Abstractions.Contracts;
+using NArk.Abstractions.Extensions;
+using NArk.Abstractions.VTXOs;
+using NArk.Abstractions.Wallets;
+using NArk.Core.Contracts;
+using NArk.Core.Services;
+using NArk.Core.Transformers;
+using NArk.Core.Transport;
+using NArk.Core.Wallet;
+using NArk.Safety.AsyncKeyedLock;
+using NArk.Tests.End2End.Common;
+using NArk.Tests.End2End.Core;
+using NArk.Tests.End2End.TestPersistance;
+using NArk.Transport.GrpcClient;
+
+namespace NArk.Tests.End2End.DelegatorServer;
+
+/// <summary>
+/// A delegate-contract client wired to a delegator endpoint. It derives a delegate contract using the
+/// delegator's pubkey, starts the <see cref="DelegationMonitorService"/> BEFORE funding, then funds —
+/// so the first VTXO insert reliably triggers an automatic delegation to the delegator. Reused by the
+/// spike and the intake / refresh e2e tests.
+/// </summary>
+internal sealed class DelegatingClientHarness : IAsyncDisposable
+{
+    public required InMemoryWalletProvider WalletProvider { get; init; }
+    public required string WalletId { get; init; }
+    public required ArkDelegateContract DelegateContract { get; init; }
+    public required IVtxoStorage VtxoStorage { get; init; }
+    public required IContractStorage ContractStorage { get; init; }
+    public required IClientTransport ClientTransport { get; init; }
+    public required VtxoSynchronizationService VtxoSync { get; init; }
+    public required DelegationMonitorService Monitor { get; init; }
+
+    /// <summary>
+    /// Sets up the delegate-contract client against <paramref name="delegatorGrpcEndpoint"/>, starts the
+    /// monitor, and funds the delegate contract. On return the delegation is in flight (the monitor fires
+    /// once vtxoSync detects the funded VTXO).
+    /// </summary>
+    public static async Task<DelegatingClientHarness> CreateAndDelegateAsync(
+        string delegatorGrpcEndpoint, long amountSats = 500_000)
+    {
+        var safetyService = new AsyncSafetyService();
+        var storage = new TestStorage(safetyService);
+        var clientTransport = new GrpcClientTransport(SharedArkInfrastructure.ArkdEndpoint.ToString());
+        var info = await clientTransport.GetServerInfoAsync();
+
+        var delegatorProvider = new GrpcDelegatorProvider(delegatorGrpcEndpoint);
+        var delegatorInfo = await delegatorProvider.GetDelegatorInfoAsync();
+        var delegateKey = KeyExtensions.ParseOutputDescriptor(delegatorInfo.Pubkey, info.Network);
+
+        var walletProvider = new InMemoryWalletProvider(clientTransport);
+        var walletId = await walletProvider.CreateTestWallet();
+        var inner = (await walletProvider.GetAddressProviderAsync(walletId))!;
+        walletProvider.SetAddressProvider(walletId,
+            new DelegatingAddressProvider(inner, delegateKey, info.SignerKey, info.UnilateralExit));
+
+        var vtxoSync = new VtxoSynchronizationService(
+            storage.VtxoStorage, clientTransport, [storage.VtxoStorage, storage.ContractStorage]);
+        await vtxoSync.StartAsync(CancellationToken.None);
+
+        var contractService = new ContractService(walletProvider, storage.ContractStorage, clientTransport);
+        var delegateContract = (ArkDelegateContract)await contractService.DeriveContract(
+            walletId, NextContractPurpose.Receive);
+
+        // Start the monitor BEFORE funding so the first VTXO insert triggers the delegation.
+        var monitor = new DelegationMonitorService(
+            storage.VtxoStorage, storage.ContractStorage,
+            [new DelegateContractDelegationTransformer(walletProvider)],
+            delegatorProvider, walletProvider, clientTransport);
+        await monitor.StartAsync(CancellationToken.None);
+
+        await DockerHelper.SendArkdNoteTo(delegateContract.GetArkAddress().ToString(false), amountSats);
+
+        return new DelegatingClientHarness
+        {
+            WalletProvider = walletProvider,
+            WalletId = walletId,
+            DelegateContract = delegateContract,
+            VtxoStorage = storage.VtxoStorage,
+            ContractStorage = storage.ContractStorage,
+            ClientTransport = clientTransport,
+            VtxoSync = vtxoSync,
+            Monitor = monitor
+        };
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        Monitor.Dispose();
+        await VtxoSync.DisposeAsync();
+    }
+}

--- a/NArk.Tests.End2End/DelegatorServer/DelegatorIntakeTests.cs
+++ b/NArk.Tests.End2End/DelegatorServer/DelegatorIntakeTests.cs
@@ -1,0 +1,39 @@
+using NArk.Abstractions.Intents;
+
+namespace NArk.Tests.End2End.DelegatorServer;
+
+public class DelegatorIntakeTests
+{
+    [Test]
+    public async Task Delegate_accepts_cosigns_and_persists_intent()
+    {
+        await using var host = await InProcessDelegatorHost.StartAsync();
+        await using var client = await DelegatingClientHarness.CreateAndDelegateAsync(host.BaseUrl);
+
+        // The monitor sends a real delegation; the server validates, co-signs the forfeit, and persists
+        // a WaitingToSubmit intent under the delegator wallet.
+        await PollUntil(async () =>
+            (await host.IntentStorage.GetIntents(states: [ArkIntentState.WaitingToSubmit])).Count > 0,
+            TimeSpan.FromMinutes(2), "delegated intent was never persisted");
+
+        var intent = (await host.IntentStorage.GetIntents(states: [ArkIntentState.WaitingToSubmit])).Single();
+        Assert.That(intent.WalletId, Is.EqualTo(host.DelegatorWalletId));
+        Assert.That(intent.PartialForfeits, Is.Not.Empty, "the co-signed forfeit must be stored");
+        Assert.That(intent.IntentVtxos, Is.Not.Empty, "the intent must reference the delegated VTXO");
+
+        TestContext.Progress.WriteLine(
+            $"Persisted delegated intent {intent.IntentTxId} ({intent.PartialForfeits.Length} forfeit, " +
+            $"{intent.IntentVtxos.Length} vtxo, validFrom={intent.ValidFrom})");
+    }
+
+    private static async Task PollUntil(Func<Task<bool>> condition, TimeSpan timeout, string failMessage)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await condition()) return;
+            await Task.Delay(1000);
+        }
+        Assert.Fail(failMessage);
+    }
+}

--- a/NArk.Tests.End2End/DelegatorServer/DelegatorServerTests.cs
+++ b/NArk.Tests.End2End/DelegatorServer/DelegatorServerTests.cs
@@ -1,0 +1,29 @@
+using System.Net.Http.Json;
+using NArk.Transport.GrpcClient;
+
+namespace NArk.Tests.End2End.DelegatorServer;
+
+public class DelegatorServerTests
+{
+    [Test]
+    public async Task GetDelegatorInfo_via_grpc_and_rest_returns_our_pubkey_and_fee()
+    {
+        await using var host = await InProcessDelegatorHost.StartAsync(fee: "123");
+
+        // gRPC against our in-process server.
+        var provider = new GrpcDelegatorProvider(host.BaseUrl);
+        var grpcInfo = await provider.GetDelegatorInfoAsync();
+        Assert.That(grpcInfo.Pubkey, Is.Not.Null.And.Not.Empty);
+        Assert.That(grpcInfo.Fee, Is.EqualTo("123"));
+
+        // REST (JSON transcoding off the proto's google.api.http annotation).
+        using var http = new HttpClient();
+        var rest = await http.GetFromJsonAsync<InfoDto>($"{host.RestBaseUrl}/v1/delegator/info");
+        Assert.That(rest!.Pubkey, Is.EqualTo(grpcInfo.Pubkey));
+        Assert.That(rest.Fee, Is.EqualTo("123"));
+
+        TestContext.Progress.WriteLine($"Our delegator pubkey: {grpcInfo.Pubkey}");
+    }
+
+    private record InfoDto(string Pubkey, string Fee, string DelegatorAddress);
+}

--- a/NArk.Tests.End2End/DelegatorServer/InProcessDelegatorHost.cs
+++ b/NArk.Tests.End2End/DelegatorServer/InProcessDelegatorHost.cs
@@ -3,7 +3,11 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Logging;
+using NArk.Abstractions.Contracts;
+using NArk.Abstractions.Intents;
+using NArk.Abstractions.VTXOs;
 using NArk.Abstractions.Wallets;
+using NArk.Core.Transport;
 using NArk.Delegator;
 using NArk.Tests.End2End.Common;
 using NArk.Tests.End2End.TestPersistance;
@@ -25,6 +29,8 @@ internal sealed class InProcessDelegatorHost : IAsyncDisposable
     public required string DelegatorWalletId { get; init; }
     public required InMemoryWalletProvider WalletProvider { get; init; }
     public required OutputDescriptor DelegateDescriptor { get; init; }
+    public required IIntentStorage IntentStorage { get; init; }
+    public required IVtxoStorage WalletVtxoStorage { get; init; }
 
     public static async Task<InProcessDelegatorHost> StartAsync(string fee = "0", string delegatorAddress = "")
     {
@@ -32,6 +38,7 @@ internal sealed class InProcessDelegatorHost : IAsyncDisposable
         var w = await FundedWalletHelper.GetFundedWallet(vtxoCount: 1, amountSatsPerVtxo: 1_000_000);
         var delegateDescriptor = await (await w.walletProvider.GetAddressProviderAsync(w.walletIdentifier))!
             .GetNextSigningDescriptor();
+        var intentStorage = TestStorage.CreateIntentStorage();
 
         var (grpcPort, restPort) = FreePorts();
         var builder = WebApplication.CreateBuilder();
@@ -44,6 +51,10 @@ internal sealed class InProcessDelegatorHost : IAsyncDisposable
         });
 
         builder.Services.AddSingleton<IWalletProvider>(w.walletProvider);
+        builder.Services.AddSingleton<IClientTransport>(w.clientTransport);
+        builder.Services.AddSingleton<IIntentStorage>(intentStorage);
+        builder.Services.AddSingleton<IContractStorage>(w.contracts);
+        builder.Services.AddSingleton<IVtxoStorage>(w.vtxoStorage);
         builder.Services.AddNArkDelegator(o =>
         {
             o.WalletId = w.walletIdentifier;
@@ -63,7 +74,9 @@ internal sealed class InProcessDelegatorHost : IAsyncDisposable
             App = app,
             DelegatorWalletId = w.walletIdentifier,
             WalletProvider = w.walletProvider,
-            DelegateDescriptor = delegateDescriptor
+            DelegateDescriptor = delegateDescriptor,
+            IntentStorage = intentStorage,
+            WalletVtxoStorage = w.vtxoStorage
         };
     }
 

--- a/NArk.Tests.End2End/DelegatorServer/InProcessDelegatorHost.cs
+++ b/NArk.Tests.End2End/DelegatorServer/InProcessDelegatorHost.cs
@@ -1,0 +1,82 @@
+using System.Net.Sockets;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Logging;
+using NArk.Abstractions.Wallets;
+using NArk.Delegator;
+using NArk.Tests.End2End.Common;
+using NArk.Tests.End2End.TestPersistance;
+using NBitcoin.Scripting;
+
+namespace NArk.Tests.End2End.DelegatorServer;
+
+/// <summary>
+/// Hosts NArk.Delegator in-process over Kestrel against the real regtest arkd, backed by a funded
+/// delegator wallet. Cleartext can't ALPN-negotiate, so gRPC (HTTP/2) and REST (HTTP/1.1) are split
+/// onto two ports: <see cref="BaseUrl"/> for gRPC and <see cref="RestBaseUrl"/> for REST. Disposing
+/// stops the host.
+/// </summary>
+internal sealed class InProcessDelegatorHost : IAsyncDisposable
+{
+    public required string BaseUrl { get; init; }
+    public required string RestBaseUrl { get; init; }
+    public required WebApplication App { get; init; }
+    public required string DelegatorWalletId { get; init; }
+    public required InMemoryWalletProvider WalletProvider { get; init; }
+    public required OutputDescriptor DelegateDescriptor { get; init; }
+
+    public static async Task<InProcessDelegatorHost> StartAsync(string fee = "0", string delegatorAddress = "")
+    {
+        // A funded delegator wallet: pays batch fees and (later) receives the service fee.
+        var w = await FundedWalletHelper.GetFundedWallet(vtxoCount: 1, amountSatsPerVtxo: 1_000_000);
+        var delegateDescriptor = await (await w.walletProvider.GetAddressProviderAsync(w.walletIdentifier))!
+            .GetNextSigningDescriptor();
+
+        var (grpcPort, restPort) = FreePorts();
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        // Cleartext gRPC needs an HTTP/2-only endpoint (no ALPN to negotiate); REST transcoding is HTTP/1.1.
+        builder.WebHost.ConfigureKestrel(o =>
+        {
+            o.ListenLocalhost(grpcPort, lo => lo.Protocols = HttpProtocols.Http2);
+            o.ListenLocalhost(restPort, lo => lo.Protocols = HttpProtocols.Http1);
+        });
+
+        builder.Services.AddSingleton<IWalletProvider>(w.walletProvider);
+        builder.Services.AddNArkDelegator(o =>
+        {
+            o.WalletId = w.walletIdentifier;
+            o.DelegateDescriptor = delegateDescriptor;
+            o.Fee = fee;
+            o.DelegatorAddress = delegatorAddress;
+        });
+
+        var app = builder.Build();
+        app.MapNArkDelegator();
+        await app.StartAsync();
+
+        return new InProcessDelegatorHost
+        {
+            BaseUrl = $"http://localhost:{grpcPort}",
+            RestBaseUrl = $"http://localhost:{restPort}",
+            App = app,
+            DelegatorWalletId = w.walletIdentifier,
+            WalletProvider = w.walletProvider,
+            DelegateDescriptor = delegateDescriptor
+        };
+    }
+
+    private static (int grpcPort, int restPort) FreePorts()
+    {
+        // Hold both listeners open simultaneously so the two ports can't collide.
+        var l1 = new TcpListener(IPAddress.Loopback, 0);
+        var l2 = new TcpListener(IPAddress.Loopback, 0);
+        l1.Start();
+        l2.Start();
+        try { return (((IPEndPoint)l1.LocalEndpoint).Port, ((IPEndPoint)l2.LocalEndpoint).Port); }
+        finally { l1.Stop(); l2.Stop(); }
+    }
+
+    public async ValueTask DisposeAsync() => await App.DisposeAsync();
+}

--- a/NArk.Tests.End2End/NArk.Tests.End2End.csproj
+++ b/NArk.Tests.End2End/NArk.Tests.End2End.csproj
@@ -32,10 +32,15 @@
     </ItemGroup>
 
     <ItemGroup>
+      <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup>
       <ProjectReference Include="..\NArk.Abstractions\NArk.Abstractions.csproj" />
       <ProjectReference Include="..\NArk.Core\NArk.Core.csproj" />
       <ProjectReference Include="..\NArk.Storage.EfCore\NArk.Storage.EfCore.csproj" />
       <ProjectReference Include="..\NArk.Swaps\NArk.Swaps.csproj" />
+      <ProjectReference Include="..\NArk.Delegator\NArk.Delegator.csproj" />
     </ItemGroup>
 
 </Project>

--- a/NArk.Tests/DelegateeServiceTests.cs
+++ b/NArk.Tests/DelegateeServiceTests.cs
@@ -1,8 +1,12 @@
 using Microsoft.Extensions.Options;
+using NArk.Abstractions.Contracts;
 using NArk.Abstractions.Extensions;
+using NArk.Abstractions.Intents;
+using NArk.Abstractions.VTXOs;
 using NArk.Abstractions.Wallets;
 using NArk.Core.Models.Options;
 using NArk.Core.Services;
+using NArk.Core.Transport;
 using NBitcoin;
 using NBitcoin.Scripting;
 using NBitcoin.Secp256k1;
@@ -31,7 +35,13 @@ public class DelegateeServiceTests
         walletProvider.GetSignerAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IArkadeWalletSigner?>(signer));
 
-        return new DelegateeService(walletProvider, new OptionsWrapper<DelegatorOptions>(options));
+        return new DelegateeService(
+            walletProvider,
+            Substitute.For<IClientTransport>(),
+            Substitute.For<IIntentStorage>(),
+            Substitute.For<IContractStorage>(),
+            Substitute.For<IVtxoStorage>(),
+            new OptionsWrapper<DelegatorOptions>(options));
     }
 
     [Test]

--- a/NArk.Tests/DelegateeServiceTests.cs
+++ b/NArk.Tests/DelegateeServiceTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.Options;
+using NArk.Abstractions.Extensions;
+using NArk.Abstractions.Wallets;
+using NArk.Core.Models.Options;
+using NArk.Core.Services;
+using NBitcoin;
+using NBitcoin.Scripting;
+using NBitcoin.Secp256k1;
+using NSubstitute;
+
+namespace NArk.Tests;
+
+[TestFixture]
+public class DelegateeServiceTests
+{
+    private const string DelegatePubkeyHex =
+        "021e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b";
+
+    private static readonly OutputDescriptor DelegateDescriptor =
+        KeyExtensions.ParseOutputDescriptor(DelegatePubkeyHex, Network.RegTest);
+
+    private static DelegateeService CreateSut(DelegatorOptions options)
+    {
+        var delegatePubkey = ECPubKey.Create(Convert.FromHexString(DelegatePubkeyHex));
+
+        var signer = Substitute.For<IArkadeWalletSigner>();
+        signer.GetPubKey(Arg.Any<OutputDescriptor>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(delegatePubkey));
+
+        var walletProvider = Substitute.For<IWalletProvider>();
+        walletProvider.GetSignerAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IArkadeWalletSigner?>(signer));
+
+        return new DelegateeService(walletProvider, new OptionsWrapper<DelegatorOptions>(options));
+    }
+
+    [Test]
+    public async Task GetInfoAsync_returns_configured_fee_address_and_signer_pubkey()
+    {
+        var sut = CreateSut(new DelegatorOptions
+        {
+            WalletId = "delegator",
+            DelegateDescriptor = DelegateDescriptor,
+            Fee = "100",
+            DelegatorAddress = "tark1qexampleaddr"
+        });
+
+        var info = await sut.GetInfoAsync();
+
+        Assert.That(info.Pubkey, Is.EqualTo(DelegatePubkeyHex));
+        Assert.That(info.Fee, Is.EqualTo("100"));
+        Assert.That(info.DelegatorAddress, Is.EqualTo("tark1qexampleaddr"));
+    }
+}

--- a/NArk.sln
+++ b/NArk.sln
@@ -26,6 +26,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NArk.Wallet.Client", "sampl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NArk.Wallet.Gateway", "samples\NArk.Wallet\NArk.Wallet.Gateway\NArk.Wallet.Gateway.csproj", "{FF5655D5-0601-499F-B04A-EF8E4D33D1A0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NArk.Delegator", "NArk.Delegator\NArk.Delegator.csproj", "{5F160AEC-61E5-4CD1-A9A4-0C9CA75243AA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -168,6 +170,18 @@ Global
 		{FF5655D5-0601-499F-B04A-EF8E4D33D1A0}.Release|x64.Build.0 = Release|Any CPU
 		{FF5655D5-0601-499F-B04A-EF8E4D33D1A0}.Release|x86.ActiveCfg = Release|Any CPU
 		{FF5655D5-0601-499F-B04A-EF8E4D33D1A0}.Release|x86.Build.0 = Release|Any CPU
+		{5F160AEC-61E5-4CD1-A9A4-0C9CA75243AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5F160AEC-61E5-4CD1-A9A4-0C9CA75243AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5F160AEC-61E5-4CD1-A9A4-0C9CA75243AA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5F160AEC-61E5-4CD1-A9A4-0C9CA75243AA}.Debug|x64.Build.0 = Debug|Any CPU
+		{5F160AEC-61E5-4CD1-A9A4-0C9CA75243AA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5F160AEC-61E5-4CD1-A9A4-0C9CA75243AA}.Debug|x86.Build.0 = Debug|Any CPU
+		{5F160AEC-61E5-4CD1-A9A4-0C9CA75243AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5F160AEC-61E5-4CD1-A9A4-0C9CA75243AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5F160AEC-61E5-4CD1-A9A4-0C9CA75243AA}.Release|x64.ActiveCfg = Release|Any CPU
+		{5F160AEC-61E5-4CD1-A9A4-0C9CA75243AA}.Release|x64.Build.0 = Release|Any CPU
+		{5F160AEC-61E5-4CD1-A9A4-0C9CA75243AA}.Release|x86.ActiveCfg = Release|Any CPU
+		{5F160AEC-61E5-4CD1-A9A4-0C9CA75243AA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ var details = await transport.GetAssetDetailsAsync(assetId);
 
 ## Delegation
 
-Delegation solves the VTXO liveness problem — VTXOs expire if not refreshed. A delegate service (e.g., [Fulmine](https://github.com/ArkLabsHQ/fulmine)) participates in batch rounds on your behalf, rolling VTXOs over before expiry.
+Delegation solves the VTXO liveness problem — VTXOs expire if not refreshed. A delegate service (e.g., [Fulmine](https://github.com/ArkLabsHQ/fulmine), or an SDK-hosted delegator — see [Running an Arkade Delegator](#running-an-arkade-delegator-server)) participates in batches on your behalf, rolling VTXOs over before expiry.
 
 ### Automated Delegation
 
@@ -401,6 +401,32 @@ services.AddTransient<IDelegationTransformer, MyCustomDelegationTransformer>();
 Each transformer implements:
 - `CanDelegate(walletId, contract, delegatePubkey)` — check eligibility
 - `GetDelegationScriptBuilders(contract)` — return (intentScript, forfeitScript) for building delegation artifacts
+
+### Running an Arkade Delegator (server)
+
+The SDK can also *be* the delegator — the server side of the `fulmine.v1.DelegatorService` (`GetDelegatorInfo` + `Delegate`). The `NArk.Delegator` library hosts the service over gRPC and REST (JSON transcoding) in any ASP.NET Core app:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+// The host must also register a funded delegator wallet (IWalletProvider), the Arkade transport
+// (IClientTransport), and intent/contract/VTXO storage — see AddArkCoreServices / AddArkEfCoreStorage.
+builder.Services.AddNArkDelegator(o =>
+{
+    o.WalletId = "delegator";                  // wallet whose signer co-signs delegations
+    o.DelegateDescriptor = delegateDescriptor; // its key, embedded in clients' delegate contracts
+    o.Fee = "0";                               // flat service fee (sats), advertised via GetDelegatorInfo
+    o.DelegatorAddress = "";                   // Arkade address the fee is paid to (when Fee > 0)
+});
+
+var app = builder.Build();
+app.MapNArkDelegator();   // GET /v1/delegator/info, POST /v1/delegate (gRPC + REST)
+app.Run();
+```
+
+On `Delegate`, the service validates the request, reconstructs the client's delegate contract (verified against the VTXO scriptPubKey), **co-signs the forfeit's delegate path** with the delegator's signer, and persists the delegation as a `WaitingToSubmit` intent with `ValidFrom = expiry − threshold`. `GetDelegatorInfo` returns the delegator's pubkey, fee, and Arkade address; clients embed the pubkey in their `ArkDelegateContract`.
+
+> **Status:** the delegation *intake* (accept → validate → co-sign → persist) is implemented and end-to-end tested against regtest arkd. The automated batch *refresh* (registering the held intent and joining a batch to roll the VTXO over before expiry) is the tracked next step. See [Delegator Server](docs/articles/delegator-server.md) for the design and the forfeit protocol.
 
 ## Collaborative Exits (On-chain)
 

--- a/docs/articles/delegator-server.md
+++ b/docs/articles/delegator-server.md
@@ -1,0 +1,59 @@
+# Delegator Server
+
+Arkade VTXOs expire if they are not periodically refreshed (re-enrolled into a new batch). A
+*delegator* is a server that refreshes a client's VTXOs on the client's behalf, so the client can go
+offline. NArk consumes a delegator (see [Delegation in the README](../../README.md#delegation)) and,
+with the `NArk.Delegator` library, can also **be** one — the server side of the
+`fulmine.v1.DelegatorService`.
+
+## The delegate contract
+
+A client that wants delegation funds its VTXOs at an `ArkDelegateContract` — a Taproot contract with
+three tapscript leaves:
+
+- **DelegatePath** — `user + delegate + server` multisig. The forfeit transaction that re-enrolls the
+  VTXO spends this leaf; the client pre-signs the user position, the delegator co-signs the delegate
+  position, and the operator completes it.
+- **CollaborativePath** — `user + server`. The intent proof (a BIP322 message) is built over this leaf.
+- **ExitPath** — `user` only, after a CSV delay. The owner's unilateral escape hatch.
+
+The `delegate` key is the delegator's own key, published by `GetDelegatorInfo`. Because every leaf is
+defined purely by `{server, user, delegate, exit-delay}` and the Taproot tree uses a fixed unspendable
+internal key, the delegator can deterministically **reconstruct** a client's contract from a received
+forfeit (identifying the user key as the leaf key that is neither its own nor the operator's) and
+verify the reconstruction against the VTXO's scriptPubKey.
+
+## Hosting
+
+`AddNArkDelegator(...)` + `MapNArkDelegator()` mount the service (gRPC + REST via JSON transcoding) in
+any ASP.NET Core host. `DelegatorOptions` configures the delegator wallet, its signing descriptor, the
+flat service fee, and the Arkade fee address. The host must also provide the standard Arkade services
+(wallet, transport, intent/contract/VTXO storage).
+
+## Intake (`Delegate`)
+
+For each delegation the service:
+
+1. Parses the intent proof + each forfeit PSBT.
+2. Reconstructs the delegate contract from the forfeit's delegate leaf and verifies its scriptPubKey
+   matches the VTXO being spent (rejecting anything that does not carry this delegator's key).
+3. **Co-signs the forfeit's delegate path** with the delegator's signer (`ALL|ANYONECANPAY`, which keeps
+   the signature valid when the operator's connector input is grafted in at batch time).
+4. Applies `reject_replace` / supersede logic for VTXOs already covered by an active delegation.
+5. When a fee is configured, verifies the intent pays it to the delegator's address.
+6. Persists the delegation as a `WaitingToSubmit` intent with `ValidFrom = expiry − threshold`, plus the
+   co-signed forfeits — reusing the existing intent storage and pipeline.
+
+## Forfeit protocol
+
+The forfeit is a TRUC (version 3) transaction spending the VTXO to the operator's forfeit address
+(`amount + Dust`) plus a P2A anchor, with the connector input added by the delegator at batch time. The
+client signs `ANYONECANPAY|ALL`; the delegator's co-signature is added at intake. The operator's
+signature is only required at fraud-redemption time, so the user + delegate signatures suffice when the
+forfeit is submitted in a batch.
+
+## Status
+
+The intake flow above is implemented and tested end-to-end against regtest arkd. The automated
+**batch refresh** — registering the held intent at `ValidFrom` and joining the batch to submit the
+stored forfeit (with the connector appended) — is the tracked next step.

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -10,6 +10,8 @@
   href: assets.md
 - name: Swaps
   href: swaps.md
+- name: Delegator Server
+  href: delegator-server.md
 - name: Storage
   href: storage.md
 - name: Recovery


### PR DESCRIPTION
## What

Lets the NArk SDK **be** a delegator (the server side of `fulmine.v1.DelegatorService`), not just consume one. A new `NArk.Delegator` ASP.NET library accepts VTXO-refresh delegations, validates and co-signs them, and persists them — reusing the existing intent storage and pipeline.

## Changes

- **`NArk.Delegator`** (new ASP.NET library): `DelegatorGrpcService` implementing the generated `DelegatorService.DelegatorServiceBase`, exposed over **gRPC + REST** (JSON transcoding off the proto's `google.api.http` annotations). `AddNArkDelegator(...)` / `MapNArkDelegator()` DI + endpoint helpers. `delegator.proto` flipped to `GrpcServices="Both"` in `NArk.Core` (no duplicate `Fulmine.V1` types).
- **`DelegateeService`** (`NArk.Core`): `GetInfoAsync` (advertise pubkey/fee/address) and `AcceptAsync` (intake): parse → reconstruct the delegate contract from the forfeit leaf and **verify it against the VTXO scriptPubKey** → **co-sign the forfeit's delegate path** with the delegator's signer → `reject_replace`/supersede → optional fee check → persist as a `WaitingToSubmit` `ArkIntent` (`ValidFrom = expiry − threshold`) plus the co-signed forfeits.
- `ArkIntent` gains a `PartialForfeits` field (round-tripped through EF Core storage); no new entity/migration.
- **Client (offline-refresh) fixes**, confirmed against fulmine's Go source:
  - declares the **delegator** as the intent cosigner (the offline owner can't cosign the refreshed tree);
  - builds the forfeit as the real Arkade structure — TRUC (v3) `VTXO → forfeit-address(amount+Dust) + P2A anchor`, `ANYONECANPAY|ALL` — instead of a placeholder OP_RETURN.

## Tests

- **Unit:** `dotnet test NArk.Tests` → 559/559 pass.
- **E2E (regtest, `--profile boltz`):** `DelegatorServerTests` (`GetDelegatorInfo` over gRPC + REST against an in-process host) and `DelegatorIntakeTests` (a real client delegation is validated, co-signed, and persisted) — both green against live arkd.

## Scope / follow-up

Ships the delegation **intake** (accept → validate → co-sign → persist), end-to-end verified. The automated **batch refresh** — registering the held intent at `ValidFrom` and joining a batch to submit the stored forfeit (with the operator connector appended) — is the tracked next step; the confirmed forfeit protocol is documented in `docs/articles/delegator-server.md`.

## Docs

README "Running an Arkade Delegator" section + `docs/articles/delegator-server.md` (+ toc). DocFX build green.
