### PR TITLE
chore(transport): Use new Subscription Id defined in latest protobuf

### DIFF
--- a/.github/workflows/proto-sync-check.yml
+++ b/.github/workflows/proto-sync-check.yml
@@ -1,0 +1,39 @@
+name: Proto Sync Check
+
+on:
+  pull_request:
+
+jobs:
+  proto-sync:
+    name: Check proto files match arkd master
+    runs-on: ubuntu-latest
+    container: alpine:latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch arkd proto files from master
+        run: |
+          mkdir -p /tmp/arkd-protos
+          for f in indexer.proto service.proto types.proto; do
+            curl -fsSL \
+              "https://raw.githubusercontent.com/arkade-os/arkd/master/api-spec/protobuf/ark/v1/${f}" \
+              -o "/tmp/arkd-protos/${f}"
+          done
+
+      - name: Diff against SDK proto files
+        run: |
+          PROTO_DIR="NArk.Core/Transport/GrpcClient/Protos/ark/v1"
+          failed=0
+          for f in indexer.proto service.proto types.proto; do
+            if ! diff -u "/tmp/arkd-protos/${f}" "${PROTO_DIR}/${f}"; then
+              echo "::error file=${PROTO_DIR}/${f}::${f} is out of sync with arkd master"
+              failed=1
+            fi
+          done
+          if [ $failed -ne 0 ]; then
+            echo ""
+            echo "Proto files are out of sync with arkade-os/arkd master."
+            echo "Copy the updated files from ~/sdks/arkd/api-spec/protobuf/ark/v1/ and commit them."
+            exit 1
+          fi
+          echo "All proto files are in sync with arkd master."

--- a/.github/workflows/proto-sync-check.yml
+++ b/.github/workflows/proto-sync-check.yml
@@ -15,9 +15,9 @@ jobs:
         run: |
           mkdir -p /tmp/arkd-protos
           for f in indexer.proto service.proto types.proto; do
-            curl -fsSL \
+            wget -q \
               "https://raw.githubusercontent.com/arkade-os/arkd/master/api-spec/protobuf/ark/v1/${f}" \
-              -o "/tmp/arkd-protos/${f}"
+              -O "/tmp/arkd-protos/${f}"
           done
 
       - name: Diff against SDK proto files

--- a/NArk.Core/Services/VtxoSynchronizationService.cs
+++ b/NArk.Core/Services/VtxoSynchronizationService.cs
@@ -340,43 +340,29 @@ public class VtxoSynchronizationService : IAsyncDisposable
         {
             var newView = await GatherActiveScriptsAsync(token);
 
-            // Empty active set → tear the subscription down (no point holding an empty
-            // subscription open). The supervisor goes idle until scripts return.
+            // Empty active set → disconnect stream and go idle.
             if (newView.Count == 0)
             {
-                if (_subscriptionId is not null)
+                if (_subscribedScripts.Count > 0)
                 {
-                    var torndown = _subscriptionId;
-                    _logger?.LogInformation("UpdateScriptsView: active set empty — tearing down subscription {Id}", torndown);
+                    _logger?.LogInformation("UpdateScriptsView: active set empty — disconnecting stream");
                     _subscriptionId = null;
                     SignalStreamGenerationChange();
-                    try
-                    {
-                        await _arkClientTransport.UnsubscribeForScriptsAsync(torndown, scripts: null, token);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger?.LogDebug(0, ex, "UpdateScriptsView: unsubscribe-all during teardown failed (subscription may already be gone)");
-                    }
                 }
                 _subscribedScripts = [];
                 return;
             }
 
-            // No live subscription (cold start, or returning from empty) → create one,
-            // wake the supervisor to stream it, and full-history catch-up the whole set.
-            if (_subscriptionId is null)
+            // Transitioning from empty → first scripts: supervisor is idle, wake it.
+            if (_subscribedScripts.Count == 0)
             {
-                _subscriptionId = await _arkClientTransport.SubscribeForScriptsAsync(newView, subscriptionId: null, token);
                 _subscribedScripts = newView;
-                _logger?.LogInformation("UpdateScriptsView: created subscription {Id} for {Count} script(s)", _subscriptionId, newView.Count);
+                _logger?.LogInformation("UpdateScriptsView: first {Count} script(s) — waking supervisor", newView.Count);
                 await EnqueueCatchupPollAsync(newView, token);
                 SignalStreamWakeup();
                 return;
             }
 
-            // Live subscription → update the watched set IN PLACE. No stream restart:
-            // arkd routes the added/removed scripts onto the already-open stream.
             var added = newView.Except(_subscribedScripts).ToHashSet();
             var removed = _subscribedScripts.Except(newView).ToHashSet();
             if (added.Count == 0 && removed.Count == 0)
@@ -385,31 +371,44 @@ public class VtxoSynchronizationService : IAsyncDisposable
                 return;
             }
 
-            _logger?.LogInformation(
-                "UpdateScriptsView: in-place update +{Added}/-{Removed} (now {Count}) on subscription {Id}",
-                added.Count, removed.Count, newView.Count, _subscriptionId);
-            try
+            // Live subscription → update in place via UpdateSubscription (no stream restart).
+            if (_subscriptionId is not null)
             {
-                if (added.Count > 0)
-                    await _arkClientTransport.SubscribeForScriptsAsync(added, _subscriptionId, token);
-                if (removed.Count > 0)
-                    await _arkClientTransport.UnsubscribeForScriptsAsync(_subscriptionId, removed, token);
-            }
-            catch (Exception ex) when (IsSubscriptionNotFound(ex))
-            {
-                // arkd GC'd the subscription (TTL after a disconnect). Recreate it and make
-                // the supervisor re-read the new id; full-history catch-up the whole set.
-                _logger?.LogInformation("UpdateScriptsView: subscription {Id} not found — recreating", _subscriptionId);
-                _subscriptionId = await _arkClientTransport.SubscribeForScriptsAsync(newView, subscriptionId: null, token);
-                _subscribedScripts = newView;
-                await EnqueueCatchupPollAsync(newView, token);
-                SignalStreamGenerationChange();
-                return;
+                _logger?.LogInformation(
+                    "UpdateScriptsView: in-place update +{Added}/-{Removed} (now {Count}) on subscription {Id}",
+                    added.Count, removed.Count, newView.Count, _subscriptionId);
+                try
+                {
+                    await _arkClientTransport.UpdateSubscriptionScriptsAsync(
+                        _subscriptionId,
+                        added.Count > 0 ? added : null,
+                        removed.Count > 0 ? removed : null,
+                        token);
+                    if (added.Count > 0)
+                        await EnqueueCatchupPollAsync(added, token);
+                    _subscribedScripts = newView;
+                    return;
+                }
+                catch (Exception ex) when (IsSubscriptionNotFound(ex))
+                {
+                    // arkd GC'd the subscription. Clear the ID and let the supervisor reopen fresh.
+                    _logger?.LogInformation("UpdateScriptsView: subscription {Id} GC'd — supervisor will reopen", _subscriptionId);
+                    _subscriptionId = null;
+                    _subscribedScripts = newView;
+                    if (added.Count > 0)
+                        await EnqueueCatchupPollAsync(added, token);
+                    SignalStreamGenerationChange();
+                    return;
+                }
             }
 
-            if (added.Count > 0)
-                await EnqueueCatchupPollAsync(added, token);
+            // No subscription ID yet (supervisor is connecting). Update the target script set
+            // and interrupt it so it reconnects with the new set as initial filter.
+            _logger?.LogInformation(
+                "UpdateScriptsView: script set changed while supervisor is connecting — restarting with {Count} scripts",
+                newView.Count);
             _subscribedScripts = newView;
+            SignalStreamGenerationChange();
         }
         finally
         {
@@ -462,29 +461,32 @@ public class VtxoSynchronizationService : IAsyncDisposable
     }
 
     /// <summary>
