### PR TITLE
fix: commit hash version field

### DIFF
--- a/NArk.Swaps/Boltz/Models/Info/VersionResponse.cs
+++ b/NArk.Swaps/Boltz/Models/Info/VersionResponse.cs
@@ -6,7 +6,4 @@ public class VersionResponse
 {
     [JsonPropertyName("version")]
     public required string Version { get; set; }
-
-    [JsonPropertyName("commitHash")]
-    public required string CommitHash { get; set; }
 }


### PR DESCRIPTION
This field doesn't exist in the API
