### PR TITLE
chore(core): build and broadcast unilateral exit tx in OnchainSweepService.cs

### DIFF
--- a/NArk.Core/Helpers/TransactionHelpers.cs
+++ b/NArk.Core/Helpers/TransactionHelpers.cs
@@ -442,4 +442,39 @@ public static class TransactionHelpers
             return forfeitTx;
         }
     }
+    
+    /// <summary>
+    /// Builds a version-2 transaction that spends a single P2TR output via a script-path
+    /// unilateral exit (CSV timelock). Fee is deducted from the output amount.
+    /// </summary>
+    public static Transaction BuildCsvSpendTransaction(
+        OutPoint vtxoOutpoint,
+        TxOut vtxoTxOut,
+        BitcoinAddress destinationAddress,
+        Sequence csvDelay,
+        TapScript tapScript,
+        ControlBlock controlBlock,
+        FeeRate feeRate,
+        Network network)
+    {
+        var tx = Transaction.Create(network);
+        tx.Version = 2;
+
+        var input = tx.Inputs.Add(vtxoOutpoint);
+        input.Sequence = csvDelay;
+
+        // P2TR script-path spend: ~64 sig + script + control block ≈ 150-200 wu
+        var witnessSize = 64 + tapScript.Script.Length + controlBlock.ToBytes().Length + 10;
+        var txBaseSize = 10 + 41 + 43; // version + input + output overhead
+        var vsize = txBaseSize + (witnessSize + 3) / 4;
+        var fee = feeRate.GetFee(vsize);
+
+        var outputAmount = vtxoTxOut.Value - fee;
+        if (outputAmount <= Money.Zero)
+            throw new InvalidOperationException(
+                $"VTXO amount ({vtxoTxOut.Value}) is too small to cover fees ({fee})");
+
+        tx.Outputs.Add(new TxOut(outputAmount, destinationAddress));
+        return tx;
+    }
 }

--- a/NArk.Core/Services/OnchainSweepService.cs
+++ b/NArk.Core/Services/OnchainSweepService.cs
@@ -1,11 +1,14 @@
 using Microsoft.Extensions.Logging;
-using NArk.Abstractions;
 using NArk.Abstractions.Blockchain;
 using NArk.Abstractions.Contracts;
+using NArk.Abstractions.Extensions;
 using NArk.Abstractions.Services;
 using NArk.Abstractions.VTXOs;
 using NArk.Abstractions.Wallets;
 using NArk.Core.Contracts;
+using NArk.Core.Scripts;
+using NArk.Core.Transport;
+using NBitcoin;
 
 namespace NArk.Core.Services;
 