-    /// The long-lived stream supervisor. Keeps one GetSubscription stream open for the
-    /// current subscription, enqueuing a poll for every pushed script. The watched set is
-    /// mutated in place by <see cref="UpdateScriptsView"/> (Subscribe/Unsubscribe) without
-    /// touching this loop. The loop only re-reads state when signalled: a generation change
-    /// (recreate/teardown) cancels the current stream token, and a wakeup ends the idle wait
-    /// after a subscription is created. On a stream drop it re-asserts the subscription
-    /// (recreating if arkd GC'd it) and reconnects.
+    /// The long-lived stream supervisor. On each loop iteration it opens a <c>GetSubscription</c>
+    /// stream — fresh (no ID, initial scripts in filter) when starting or after a GC, or as a
+    /// reconnect (existing ID) after a transient drop. The server sends
+    /// <see cref="VtxoSubscriptionStarted"/> as the first event on a new subscription, which
+    /// is stored so <see cref="UpdateScriptsView"/> can call <c>UpdateSubscription</c> in place.
     /// </summary>
     private async Task RunStreamSupervisorAsync(CancellationToken shutdownToken)
     {
         while (!shutdownToken.IsCancellationRequested)
         {
-            string? subscriptionId;
+            HashSet<string>? initialScripts = null;
+            string? reconnectId = null;
             var streamToken = CancellationToken.None;
+
             await _viewSyncLock.WaitAsync(shutdownToken);
             try
             {
-                subscriptionId = _subscriptionId;
-                if (subscriptionId is not null)
+                if (_subscribedScripts.Count > 0)
                 {
                     _streamGenerationCts?.Dispose();
                     _streamGenerationCts = CancellationTokenSource.CreateLinkedTokenSource(shutdownToken);
                     streamToken = _streamGenerationCts.Token;
+                    reconnectId = _subscriptionId;
+                    // Pass initial scripts only when opening fresh (no reconnect ID).
+                    if (reconnectId is null)
+                        initialScripts = [.._subscribedScripts];
                 }
             }
             finally
@@ -492,9 +494,9 @@ public class VtxoSynchronizationService : IAsyncDisposable
                 _viewSyncLock.Release();
             }
 
-            if (subscriptionId is null)
+            if (initialScripts is null && reconnectId is null)
             {
-                // Idle: nothing to watch. Wait until a subscription is created.
+                // Idle: no scripts to watch. Wait until scripts are added.
                 try { await _streamWakeup.WaitAsync(shutdownToken); }
                 catch (OperationCanceledException) { return; }
                 continue;
@@ -503,23 +505,35 @@ public class VtxoSynchronizationService : IAsyncDisposable
             var endedGracefully = false;
             try
             {
-                _logger?.LogInformation("VTXO subscription stream starting (subscription {Id})", subscriptionId);
-                await foreach (var changed in _arkClientTransport.GetVtxoSubscriptionStreamAsync(subscriptionId, streamToken))
+                _logger?.LogInformation("VTXO subscription stream opening (id={Id})", reconnectId ?? "new");
+
+                await foreach (var ev in _arkClientTransport.OpenSubscriptionStreamAsync(
+                    initialScripts, reconnectId, streamToken))
                 {
-                    _logger?.LogInformation(
-                        "VTXO subscription stream: arkd pushed update for {Count} script(s): [{Scripts}]",
-                        changed.Count, string.Join(", ", changed));
-                    // Single immediate poll for the pushed scripts; the 5s safety-net poll
-                    // is the backstop if this loses the race against arkd's indexer.
-                    try
+                    switch (ev)
                     {
-                        var after = DateTimeOffset.UtcNow - StreamPollLookback;
-                        await _readyToPoll.Writer.WriteAsync(new PollRequest(changed, after), streamToken);
-                    }
-                    catch (OperationCanceledException) { }
-                    catch (Exception ex)
-                    {
-                        _logger?.LogWarning(ex, "Stream push: failed to enqueue immediate poll");
+                        case VtxoSubscriptionStarted started:
+                            await _viewSyncLock.WaitAsync(shutdownToken);
+                            try { _subscriptionId = started.SubscriptionId; }
+                            finally { _viewSyncLock.Release(); }
+                            _logger?.LogInformation("VTXO subscription started (id={Id})", started.SubscriptionId);
+                            break;
+
+                        case VtxoScriptsChanged changed:
+                            _logger?.LogInformation(
+                                "VTXO subscription stream: arkd pushed update for {Count} script(s): [{Scripts}]",
+                                changed.Scripts.Count, string.Join(", ", changed.Scripts));
+                            try
+                            {
+                                var after = DateTimeOffset.UtcNow - StreamPollLookback;
+                                await _readyToPoll.Writer.WriteAsync(new PollRequest(changed.Scripts, after), streamToken);
+                            }
+                            catch (OperationCanceledException) { }
+                            catch (Exception ex)
+                            {
+                                _logger?.LogWarning(ex, "Stream push: failed to enqueue immediate poll");
+                            }
+                            break;
                     }
                 }
                 endedGracefully = true;
@@ -530,8 +544,16 @@ public class VtxoSynchronizationService : IAsyncDisposable
             }
             catch (OperationCanceledException)
             {
-                // Generation change (recreate/teardown) — re-read state on the next loop.
+                // Generation change (script set update or teardown) — re-read state on next loop.
                 continue;
+            }
+            catch (Exception ex) when (IsSubscriptionNotFound(ex))
+            {
+                // Subscription was GC'd by arkd. Clear the ID so next loop opens fresh.
+                _logger?.LogInformation("VTXO subscription {Id} GC'd — reopening fresh", reconnectId);
+                await _viewSyncLock.WaitAsync(shutdownToken);
+                try { _subscriptionId = null; }
+                finally { _viewSyncLock.Release(); }
             }
             catch (Exception ex)
             {
@@ -542,54 +564,6 @@ public class VtxoSynchronizationService : IAsyncDisposable
 
             if (endedGracefully)
                 _logger?.LogWarning("VTXO subscription stream ended (arkd closed it) — reconnecting");
-
-            // Re-assert the subscription so a TTL-GC'd listener is recreated, then loop to reconnect.
-            await ReassertSubscriptionAsync(subscriptionId, shutdownToken);
-        }
-    }
-
-    /// <summary>
-    /// After the supervisor's stream dropped, re-asserts the subscription's topics on the
-    /// same id (a no-op while the listener is alive within its TTL). If arkd GC'd the
-    /// listener, recreates it and full-history catch-up the set. The fresh-derive safety-net
-    /// poll covers detection regardless, so a transient failure here is non-fatal.
-    /// </summary>
-    private async Task ReassertSubscriptionAsync(string staleSubscriptionId, CancellationToken shutdownToken)
-    {
-        await _viewSyncLock.WaitAsync(shutdownToken);
-        try
-        {
-            // A concurrent UpdateScriptsView already recreated/tore down — let the supervisor
-            // re-read on the next loop instead of fighting it.
-            if (_subscriptionId != staleSubscriptionId)
-                return;
-            if (_subscribedScripts.Count == 0)
-            {
-                _subscriptionId = null;
-                return;
-            }
-
-            try
-            {
-                await _arkClientTransport.SubscribeForScriptsAsync(_subscribedScripts, staleSubscriptionId, shutdownToken);
-            }
-            catch (Exception ex) when (IsSubscriptionNotFound(ex))
-            {
-                _logger?.LogInformation("Reconnect: subscription {Id} was GC'd — recreating", staleSubscriptionId);
-                _subscriptionId = await _arkClientTransport.SubscribeForScriptsAsync(_subscribedScripts, subscriptionId: null, shutdownToken);
-                await EnqueueCatchupPollAsync(_subscribedScripts, shutdownToken);
-            }
-        }
-        catch (OperationCanceledException) when (shutdownToken.IsCancellationRequested)
-        {
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogWarning(ex, "Failed to re-assert VTXO subscription on reconnect; safety-net poll still covers detection");
-        }
-        finally
-        {
-            _viewSyncLock.Release();
         }
     }
 

--- a/NArk.Core/Transport/CachingClientTransport.cs
+++ b/NArk.Core/Transport/CachingClientTransport.cs
@@ -155,15 +155,13 @@ public class CachingClientTransport : IClientTransport, IServerInfoCacheInvalida
     public bool HasValidServerInfoCache => _cachedServerInfo != null && DateTimeOffset.UtcNow < _serverInfoExpiresAt;
 
     // Pass-through methods — digest mismatch invalidates the server info cache before propagating.
+    
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+    public IAsyncEnumerable<VtxoSubscriptionEvent> OpenSubscriptionStreamAsync(IReadOnlySet<string>? initialScripts, string? existingSubscriptionId, CancellationToken cancellationToken = default)
+        => GuardStream(_inner.OpenSubscriptionStreamAsync(initialScripts, existingSubscriptionId, cancellationToken));
 
-    public Task<string> SubscribeForScriptsAsync(IReadOnlySet<string> scripts, string? subscriptionId, CancellationToken cancellationToken = default)
-        => Guard(() => _inner.SubscribeForScriptsAsync(scripts, subscriptionId, cancellationToken));
-
-    public Task UnsubscribeForScriptsAsync(string subscriptionId, IReadOnlySet<string>? scripts, CancellationToken cancellationToken = default)
-        => Guard(() => _inner.UnsubscribeForScriptsAsync(subscriptionId, scripts, cancellationToken));
-
-    public IAsyncEnumerable<HashSet<string>> GetVtxoSubscriptionStreamAsync(string subscriptionId, CancellationToken cancellationToken = default)
-        => GuardStream(_inner.GetVtxoSubscriptionStreamAsync(subscriptionId, cancellationToken));
+    public Task UpdateSubscriptionScriptsAsync(string subscriptionId, IReadOnlySet<string>? add, IReadOnlySet<string>? remove, CancellationToken cancellationToken = default)
+        => Guard(() => _inner.UpdateSubscriptionScriptsAsync(subscriptionId, add, remove, cancellationToken));
 
     public IAsyncEnumerable<ArkVtxo> GetVtxoByScriptsAsSnapshot(IReadOnlySet<string> scripts, CancellationToken cancellationToken = default)
         => GuardStream(_inner.GetVtxoByScriptsAsSnapshot(scripts, cancellationToken));
@@ -211,7 +209,7 @@ public class CachingClientTransport : IClientTransport, IServerInfoCacheInvalida
     public Task<ArkIntent[]> GetIntentsByProofAsync(string proof, string message, CancellationToken cancellationToken = default)
         => Guard(() => _inner.GetIntentsByProofAsync(proof, message, cancellationToken));
 
-    public Task<Models.PendingArkTransaction[]> GetPendingTxAsync(string proof, string message,
+    public Task<PendingArkTransaction[]> GetPendingTxAsync(string proof, string message,
         CancellationToken cancellationToken = default)
         => Guard(() => _inner.GetPendingTxAsync(proof, message, cancellationToken));
 
@@ -223,6 +221,7 @@ public class CachingClientTransport : IClientTransport, IServerInfoCacheInvalida
 
     public Task<IReadOnlyList<VtxoTreeNode>> GetVtxoTreeAsync(OutPoint batchOutpoint, CancellationToken cancellationToken = default)
         => Guard(() => _inner.GetVtxoTreeAsync(batchOutpoint, cancellationToken));
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
     private static readonly ServerInfoChangedEventArgs DigestMismatchArgs =
         new() { Reason = ServerInfoChangedReason.DigestMismatch };

--- a/NArk.Core/Transport/GrpcClient/GrpcClientTransport.Vtxo.cs
+++ b/NArk.Core/Transport/GrpcClient/GrpcClientTransport.Vtxo.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using Ark.V1;
 using Grpc.Core;
 using NArk.Abstractions.VTXOs;
+using NArk.Core.Transport;
 using NBitcoin;
 
 namespace NArk.Transport.GrpcClient;
@@ -93,45 +94,62 @@ public partial class GrpcClientTransport
         }
     }
 