@@ -17,9 +20,10 @@ namespace NArk.Core.Services;
 public class OnchainSweepService(
     IVtxoStorage vtxoStorage,
     IContractStorage contractStorage,
-    IBitcoinBlockchain chainTimeProvider,
+    IBitcoinBlockchain blockchain,
     IContractService contractService,
     IWalletProvider walletProvider,
+    IClientTransport transport,
     IOnchainSweepHandler? sweepHandler = null,
     ILogger<OnchainSweepService>? logger = null)
 {
@@ -29,7 +33,7 @@ public class OnchainSweepService(
     /// </summary>
     public async Task SweepExpiredUtxosAsync(CancellationToken cancellationToken)
     {
-        var chainTime = await chainTimeProvider.GetChainTime(cancellationToken);
+        var chainTime = await blockchain.GetChainTime(cancellationToken);
         logger?.LogDebug("Checking for expired unrolled UTXOs at height {Height}, time {Time}",
             chainTime.Height, chainTime.Timestamp);
 
@@ -100,25 +104,69 @@ public class OnchainSweepService(
             }
         }
 
-        // Default behavior: sweep to a fresh boarding address
         logger?.LogInformation(
             "Sweeping expired UTXO {Outpoint} ({Amount} sats) to fresh boarding address",
             vtxo.OutPoint, vtxo.Amount);
 
-        // Derive a fresh boarding contract for the destination
+        var serverInfo = await transport.GetServerInfoAsync(cancellationToken);
+
+        var contract = ArkContractParser.Parse(contractEntity.Type, contractEntity.AdditionalData, serverInfo.Network)
+            ?? throw new InvalidOperationException(
+                $"Failed to parse contract for VTXO {vtxo.OutPoint}");
+
+        if (contract is not ArkBoardingContract boardingContract)
+            throw new InvalidOperationException(
+                $"VTXO {vtxo.OutPoint} has contract type '{contractEntity.Type}'; only boarding contracts are swept via {nameof(OnchainSweepService)}");
+
+        var unilateralTapScript = (UnilateralPathArkTapScript)boardingContract.UnilateralPath();
+        var tapScript = unilateralTapScript.Build();
+        var spendInfo = boardingContract.GetTaprootSpendInfo();
+        var controlBlock = spendInfo.GetControlBlock(tapScript);
+
+        var vtxoTxOut = new TxOut(Money.Satoshis(vtxo.Amount), Script.FromHex(vtxo.Script));
+
         var freshContract = await contractService.DeriveContract(
             contractEntity.WalletIdentifier,
             NextContractPurpose.Boarding,
             cancellationToken: cancellationToken);
 
-        _ = freshContract; // Will be used as the output address once tx building is implemented
+        if (freshContract is not ArkBoardingContract freshBoarding)
+            throw new InvalidOperationException(
+                $"DeriveContract returned a non-boarding contract for wallet {contractEntity.WalletIdentifier}");
 
-        // TODO: Build sweep transaction
-        // 1. Create tx spending via UnilateralPath() of the contract
-        // 2. Set sequence to the CSV value
-        // 3. Output to fresh boarding address
-        // 4. Sign with wallet signer
-        // 5. Broadcast via Esplora POST /tx
-        throw new NotImplementedException("Sweep transaction building not yet implemented");
+        var destinationAddress = freshBoarding.GetOnchainAddress(serverInfo.Network);
+
+        var signer = await walletProvider.GetSignerAsync(contractEntity.WalletIdentifier, cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"No signer for wallet {contractEntity.WalletIdentifier}; cannot sweep VTXO {vtxo.OutPoint}");
+
+        if (!contractEntity.AdditionalData.TryGetValue("user", out var userDesc))
+            throw new InvalidOperationException(
+                $"User descriptor missing from contract data for VTXO {vtxo.OutPoint}");
+        var descriptor = KeyExtensions.ParseOutputDescriptor(userDesc, serverInfo.Network);
+
+        var feeRate = await blockchain.EstimateFeeRateAsync(6, cancellationToken);
+        var sweepTx = Helpers.TransactionHelpers.BuildCsvSpendTransaction(
+            vtxo.OutPoint, vtxoTxOut, destinationAddress,
+            unilateralTapScript.Timeout, tapScript, controlBlock,
+            feeRate, serverInfo.Network);
+
+        var precomputed = sweepTx.PrecomputeTransactionData([vtxoTxOut]);
+        var sighash = sweepTx.GetSignatureHashTaproot(
+            precomputed,
+            new TaprootExecutionData(0, tapScript.LeafHash) { SigHash = TaprootSigHash.Default });
+
+        var (_, sig) = await signer.Sign(descriptor, sighash, cancellationToken);
+        sweepTx.Inputs[0].WitScript = new WitScript(
+            [sig.ToBytes(), tapScript.Script.ToBytes(), controlBlock.ToBytes()], true);
+
+        var success = await blockchain.BroadcastAsync(sweepTx, cancellationToken);
+        if (!success)
+            throw new InvalidOperationException(
+                $"Failed to broadcast sweep tx for VTXO {vtxo.OutPoint}");
+
+        logger?.LogInformation(
+            "Swept expired VTXO {Outpoint} ({Amount} sats) → {Address}, txid {SweepTxid}",
+            vtxo.OutPoint, vtxo.Amount, destinationAddress, sweepTx.GetHash());
     }
 }

--- a/NArk.Core/Services/UnilateralExitService.cs
+++ b/NArk.Core/Services/UnilateralExitService.cs
@@ -365,7 +365,7 @@ public class UnilateralExitService(
         // 5. Build, sign, broadcast claim.
         var claimAddress = BitcoinAddress.Create(plan.ClaimAddress, serverInfo.Network);
         var feeRate = await blockchain.EstimateFeeRateAsync(6, cancellationToken);
-        var claimTx = BuildClaimTransaction(
+        var claimTx = Helpers.TransactionHelpers.BuildCsvSpendTransaction(
             vtxoOutpoint, vtxoTxOut.TxOut, claimAddress, serverInfo.UnilateralExit,
             tapScript, controlBlock, feeRate, serverInfo.Network);
 
@@ -701,7 +701,7 @@ public class UnilateralExitService(
             var claimAddress = BitcoinAddress.Create(session.ClaimAddress, serverInfo.Network);
             var feeRate = await blockchain.EstimateFeeRateAsync(6, ct);
 
-            var claimTx = BuildClaimTransaction(
+            var claimTx = Helpers.TransactionHelpers.BuildCsvSpendTransaction(
                 vtxoOutpoint,
                 vtxoTxOut.TxOut,
                 claimAddress,
@@ -807,40 +807,6 @@ public class UnilateralExitService(
         {
             logger?.LogError(ex, "Error checking claim tx for session {SessionId}", session.Id);
         }
-    }
-
-    private static Transaction BuildClaimTransaction(
-        OutPoint vtxoOutpoint,
-        TxOut vtxoTxOut,
-        BitcoinAddress claimAddress,
-        Sequence csvDelay,
-        TapScript tapScript,
-        ControlBlock controlBlock,
-        FeeRate feeRate,
-        Network network)
-    {
-        var claimTx = Transaction.Create(network);
-        claimTx.Version = 2;
-
-        // Input: VTXO output with CSV sequence
-        var input = claimTx.Inputs.Add(vtxoOutpoint);
-        input.Sequence = csvDelay;
-
-        // Estimate size for fee calculation
-        // P2TR script-path spend: ~64 sig + script + control block ≈ 150-200 wu
-        var witnessSize = 64 + tapScript.Script.Length + controlBlock.ToBytes().Length + 10;
-        var txBaseSize = 10 + 41 + 43; // version + input + output overhead
-        var vsize = txBaseSize + (witnessSize + 3) / 4;
-        var fee = feeRate.GetFee(vsize);
-
-        var claimAmount = vtxoTxOut.Value - fee;
-        if (claimAmount <= Money.Zero)
-            throw new InvalidOperationException(
-                $"VTXO amount ({vtxoTxOut.Value}) is too small to cover fees ({fee})");
-
-        claimTx.Outputs.Add(new TxOut(claimAmount, claimAddress));
-
-        return claimTx;
     }
 
     /// <summary>

--- a/NArk.Tests/OnchainSweepServiceTests.cs
+++ b/NArk.Tests/OnchainSweepServiceTests.cs
@@ -4,10 +4,14 @@ using NArk.Abstractions.Extensions;
 using NArk.Abstractions.Services;
 using NArk.Abstractions.VTXOs;
 using NArk.Abstractions.Wallets;
+using NArk.Core;
 using NArk.Core.Contracts;
+using NArk.Core.Scripts;
 using NArk.Core.Services;
+using NArk.Core.Transport;
 using NBitcoin;
 using NBitcoin.Scripting;
+using NBitcoin.Secp256k1;
 using NSubstitute;
 
 namespace NArk.Tests;
@@ -17,9 +21,11 @@ public class OnchainSweepServiceTests
 {
     private IVtxoStorage _vtxoStorage = null!;
     private IContractStorage _contractStorage = null!;
-    private IBitcoinBlockchain _chainTimeProvider = null!;
+    private IBitcoinBlockchain _blockchain = null!;
     private IContractService _contractService = null!;
     private IWalletProvider _walletProvider = null!;
+    private IClientTransport _transport = null!;
+    private IArkadeWalletSigner _signer = null!;
     private IOnchainSweepHandler _sweepHandler = null!;
 
     private static readonly TimeHeight CurrentTime = new(
@@ -44,13 +50,37 @@ public class OnchainSweepServiceTests
     {
         _vtxoStorage = Substitute.For<IVtxoStorage>();
         _contractStorage = Substitute.For<IContractStorage>();
-        _chainTimeProvider = Substitute.For<IBitcoinBlockchain>();
+        _blockchain = Substitute.For<IBitcoinBlockchain>();
         _contractService = Substitute.For<IContractService>();
         _walletProvider = Substitute.For<IWalletProvider>();
+        _transport = Substitute.For<IClientTransport>();
+        _signer = Substitute.For<IArkadeWalletSigner>();
         _sweepHandler = Substitute.For<IOnchainSweepHandler>();
 
-        _chainTimeProvider.GetChainTime(Arg.Any<CancellationToken>())
+        _blockchain.GetChainTime(Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(CurrentTime));
+        _blockchain.EstimateFeeRateAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new FeeRate(Money.Satoshis(10), 1)));
+        _blockchain.BroadcastAsync(Arg.Any<Transaction>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(true));
+
+        _transport.GetServerInfoAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(CreateServerInfo()));
+
+        _walletProvider.GetSignerAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IArkadeWalletSigner?>(_signer));
+
+        // Sign with a real key so the witness bytes are non-null
+        var signingKey = new Key();
+        _signer.Sign(Arg.Any<OutputDescriptor>(), Arg.Any<uint256>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var hash = callInfo.Arg<uint256>();
+                var taprootSig = signingKey.SignTaprootKeySpend(hash, TaprootSigHash.Default);
+                if (!SecpSchnorrSignature.TryCreate(taprootSig.SchnorrSignature.ToBytes(), out var schnorr))
+                    throw new InvalidOperationException("Failed to create test schnorr signature");
+                return Task.FromResult((ECXOnlyPubKey.Create(signingKey.PubKey.TaprootInternalKey.ToBytes()), schnorr!));
+            });
 
         // Default: no VTXOs
         SetupVtxoStorage();
@@ -64,10 +94,28 @@ public class OnchainSweepServiceTests
         return new OnchainSweepService(
             _vtxoStorage,
             _contractStorage,
-            _chainTimeProvider,
+            _blockchain,
             _contractService,
             _walletProvider,
+            _transport,
             handler);
+    }
+
+    private static ArkServerInfo CreateServerInfo()
+    {
+        var emptyMultisig = new NofNMultisigTapScript(Array.Empty<ECXOnlyPubKey>());
+        return new ArkServerInfo(
+            Dust: Money.Satoshis(546),
+            SignerKey: TestServerKey,
+            DeprecatedSigners: new Dictionary<ECXOnlyPubKey, long>(ECXOnlyPubKeyComparer.Instance),
+            Network: Network.RegTest,
+            UnilateralExit: BoardingExitDelay,
+            BoardingExit: BoardingExitDelay,
+            ForfeitAddress: BitcoinAddress.Create("bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080", Network.RegTest),
+            ForfeitPubKey: ECXOnlyPubKey.Create(new Key().PubKey.TaprootInternalKey.ToBytes()),
+            CheckpointTapScript: new UnilateralPathArkTapScript(BoardingExitDelay, emptyMultisig),
+            FeeTerms: new ArkOperatorFeeTerms("1", "0", "0", "0", "0"),
+            Digest: "");
     }
 
     private void SetupVtxoStorage(params ArkVtxo[] vtxos)
@@ -130,13 +178,12 @@ public class OnchainSweepServiceTests
     }
 
     [Test]
-    public async Task SweepExpiredUtxosAsync_DetectsExpiredUnrolledVtxos()
+    public async Task SweepExpiredUtxosAsync_SweepsExpiredUnrolledVtxo()
     {
         // Arrange
         var contract = CreateBoardingContract();
         var contractEntity = CreateContractEntity(contract);
 
-        // Expired: ExpiresAt is in the past
         var expiredVtxo = CreateVtxo(
             contractEntity.Script,
             expiresAt: CurrentTime.Timestamp.AddHours(-1),
@@ -156,15 +203,20 @@ public class OnchainSweepServiceTests
 
         var service = CreateService();
 
-        // Act — completes without throwing (NotImplementedException is caught per-UTXO)
+        // Act
         await service.SweepExpiredUtxosAsync(CancellationToken.None);
 
-        // Assert — detection occurred: it derived a fresh boarding contract for the sweep destination
+        // Assert — derived a fresh boarding contract for the sweep destination
         await _contractService.Received(1).DeriveContract(
             TestWalletId,
             NextContractPurpose.Boarding,
             Arg.Any<ContractActivityState>(),
             Arg.Any<Dictionary<string, string>?>(),
+            Arg.Any<CancellationToken>());
+
+        // Assert — broadcast the sweep transaction
+        await _blockchain.Received(1).BroadcastAsync(
+            Arg.Any<Transaction>(),
             Arg.Any<CancellationToken>());
     }
 


### PR DESCRIPTION
Moves csv spend tx building to TransactionHelpers.cs since it was already done in UnilateralExitService.cs, so there was no point in repeating it 2 times. 

Cleans existing TODO from c0b1f98b (06.03.2026)