-    public async Task<string> SubscribeForScriptsAsync(IReadOnlySet<string> scripts,
-        string? subscriptionId, CancellationToken cancellationToken = default)
-    {
-        var req = new SubscribeForScriptsRequest { SubscriptionId = subscriptionId ?? string.Empty };
-        req.Scripts.AddRange(scripts);
-        var res = await _indexerServiceClient.SubscribeForScriptsAsync(req, cancellationToken: cancellationToken);
-        return res.SubscriptionId;
-    }
-
-    public async Task UnsubscribeForScriptsAsync(string subscriptionId,
-        IReadOnlySet<string>? scripts, CancellationToken cancellationToken = default)
-    {
-        var req = new UnsubscribeForScriptsRequest { SubscriptionId = subscriptionId };
-        if (scripts is not null)
-            req.Scripts.AddRange(scripts);
-        await _indexerServiceClient.UnsubscribeForScriptsAsync(req, cancellationToken: cancellationToken);
-    }
-
-    public async IAsyncEnumerable<HashSet<string>> GetVtxoSubscriptionStreamAsync(string subscriptionId,
+    public async IAsyncEnumerable<VtxoSubscriptionEvent> OpenSubscriptionStreamAsync(
+        IReadOnlySet<string>? initialScripts,
+        string? existingSubscriptionId,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        var stream = _indexerServiceClient.GetSubscription(
-            new GetSubscriptionRequest { SubscriptionId = subscriptionId }, cancellationToken: cancellationToken);
+        var request = new GetSubscriptionRequest
+        {
+            SubscriptionId = existingSubscriptionId ?? string.Empty,
+        };
+
+        if (existingSubscriptionId is null && initialScripts?.Count > 0)
+        {
+            request.Filter = new SubscriptionFilter { Scripts = new ScriptFilter() };
+            request.Filter.Scripts.Add.AddRange(initialScripts);
+        }
+
+        var stream = _indexerServiceClient.GetSubscription(request, cancellationToken: cancellationToken);
 
         await foreach (var response in stream.ResponseStream.ReadAllAsync(cancellationToken))
         {
-            if (response == null) continue;
             switch (response.DataCase)
             {
-                case GetSubscriptionResponse.DataOneofCase.None:
-                case GetSubscriptionResponse.DataOneofCase.Heartbeat:
+                case GetSubscriptionResponse.DataOneofCase.SubscriptionStarted:
+                    yield return new VtxoSubscriptionStarted(response.SubscriptionStarted.SubscriptionId);
                     break;
                 case GetSubscriptionResponse.DataOneofCase.Event when response.Event is not null:
-                    yield return response.Event.Scripts.ToHashSet();
+                    yield return new VtxoScriptsChanged(response.Event.Scripts.ToHashSet());
                     break;
-                default:
-                    throw new InvalidDataException("Operator error: unexpected response from indexer");
+                case GetSubscriptionResponse.DataOneofCase.Heartbeat:
+                case GetSubscriptionResponse.DataOneofCase.None:
+                    break;
             }
         }
+    }
+
+    public async Task UpdateSubscriptionScriptsAsync(
+        string subscriptionId,
+        IReadOnlySet<string>? add,
+        IReadOnlySet<string>? remove,
+        CancellationToken cancellationToken = default)
+    {
+        if ((add is null || add.Count == 0) && (remove is null || remove.Count == 0))
+            return;
+
+        var req = new UpdateSubscriptionRequest
+        {
+            SubscriptionId = subscriptionId,
+            Filter = new SubscriptionFilter { Scripts = new ScriptFilter() },
+        };
+
+        if (add?.Count > 0)
+            req.Filter.Scripts.Add.AddRange(add);
+        if (remove?.Count > 0)
+            req.Filter.Scripts.Remove.AddRange(remove);
+
+        await _indexerServiceClient.UpdateSubscriptionAsync(req, cancellationToken: cancellationToken);
     }
 
     public async IAsyncEnumerable<ArkVtxo> GetVtxosByOutpoints(

--- a/NArk.Core/Transport/GrpcClient/Protos/ark/v1/indexer.proto
+++ b/NArk.Core/Transport/GrpcClient/Protos/ark/v1/indexer.proto
@@ -3,7 +3,6 @@ syntax = "proto3";
 package ark.v1;
 
 import "meshapi/gateway/annotations.proto";
-
 service IndexerService {
   // GetCommitmentTx returns information about a specific commitment transaction identified by the
   // provided txid.
@@ -75,6 +74,7 @@ service IndexerService {
     };
   }
 
+  // GetAsset returns the asset information and metadata for the specified asset ID.
   rpc GetAsset(GetAssetRequest) returns (GetAssetResponse) {
     option (meshapi.gateway.http) = {
       get: "/v1/indexer/asset/{asset_id}"
@@ -126,6 +126,26 @@ service IndexerService {
         disable_chunked_transfer: true
         disable_websockets: true
       }
+      additional_bindings: [
+        {
+          get: "/v1/indexer/subscription"
+          stream: {
+            disable_chunked_transfer: true
+            disable_websockets: true
+          }
+        }
+      ]
+    };
+  };
+
+  // UpdateSubscription updates an existing subscription created via
+  // GetSubscription. See UpdateSubscriptionRequest for the full set of
+  // supported filter combinations and their semantics.
+  rpc UpdateSubscription(UpdateSubscriptionRequest)
+      returns (UpdateSubscriptionResponse) {
+    option (meshapi.gateway.http) = {
+      post: "/v1/indexer/subscription/update"
+      body: "*"
     };
   };
 }
@@ -180,15 +200,26 @@ message GetVtxoTreeLeavesResponse {
 }
 
 message GetVtxosRequest {
+  // Either specify a list of vtxo scripts.
   repeated string scripts = 1;
+  // Or specify a list of vtxo outpoints. The 2 filters are mutually exclusive.
   repeated string outpoints = 2;
+  // Retrieve only spendable vtxos
   bool spendable_only = 3;
+  // Retrieve only spent vtxos.
   bool spent_only = 4;
+  // Retrieve only recoverable vtxos (notes, subdust or swept vtxos).
+  // The 3 filters are mutually exclusive,
   bool recoverable_only = 5;
   IndexerPageRequest page = 6;
+  // Include only spent vtxos that are not finalized.
   bool pending_only = 7;
+  // Include only vtxos with last update after the given unix time in milliseconds.
+  // A value of 0 means no lower bound.
   int64 after = 8;
-  int64 before = 9;
+  // Include only vtxos with last update before the given unix time in milliseconds,
+  // greater value than the after when specified. A value of 0 means no upper bound.
+  int64 before = 9; 
 }
 message GetVtxosResponse {
   repeated IndexerVtxo vtxos = 1;
@@ -198,19 +229,41 @@ message GetVtxosResponse {
 message GetVtxoChainRequest {
   IndexerOutpoint outpoint = 1;
   IndexerPageRequest page = 2;
+  // Either auth_token or intent can be provided to prove ownership.
+  oneof auth {
+    // Intent that directly proves ownership of the vtxo. If passed, the outpoint field is ignored.
+    IndexerIntent intent = 3;
+    // Valid auth_token can also be used if the ownership has already been proved.
+    // A valid token obtained from GetVirtualTxs rpc can be recycled for this request.
+    string token = 4;
+  }
 }
 message GetVtxoChainResponse {
   repeated IndexerChain chain = 1;
   IndexerPageResponse page = 2;
+  // Auth token can be used for other rpcs related to this vtxo/tx that require proof of ownership.
+  string auth_token = 3;
 }
 
 message GetVirtualTxsRequest {
   repeated string txids = 1;
   IndexerPageRequest page = 2;
+  // Either auth_token or intent can be provided to prove ownership.
+  oneof auth {
+    // Intent that directly proves ownership of the transaction inputs.
+    // If passed, the txids field is ignored.
+    IndexerIntent intent = 3;
+    // Valid auth_token can also be used if the ownership has already been proved.
+    // A valid token obtained from GetVtxoChain rpc can be recycled for this request.
+    string token = 4;
+  }
 }
+
 message GetVirtualTxsResponse {
   repeated string txs = 1;
   IndexerPageResponse page = 2;
+  // Auth token can be used for other rpcs related to this vtxo/tx that require proof of ownership.
+  string auth_token = 3;
 }
 
 message GetAssetRequest {
@@ -310,6 +363,11 @@ enum IndexerChainedTxType {
   INDEXER_CHAINED_TX_TYPE_CHECKPOINT = 4;
 }
 
+message IndexerIntent {
+  string proof = 1;
+  string message = 2;
+}
+
 message IndexerPageRequest {
   int32 size = 1;
   int32 index = 2;
@@ -339,16 +397,105 @@ message UnsubscribeForScriptsRequest {
 
 message UnsubscribeForScriptsResponse {}
 
+
 message GetSubscriptionRequest {
+  // If empty, server creates a new subscription automatically.
   string subscription_id = 1;
+  // Optional: filter to apply on stream creation. Only used when
+  // subscription_id is empty; ignored otherwise. See
+  // UpdateSubscriptionRequest for filter semantics.
+  SubscriptionFilter filter = 2;
 }
 
 message GetSubscriptionResponse {
   oneof data {
     IndexerHeartbeat heartbeat = 1;
     IndexerSubscriptionEvent event = 2;
+    SubscriptionStartedEvent subscription_started = 3;
   }
 }
+
+message SubscriptionStartedEvent {
+  string subscription_id = 1;
+}
+
+// SubscriptionFilter is the payload carried by GetSubscription's initial
+// filter and by UpdateSubscription. See UpdateSubscriptionRequest for the
+// per-call semantics of each field.
+//
+// At runtime, a tx event is dispatched to a subscription when any of its
+// expressions evaluates to true on the event's tx, OR when the event
+// carries a vtxo whose script is in the subscription's script set.
+message SubscriptionFilter {
+  // CEL expressions evaluated against each indexed tx envelope. The
+  // indexer combines them with OR.
+  repeated string expressions = 1;
+  // Script add/remove operations. Will be migrated to a CEL formula in a
+  // future protocol version and removed.
+  ScriptFilter scripts = 2;
+}
+
+message ScriptFilter {
+  repeated string add = 1;
+  repeated string remove = 2;
+}
+
+// UpdateSubscriptionRequest mutates an existing subscription. Both filter
+// fields are optional and may be set together. The subscription_id must
+// be non-empty and the filter must be present; otherwise InvalidArgument
+// is returned.
+//
+// Expressions (filter.expressions):
+//   - Always overwritten as a whole. The field's contents replace any
+//     previously-set expressions even when the list is empty (which
+//     clears them entirely).
+//   - Duplicate expressions are deduplicated, since the underlying set
+//     is keyed by expression string.
+//   - Bounded by a server-side per-subscription cap; exceeding it returns
+//     InvalidArgument.
+//
+// Scripts (filter.scripts):
+//   - When the scripts field is unset, scripts are left untouched.
+//   - When set with both `add` and `remove` empty, the call clears all
+//     scripts (mirrors UnsubscribeForScripts with an empty scripts list).
+//   - When set with `add` non-empty, those scripts are added.
+//   - When set with `remove` non-empty, those scripts are removed.
+//   - `add` and `remove` may be combined in a single call. When the two
+//     lists overlap, remove takes precedence, since add is applied first
+//     and remove second.
+//   - Both operations are idempotent: adding an already-subscribed
+//     script is a no-op, and removing an unsubscribed script is a no-op.
+//
+// Atomicity:
+//   - All inputs (CEL expressions, scripts to add, scripts to remove) are
+//     validated before any state is mutated. If any single input fails
+//     validation, no mutations are applied and even valid entries in the
+//     same request are discarded. An InvalidArgument response therefore
+//     guarantees the subscription is unchanged.
+//   - A successful response guarantees all requested mutations were
+//     applied.
+//
+// Errors:
+//   - NotFound: subscription_id does not match a live subscription.
+//   - InvalidArgument: any CEL compile error, any script parse error, or
+//     the expressions cap exceeded.
+//
+// GetSubscription initial filter:
+//   - The same SubscriptionFilter shape is accepted by
+//     GetSubscriptionRequest.filter on stream creation, with the same
+//     semantics as above and two exceptions.
+//   - `scripts.remove` is ignored on creation, since a freshly-created
+//     subscription has no scripts to remove.
+//   - When `scripts` is set with both `add` and `remove` empty on
+//     creation, the clear-all behavior does not fire either, since there
+//     is nothing to clear. An empty SubscriptionFilter is therefore a
+//     no-op on creation.
+message UpdateSubscriptionRequest {
+  string subscription_id = 1;
+  SubscriptionFilter filter = 2;
+}
+
+message UpdateSubscriptionResponse {}
 
 message IndexerTxData {
   string txid = 1;

--- a/NArk.Core/Transport/GrpcClient/Protos/ark/v1/service.proto
+++ b/NArk.Core/Transport/GrpcClient/Protos/ark/v1/service.proto
@@ -93,7 +93,9 @@ service ArkService {
   // Clients should use this stream as soon as they are ready to join a batch and can listen for
   // various events such as batch start, batch finalization, and other related activities.
   // The server pushes these events to the client in real-time as soon as its ready to move to the
-  // next phase of the batch processing.
+  // next phase of the batch processing. Upon creation of the stream, the event StreamStartedEvent
+  // is immediately sent, which passes along the stream id, to be used by the client for future
+  // calls to UpdateStreamTopics.
   rpc GetEventStream(GetEventStreamRequest) returns (stream GetEventStreamResponse) {
     option (meshapi.gateway.http) = {
       get: "/v1/batch/events"
@@ -103,6 +105,16 @@ service ArkService {
       }
     };
   };
+
+  // UpdateStreamTopics allows a client to modify the topics of their event stream. They can add,
+  // remove, or specify a list of topics, providing them control over the events received on the
+  // event stream. 
+  rpc UpdateStreamTopics(UpdateStreamTopicsRequest) returns (UpdateStreamTopicsResponse) {
+    option (meshapi.gateway.http) = {
+      post: "/v1/batch/updateTopics"
+      body: "*"
+    };
+  }
 
   // SubmitTx is the first leg of the process of spending vtxos offchain and allows a client to
   // submit a signed Ark transaction and the unsigned checkpoint transactions.
@@ -150,16 +162,13 @@ service ArkService {
     };
   }
 
-  rpc UpdateStreamTopics(UpdateStreamTopicsRequest) returns (UpdateStreamTopicsResponse) {
-    option (meshapi.gateway.http) = {
-      post: "/v1/batch/updateTopics"
-      body: "*"
-    };
-  }
-
   rpc GetIntent(GetIntentRequest) returns (GetIntentResponse) {
     option (meshapi.gateway.http) = {
       get: "/v1/intent"
+      additional_bindings {
+        post: "/v1/intent"
+        body: "*"
+      }
     };
   }
 }
@@ -258,6 +267,34 @@ message GetEventStreamResponse {
   }
 }
 
+message ModifyTopics {
+  repeated string add_topics = 1;
+  repeated string remove_topics = 2;
+}
+
+message OverwriteTopics {
+  repeated string topics = 1;
+}
+
+// Adding and removing topics can both be supplied in the same request,
+// allowing for simultaneous changes.
+// overwrite_topics will take precedence, and if set, then the add/remove
+// topics are ignored. The stream_id is required.
+message UpdateStreamTopicsRequest {
+  string stream_id = 1;
+
+  oneof topics_change {
+    ModifyTopics modify = 2;
+    OverwriteTopics overwrite = 3;
+  }
+}
+
+message UpdateStreamTopicsResponse {
+  repeated string topics_added = 1;
+  repeated string topics_removed = 2;
+  repeated string all_topics = 3;
+}
+
 message SubmitTxRequest {
   string signed_ark_tx = 1;
   repeated string checkpoint_txs = 2;
@@ -283,45 +320,26 @@ message GetPendingTxResponse {
   repeated PendingTx pending_txs = 1;
 }
 
-message ModifyTopics {
-  repeated string add_topics = 1;
-  repeated string remove_topics = 2;
-}
-
-message OverwriteTopics {
-  repeated string topics = 1;
-}
-
-message UpdateStreamTopicsRequest {
-  string stream_id = 1;
-  oneof topics_change {
-    ModifyTopics modify = 2;
-    OverwriteTopics overwrite = 3;
-  }
-}
-
-message UpdateStreamTopicsResponse {
-  repeated string topics_added = 1;
-  repeated string topics_removed = 2;
-  repeated string all_topics = 3;
-}
-
 message GetTransactionsStreamRequest {}
 message GetTransactionsStreamResponse {
   oneof data {
     TxNotification commitment_tx = 1;
     TxNotification ark_tx = 2;
     Heartbeat heartbeat = 3;
+    TxNotification sweep_tx = 4;
   }
 }
 
 message GetIntentRequest {
   oneof filter {
-      string txid = 1;
-      Intent intent = 2;
-    }
+    string txid = 1;
+    Intent intent = 2;
+  }
 }
 
+// The repeated intents field is always populated with the matching results.
+// The singular intent field is only set for backward compatibility when the
+// request uses the txid filter, in which case it mirrors intents[0].
 message GetIntentResponse {
   Intent intent = 1;
   repeated Intent intents = 2;

--- a/NArk.Core/Transport/GrpcClient/Protos/ark/v1/types.proto
+++ b/NArk.Core/Transport/GrpcClient/Protos/ark/v1/types.proto
@@ -48,6 +48,7 @@ message TxNotification {
   repeated Vtxo spendable_vtxos = 4;
   // This field is set only in case of offchain tx.
   map<string, TxData> checkpoint_txs = 5; // key: outpoint, value: checkpoint txid
+  repeated Outpoint swept_vtxos = 6;
 }
 
 message Tapscripts {
@@ -154,6 +155,7 @@ message Heartbeat {
 message StreamStartedEvent {
   string id = 1;
 }
+
 
 message ErrorDetails {
   int32 code = 1;

--- a/NArk.Core/Transport/IClientTransport.cs
+++ b/NArk.Core/Transport/IClientTransport.cs
@@ -1,4 +1,3 @@
-using System.Runtime.CompilerServices;
 using NArk.Abstractions.Batches;
 using NArk.Abstractions.Batches.ServerEvents;
 using NArk.Abstractions.Intents;
@@ -13,47 +12,34 @@ public interface IClientTransport
     Task<ArkServerInfo> GetServerInfoAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Creates a new VTXO-script subscription (when <paramref name="subscriptionId"/> is null
-    /// or empty) or adds scripts to an existing one. Returns the subscription id to open the
-    /// stream with via <see cref="GetVtxoSubscriptionStreamAsync"/>.
+    /// Opens a server-streaming subscription for VTXO script events.
     /// <para>
-    /// arkd's subscription is mutable while its stream is open: scripts added here are routed
-    /// onto the already-open stream, so the watched set can be updated in place without tearing
-    /// the stream down and resubscribing.
+    /// When <paramref name="existingSubscriptionId"/> is <c>null</c>, the server creates a new
+    /// subscription. The first yielded event is always <see cref="VtxoSubscriptionStarted"/>
+    /// carrying the server-assigned ID. Pass <paramref name="initialScripts"/> to register the
+    /// initial watched set at stream-open time (only honoured on new subscriptions).
+    /// </para>
+    /// <para>
+    /// When <paramref name="existingSubscriptionId"/> is provided, the server reconnects to an
+    /// existing subscription. If the subscription was GC'd the stream throws a <c>NotFound</c>
+    /// error; the caller should retry with a <c>null</c> ID to open a fresh subscription.
     /// </para>
     /// </summary>
-    Task<string> SubscribeForScriptsAsync(IReadOnlySet<string> scripts, string? subscriptionId,
+    IAsyncEnumerable<VtxoSubscriptionEvent> OpenSubscriptionStreamAsync(
+        IReadOnlySet<string>? initialScripts,
+        string? existingSubscriptionId,
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Removes scripts from an existing subscription. When <paramref name="scripts"/> is null or
-    /// empty, all scripts are removed and the subscription is torn down server-side.
+    /// Updates the script set of an existing subscription in place without tearing the stream down.
+    /// Both <paramref name="add"/> and <paramref name="remove"/> are optional; when both are null
+    /// or empty the call is a no-op. Throws <c>NotFound</c> when the subscription was GC'd.
     /// </summary>
-    Task UnsubscribeForScriptsAsync(string subscriptionId, IReadOnlySet<string>? scripts,
+    Task UpdateSubscriptionScriptsAsync(
+        string subscriptionId,
+        IReadOnlySet<string>? add,
+        IReadOnlySet<string>? remove,
         CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Opens the long-lived server stream for a subscription, yielding the set of scripts whose
-    /// VTXOs changed on each push. The subscription's script set may be mutated in place via
-    /// <see cref="SubscribeForScriptsAsync"/> / <see cref="UnsubscribeForScriptsAsync"/> while
-    /// this stream stays open.
-    /// </summary>
-    IAsyncEnumerable<HashSet<string>> GetVtxoSubscriptionStreamAsync(string subscriptionId,
-        CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Convenience: create a one-shot subscription for <paramref name="scripts"/> and stream it.
-    /// Built on the composable primitives above; it does not surface the subscription id, so it
-    /// cannot update the watched set in place — prefer the primitives when the set changes over
-    /// time (see <see cref="SubscribeForScriptsAsync"/>).
-    /// </summary>
-    async IAsyncEnumerable<HashSet<string>> GetVtxoToPollAsStream(IReadOnlySet<string> scripts,
-        [EnumeratorCancellation] CancellationToken token = default)
-    {
-        var subscriptionId = await SubscribeForScriptsAsync(scripts, subscriptionId: null, token);
-        await foreach (var changed in GetVtxoSubscriptionStreamAsync(subscriptionId, token))
-            yield return changed;
-    }
 
     IAsyncEnumerable<ArkVtxo> GetVtxoByScriptsAsSnapshot(IReadOnlySet<string> scripts,
         CancellationToken cancellationToken = default);

--- a/NArk.Core/Transport/IndexerSubscriptionEvent.cs
+++ b/NArk.Core/Transport/IndexerSubscriptionEvent.cs
@@ -1,0 +1,14 @@
+namespace NArk.Core.Transport;
+
+/// <summary>Discriminated union for events yielded by <see cref="IClientTransport.OpenSubscriptionStreamAsync"/>.</summary>
+public abstract record VtxoSubscriptionEvent;
+
+/// <summary>
+/// First event on every new subscription stream. Carries the server-assigned subscription ID
+/// that the caller must store for subsequent <see cref="IClientTransport.UpdateSubscriptionScriptsAsync"/> calls
+/// and for reconnecting via <see cref="IClientTransport.OpenSubscriptionStreamAsync"/>.
+/// </summary>
+public record VtxoSubscriptionStarted(string SubscriptionId) : VtxoSubscriptionEvent;
+
+/// <summary>Scripts whose VTXOs changed since the last push.</summary>
+public record VtxoScriptsChanged(HashSet<string> Scripts) : VtxoSubscriptionEvent;

--- a/NArk.Core/Transport/RestClient/RestClientTransport.Vtxo.cs
+++ b/NArk.Core/Transport/RestClient/RestClientTransport.Vtxo.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Web;
 using NArk.Abstractions.VTXOs;
+using NArk.Core.Transport;
 using NBitcoin;
 
 namespace NArk.Transport.RestClient;
@@ -79,57 +80,48 @@ public partial class RestClientTransport
         }
     }
 
-    public async Task<string> SubscribeForScriptsAsync(IReadOnlySet<string> scripts,
-        string? subscriptionId, CancellationToken cancellationToken = default)
-    {
-        var subReq = new { scripts = scripts.ToArray(), subscription_id = subscriptionId ?? "" };
-        var subResponse = await _http.PostAsJsonAsync("/v1/indexer/script/subscribe", subReq, JsonOpts, cancellationToken);
-        await EnsureSuccessWithBodyAsync(subResponse, "SubscribeForScripts", cancellationToken);
-        var subJson = await subResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOpts, cancellationToken);
-        return subJson.GetProperty("subscription_id").GetString()!;
-    }
-
-    public async Task UnsubscribeForScriptsAsync(string subscriptionId,
-        IReadOnlySet<string>? scripts, CancellationToken cancellationToken = default)
-    {
-        // Empty scripts ⇒ arkd removes all topics and tears the subscription down.
-        var req = new { subscription_id = subscriptionId, scripts = scripts?.ToArray() ?? [] };
-        var response = await _http.PostAsJsonAsync("/v1/indexer/script/unsubscribe", req, JsonOpts, cancellationToken);
-        await EnsureSuccessWithBodyAsync(response, "UnsubscribeForScripts", cancellationToken);
-    }
-
-    // Surfaces the server error body in the exception message so callers can detect arkd's
-    // "subscription <id> not found" (the trigger for recreating a GC'd subscription).
-    private static async Task EnsureSuccessWithBodyAsync(HttpResponseMessage response, string op, CancellationToken cancellationToken)
-    {
-        if (response.IsSuccessStatusCode)
-            return;
-        var body = await response.Content.ReadAsStringAsync(cancellationToken);
-        throw new HttpRequestException($"{op} failed ({(int)response.StatusCode}): {body}");
-    }
-
-    public async IAsyncEnumerable<HashSet<string>> GetVtxoSubscriptionStreamAsync(string subscriptionId,
+    public async IAsyncEnumerable<VtxoSubscriptionEvent> OpenSubscriptionStreamAsync(
+        IReadOnlySet<string>? initialScripts,
+        string? existingSubscriptionId,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        // Stream subscription events via SSE (gRPC-gateway server streaming → newline-delimited JSON)
-        using var stream = await _http.GetStreamAsync(
-            $"/v1/indexer/script/subscription/{subscriptionId}", cancellationToken);
+        string url;
+        if (existingSubscriptionId is not null)
+        {
+            url = $"/v1/indexer/script/subscription/{existingSubscriptionId}";
+        }
+        else
+        {
+            var query = HttpUtility.ParseQueryString(string.Empty);
+            if (initialScripts?.Count > 0)
+                foreach (var s in initialScripts)
+                    query.Add("filter.scripts.add", s);
+            url = query.Count > 0 ? $"/v1/indexer/subscription?{query}" : "/v1/indexer/subscription";
+        }
+
+        using var stream = await _http.GetStreamAsync(url, cancellationToken);
         using var reader = new StreamReader(stream);
 
         while (!cancellationToken.IsCancellationRequested)
         {
             var line = await reader.ReadLineAsync(cancellationToken);
-            if (line is null) break; // Stream closed
+            if (line is null) break;
             if (string.IsNullOrWhiteSpace(line)) continue;
 
             JsonElement evt;
             try { evt = JsonSerializer.Deserialize<JsonElement>(line, JsonOpts); }
             catch { continue; }
 
-            // Heartbeat — skip
             if (evt.TryGetProperty("heartbeat", out _)) continue;
 
-            // Subscription event — extract scripts
+            if (evt.TryGetProperty("subscriptionStarted", out var started) &&
+                started.TryGetProperty("subscriptionId", out var idProp))
+            {
+                var id = idProp.GetString();
+                if (id is not null) yield return new VtxoSubscriptionStarted(id);
+                continue;
+            }
+
             if (evt.TryGetProperty("event", out var eventData) &&
                 eventData.TryGetProperty("scripts", out var scriptsArr))
             {
@@ -140,9 +132,44 @@ public partial class RestClientTransport
                     if (val is not null) changedScripts.Add(val);
                 }
                 if (changedScripts.Count > 0)
-                    yield return changedScripts;
+                    yield return new VtxoScriptsChanged(changedScripts);
             }
         }
+    }
+
+    public async Task UpdateSubscriptionScriptsAsync(
+        string subscriptionId,
+        IReadOnlySet<string>? add,
+        IReadOnlySet<string>? remove,
+        CancellationToken cancellationToken = default)
+    {
+        if ((add is null || add.Count == 0) && (remove is null || remove.Count == 0))
+            return;
+
+        var req = new
+        {
+            subscription_id = subscriptionId,
+            filter = new
+            {
+                scripts = new
+                {
+                    add = add?.ToArray() ?? [],
+                    remove = remove?.ToArray() ?? [],
+                }
+            }
+        };
+        var response = await _http.PostAsJsonAsync("/v1/indexer/subscription/update", req, JsonOpts, cancellationToken);
+        await EnsureSuccessWithBodyAsync(response, "UpdateSubscription", cancellationToken);
+    }
+
+    // Surfaces the server error body in the exception message so callers can detect arkd's
+    // "subscription <id> not found" (the trigger for recreating a GC'd subscription).
+    private static async Task EnsureSuccessWithBodyAsync(HttpResponseMessage response, string op, CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode)
+            return;
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+        throw new HttpRequestException($"{op} failed ({(int)response.StatusCode}): {body}");
     }
 
     public async IAsyncEnumerable<ArkVtxo> GetVtxosByOutpoints(

--- a/NArk.Tests.End2End/PendingArkTransactionRecoveryTests.cs
+++ b/NArk.Tests.End2End/PendingArkTransactionRecoveryTests.cs
@@ -1,13 +1,10 @@
-using CliWrap;
 using NArk.Abstractions;
 using NArk.Abstractions.Batches;
 using NArk.Abstractions.Batches.ServerEvents;
-using NArk.Abstractions.Contracts;
 using NArk.Abstractions.Intents;
 using NArk.Abstractions.VTXOs;
 using NArk.Abstractions.Wallets;
 using NArk.Core;
-using NArk.Core.Contracts;
 using NArk.Core.Services;
 using NArk.Core.Transformers;
 using NArk.Core.Transport;
@@ -143,14 +140,20 @@ public class PendingArkTransactionRecoveryTests
         public Task<ArkServerInfo> GetServerInfoAsync(CancellationToken cancellationToken = default)
             => _inner.GetServerInfoAsync(cancellationToken);
 
-        public Task<string> SubscribeForScriptsAsync(IReadOnlySet<string> scripts, string? subscriptionId, CancellationToken cancellationToken = default)
-            => _inner.SubscribeForScriptsAsync(scripts, subscriptionId, cancellationToken);
+        public IAsyncEnumerable<VtxoSubscriptionEvent> OpenSubscriptionStreamAsync(
+            IReadOnlySet<string>? initialScripts, 
+            string? existingSubscriptionId,
+            CancellationToken cancellationToken = default) =>
+                _inner.OpenSubscriptionStreamAsync(initialScripts, existingSubscriptionId, cancellationToken);
 
-        public Task UnsubscribeForScriptsAsync(string subscriptionId, IReadOnlySet<string>? scripts, CancellationToken cancellationToken = default)
-            => _inner.UnsubscribeForScriptsAsync(subscriptionId, scripts, cancellationToken);
+        public Task UpdateSubscriptionScriptsAsync(
+            string subscriptionId, 
+            IReadOnlySet<string>? add, 
+            IReadOnlySet<string>? remove,
+            CancellationToken cancellationToken = default) =>
+                 _inner.UpdateSubscriptionScriptsAsync(subscriptionId, add, remove, cancellationToken);
+        
 
-        public IAsyncEnumerable<HashSet<string>> GetVtxoSubscriptionStreamAsync(string subscriptionId, CancellationToken cancellationToken = default)
-            => _inner.GetVtxoSubscriptionStreamAsync(subscriptionId, cancellationToken);
 
         public IAsyncEnumerable<ArkVtxo> GetVtxoByScriptsAsSnapshot(IReadOnlySet<string> scripts, CancellationToken cancellationToken = default)
             => _inner.GetVtxoByScriptsAsSnapshot(scripts, cancellationToken);

--- a/NArk.Tests/Sync/VtxoSynchronizationServiceViewUpdateTests.cs
+++ b/NArk.Tests/Sync/VtxoSynchronizationServiceViewUpdateTests.cs
@@ -9,7 +9,7 @@ namespace NArk.Tests.Sync;
 
 /// <summary>
 /// Covers the in-place subscription model: a script-set change updates arkd's subscription
-/// via Subscribe/Unsubscribe without tearing the stream down, the subscription is recreated
+/// via UpdateSubscription without tearing the stream down, the subscription is recreated
 /// when arkd GC's it, an empty set tears it down, and the fresh-derive safety-net poll still
 /// reconciles a drifted/missed subscription.
 /// </summary>
@@ -34,16 +34,20 @@ public class VtxoSynchronizationServiceViewUpdateTests
                 Arg.Any<IReadOnlySet<string>>(), Arg.Any<DateTimeOffset?>(),
                 Arg.Any<DateTimeOffset?>(), Arg.Any<CancellationToken>())
             .Returns(_ => System.Linq.AsyncEnumerable.Empty<ArkVtxo>());
-        // Create (subscriptionId == null) ⇒ a fresh id; add-to-existing ⇒ echo the id back.
-        _transport.SubscribeForScriptsAsync(Arg.Any<IReadOnlySet<string>>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns(ci => Task.FromResult(ci.ArgAt<string?>(1) ?? $"sub-{Interlocked.Increment(ref _subCounter)}"));
-        // Keep the stream open until cancelled, so an in-place update can't be mistaken for a restart.
-        _transport.GetVtxoSubscriptionStreamAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(ci => BlockingStream(ci.ArgAt<CancellationToken>(1)));
+        // New subscription (no existing ID) → yield SubscriptionStarted then block.
+        _transport.OpenSubscriptionStreamAsync(
+                Arg.Any<IReadOnlySet<string>?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(ci =>
+            {
+                var existingId = ci.ArgAt<string?>(1);
+                var ct = ci.ArgAt<CancellationToken>(2);
+                var id = existingId ?? $"sub-{Interlocked.Increment(ref _subCounter)}";
+                return NewSubscriptionStream(id, ct);
+            });
     }
 
     [Test]
-    public async Task InitialActiveSet_CreatesSubscriptionAndOpensStream()
+    public async Task InitialActiveSet_OpensStreamAndReceivesSubscriptionId()
     {
         var provider = MutableProvider(ScriptA, ScriptB);
         await using var sut = New([provider]);
@@ -51,9 +55,11 @@ public class VtxoSynchronizationServiceViewUpdateTests
         await sut.StartAsync(CancellationToken.None);
         await WaitForAsync(() => StreamOpenCount() >= 1);
 
-        await _transport.Received().SubscribeForScriptsAsync(
-            Arg.Is<IReadOnlySet<string>>(s => s.SetEquals(new HashSet<string> { ScriptA, ScriptB })),
-            Arg.Is<string?>(id => id == null), Arg.Any<CancellationToken>());
+        // Stream opened with initial scripts and no existing ID.
+        _transport.Received().OpenSubscriptionStreamAsync(
+            Arg.Is<IReadOnlySet<string>?>(s => s != null && s.SetEquals(new HashSet<string> { ScriptA, ScriptB })),
+            Arg.Is<string?>(id => id == null),
+            Arg.Any<CancellationToken>());
         Assert.That(StreamOpenCount(), Is.EqualTo(1));
     }
 
@@ -67,22 +73,22 @@ public class VtxoSynchronizationServiceViewUpdateTests
         await sut.StartAsync(CancellationToken.None);
         await WaitForAsync(() => StreamOpenCount() >= 1);
 
-        // A new contract is derived → fires ActiveScriptsChanged.
         scripts.Add(ScriptC);
         provider.ActiveScriptsChanged += Raise.Event<EventHandler>(provider, EventArgs.Empty);
 
-        await WaitForAsync(() => CallCount(nameof(IClientTransport.SubscribeForScriptsAsync)) >= 2);
+        await WaitForAsync(() => UpdateCount() >= 1);
 
-        // The new script was added to the EXISTING subscription (non-null id), not a fresh one.
-        await _transport.Received().SubscribeForScriptsAsync(
-            Arg.Is<IReadOnlySet<string>>(s => s.SetEquals(new HashSet<string> { ScriptC })),
-            Arg.Is<string?>(id => id != null), Arg.Any<CancellationToken>());
-        // And the stream was never reopened — the watched set changed in place.
+        // In-place update: add ScriptC on the existing subscription, do not restart stream.
+        await _transport.Received().UpdateSubscriptionScriptsAsync(
+            Arg.Any<string>(),
+            Arg.Is<IReadOnlySet<string>?>(s => s != null && s.SetEquals(new HashSet<string> { ScriptC })),
+            Arg.Is<IReadOnlySet<string>?>(s => s == null || s.Count == 0),
+            Arg.Any<CancellationToken>());
         Assert.That(StreamOpenCount(), Is.EqualTo(1), "in-place update must not restart the stream");
     }
 
     [Test]
-    public async Task ScriptRemoved_UnsubscribesInPlace()
+    public async Task ScriptRemoved_UpdatesInPlace()
     {
         var scripts = new HashSet<string> { ScriptA, ScriptB };
         var provider = MutableProvider(scripts);
@@ -94,10 +100,11 @@ public class VtxoSynchronizationServiceViewUpdateTests
         scripts.Remove(ScriptB);
         provider.ActiveScriptsChanged += Raise.Event<EventHandler>(provider, EventArgs.Empty);
 
-        await WaitForAsync(() => CallCount(nameof(IClientTransport.UnsubscribeForScriptsAsync)) >= 1);
+        await WaitForAsync(() => UpdateCount() >= 1);
 
-        await _transport.Received().UnsubscribeForScriptsAsync(
+        await _transport.Received().UpdateSubscriptionScriptsAsync(
             Arg.Any<string>(),
+            Arg.Is<IReadOnlySet<string>?>(s => s == null || s.Count == 0),
             Arg.Is<IReadOnlySet<string>?>(s => s != null && s.SetEquals(new HashSet<string> { ScriptB })),
             Arg.Any<CancellationToken>());
         Assert.That(StreamOpenCount(), Is.EqualTo(1));
@@ -116,12 +123,11 @@ public class VtxoSynchronizationServiceViewUpdateTests
         scripts.Clear();
         provider.ActiveScriptsChanged += Raise.Event<EventHandler>(provider, EventArgs.Empty);
 
-        await WaitForAsync(() => CallCount(nameof(IClientTransport.UnsubscribeForScriptsAsync)) >= 1);
+        await WaitForAsync(() => sut.ListenedScripts.Count == 0, timeoutMs: 3000);
 
-        // Unsubscribe-all (null scripts) tears the subscription down server-side.
-        await _transport.Received().UnsubscribeForScriptsAsync(
-            Arg.Any<string>(), Arg.Is<IReadOnlySet<string>?>(s => s == null), Arg.Any<CancellationToken>());
         Assert.That(sut.ListenedScripts, Is.Empty);
+        // No extra stream opens after teardown.
+        Assert.That(StreamOpenCount(), Is.EqualTo(1));
     }
 
     [Test]
@@ -130,12 +136,11 @@ public class VtxoSynchronizationServiceViewUpdateTests
         var scripts = new HashSet<string> { ScriptA };
         var provider = MutableProvider(scripts);
 
-        // The in-place add (non-null subscription id) fails as if arkd GC'd the listener;
-        // the recreate (null id) succeeds.
-        _transport.SubscribeForScriptsAsync(Arg.Any<IReadOnlySet<string>>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns(ci => ci.ArgAt<string?>(1) is null
-                ? Task.FromResult($"sub-{Interlocked.Increment(ref _subCounter)}")
-                : Task.FromException<string>(new InvalidOperationException("subscription sub-1 not found")));
+        // UpdateSubscription fails as if arkd GC'd the listener; the supervisor then reopens fresh.
+        _transport.UpdateSubscriptionScriptsAsync(
+                Arg.Any<string>(), Arg.Any<IReadOnlySet<string>?>(),
+                Arg.Any<IReadOnlySet<string>?>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromException(new InvalidOperationException("subscription sub-1 not found")));
 
         await using var sut = New([provider]);
         await sut.StartAsync(CancellationToken.None);
@@ -144,10 +149,10 @@ public class VtxoSynchronizationServiceViewUpdateTests
         scripts.Add(ScriptC);
         provider.ActiveScriptsChanged += Raise.Event<EventHandler>(provider, EventArgs.Empty);
 
-        // Recreate ⇒ a second create call (null id) and a second stream open on the new id.
-        await WaitForAsync(() => CreateCount() >= 2 && StreamOpenCount() >= 2);
+        // GC → UpdateSubscription throws → supervisor reopens fresh → second stream open.
+        await WaitForAsync(() => StreamOpenCount() >= 2);
 
-        Assert.That(CreateCount(), Is.GreaterThanOrEqualTo(2), "GC'd subscription must be recreated with a fresh id");
+        Assert.That(StreamOpenCount(), Is.GreaterThanOrEqualTo(2), "GC'd subscription must cause a fresh stream open");
         Assert.That(sut.ListenedScripts, Does.Contain(ScriptC));
     }
 
@@ -191,7 +196,6 @@ public class VtxoSynchronizationServiceViewUpdateTests
     private VtxoSynchronizationService New(IActiveScriptsProvider[] providers, TimeSpan? pollInterval = null) =>
         new(_vtxoStorage, _transport, providers, walletStorage: null)
         {
-            // Default to a long interval so event-driven tests aren't perturbed by the poll.
             RoutinePollInterval = pollInterval ?? TimeSpan.FromSeconds(30)
         };
 
@@ -209,13 +213,8 @@ public class VtxoSynchronizationServiceViewUpdateTests
     private int CallCount(string method) =>
         _transport.ReceivedCalls().Count(c => c.GetMethodInfo().Name == method);
 
-    private int StreamOpenCount() => CallCount(nameof(IClientTransport.GetVtxoSubscriptionStreamAsync));
-
-    // Number of "create" calls = SubscribeForScriptsAsync with a null subscription id.
-    private int CreateCount() =>
-        _transport.ReceivedCalls()
-            .Where(c => c.GetMethodInfo().Name == nameof(IClientTransport.SubscribeForScriptsAsync))
-            .Count(c => c.GetArguments()[1] is null);
+    private int StreamOpenCount() => CallCount(nameof(IClientTransport.OpenSubscriptionStreamAsync));
+    private int UpdateCount() => CallCount(nameof(IClientTransport.UpdateSubscriptionScriptsAsync));
 
     private HashSet<string> PolledScripts()
     {
@@ -229,15 +228,13 @@ public class VtxoSynchronizationServiceViewUpdateTests
         return polled;
     }
 
-    private static async IAsyncEnumerable<HashSet<string>> BlockingStream(
-        [EnumeratorCancellation] CancellationToken ct = default)
+    private static async IAsyncEnumerable<VtxoSubscriptionEvent> NewSubscriptionStream(
+        string id, [EnumeratorCancellation] CancellationToken ct = default)
     {
+        yield return new VtxoSubscriptionStarted(id);
         var tcs = new TaskCompletionSource();
         await using (ct.Register(() => tcs.TrySetResult()))
-        {
             await tcs.Task;
-        }
-        yield break;
     }
 
     private static async Task WaitForAsync(Func<bool> predicate, int timeoutMs = 3000)


### PR DESCRIPTION
- Proto sync: updated indexer.proto, service.proto, types.proto to match arkade-os/arkd master verbatim
- Subscription API migration: replaced the old 3-step subscription flow (SubscribeForScripts -> GetSubscription(id) -> UnsubscribeForScripts) with the new single-endpoint model:
  - OpenSubscriptionStreamAsync(initialScripts, existingSubscriptionId) — server creates the subscription inline and returns the ID as the first stream event (VtxoSubscriptionStarted); passing an existing ID reconnects
  - UpdateSubscriptionScriptsAsync(id, add, remove) — in-place script set changes without tearing the stream down
  - Eliminates the stale-ID problem: the subscription ID is no longer stored between reconnections
- VtxoSynchronizationService: rewritten supervisor loop to consume VtxoSubscriptionStarted from the stream, removed ReassertSubscriptionAsync, simplified UpdateScriptsView (in-place update via UpdateSubscriptionScriptsAsync; clears ID on NotFound and reopens fresh)
- CI: added proto-sync-check.yml — runs on every PR, fetches indexer/service/types.proto from arkade-os/arkd master and diffs against the SDK copies; fails with a file-level annotation if any file is out of sync