### PR TITLE
feat(tests): Add rust-sdk test vectors

### DIFF
--- a/NArk.Core/Contracts/VHTLCContract.cs
+++ b/NArk.Core/Contracts/VHTLCContract.cs
@@ -117,6 +117,27 @@ public class VHTLCContract : ArkContract
             CreateCooperativeScript(), null, null, null, vtxo.Swept, vtxo.Unrolled);
     }
 
+    /// <summary>
+    /// Creates a VHTLC contract from raw parameters, validating hash byte length and seconds timelocks
+    /// before encoding them into NBitcoin types (which lose the original value on rounding).
+    /// </summary>
+    public static VHTLCContract Create(
+        OutputDescriptor server, OutputDescriptor sender, OutputDescriptor receiver,
+        byte[] preimageHashBytes, LockTime refundLocktime,
+        VHtlcDelay unilateralClaimDelay, VHtlcDelay unilateralRefundDelay, VHtlcDelay unilateralRefundWithoutReceiverDelay)
+    {
+        if (preimageHashBytes.Length != 20)
+            throw new ArgumentException("preimage hash must be 20 bytes", nameof(preimageHashBytes));
+        if (refundLocktime.Value == 0)
+            throw new ArgumentException("refund locktime must be greater than 0", nameof(refundLocktime));
+
+        return new VHTLCContract(server, sender, receiver,
+            new uint160(preimageHashBytes, false), refundLocktime,
+            unilateralClaimDelay.ToSequence(nameof(unilateralClaimDelay)),
+            unilateralRefundDelay.ToSequence(nameof(unilateralRefundDelay)),
+            unilateralRefundWithoutReceiverDelay.ToSequence(nameof(unilateralRefundWithoutReceiverDelay)));
+    }
+
     public static ArkContract? Parse(Dictionary<string, string> contractData, Network network)
     {
         var server = KeyExtensions.ParseOutputDescriptor(contractData["server"], network);
@@ -188,5 +209,27 @@ public class VHTLCContract : ArkContract
         // unilateralRefundWithoutReceiver (sender after unilateralRefundWithoutReceiverDelay)
         return new UnilateralPathArkTapScript(UnilateralRefundWithoutReceiverDelay,
             new NofNMultisigTapScript([Sender.ToXOnlyPubKey()]));
+    }
+}
+
+/// <summary>A CSV timelock delay for a VHTLC contract, expressed in blocks or seconds.</summary>
+public readonly record struct VHtlcDelay(bool IsSeconds, uint Value)
+{
+    public static VHtlcDelay Blocks(uint blocks) => new(false, blocks);
+    public static VHtlcDelay Seconds(uint seconds) => new(true, seconds);
+
+    internal Sequence ToSequence(string fieldName)
+    {
+        if (Value == 0)
+            throw new ArgumentException($"{fieldName} must be greater than 0");
+        if (IsSeconds)
+        {
+            if (Value < 512)
+                throw new ArgumentException("seconds timelock must be greater or equal to 512");
+            if (Value % 512 != 0)
+                throw new ArgumentException("seconds timelock must be a multiple of 512");
+            return new Sequence(TimeSpan.FromSeconds(Value));
+        }
+        return new Sequence(Value);
     }
 }

--- a/NArk.Tests/VHtlcContractTests.cs
+++ b/NArk.Tests/VHtlcContractTests.cs
@@ -1,49 +1,106 @@
 using NArk.Core.Contracts;
 using NArk.Abstractions.Extensions;
 using NBitcoin;
+using NBitcoin.Scripting;
 
 namespace NArk.Tests;
 
-//TODO: implement more from: https://github.com/arkade-os/rust-sdk/blob/master/ark-core/src/vhtlc_fixtures/vhtlc.json
 public class VHtlcContractTests
 {
+    private static readonly OutputDescriptor Server =
+        KeyExtensions.ParseOutputDescriptor("03aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88", Network.RegTest);
+    private static readonly OutputDescriptor Sender =
+        KeyExtensions.ParseOutputDescriptor("030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4", Network.RegTest);
+    private static readonly OutputDescriptor Receiver =
+        KeyExtensions.ParseOutputDescriptor("021e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b", Network.RegTest);
+    private static readonly byte[] ValidHashBytes = Convert.FromHexString("4d487dd3753a89bc9fe98401d1196523058251fc");
+
+    // valid[0]: CSV locktime > 16
     [Test]
     public void CanCreateValidContract_CSVLockTimeGt16()
     {
-        var server =
-            KeyExtensions.ParseOutputDescriptor(
-                "03aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88", Network.RegTest);
-        var sender =
-            KeyExtensions.ParseOutputDescriptor("030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4",
-                Network.RegTest);
-        var receiver =
-            KeyExtensions.ParseOutputDescriptor("021e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b",
-                Network.RegTest);
-        var hash = Convert.FromHexString("4d487dd3753a89bc9fe98401d1196523058251fc");
-        var contract =
-            new VHTLCContract(server, sender, receiver, new uint160(hash, false), new LockTime(265), new Sequence(17), new Sequence(144), new Sequence(144));
+        var contract = new VHTLCContract(Server, Sender, Receiver,
+            new uint160(ValidHashBytes, false), new LockTime(265),
+            new Sequence(17), new Sequence(144), new Sequence(144));
         Assert.That(contract.GetArkAddress().ToString(false),
-            Is.EqualTo(
-                "tark1qz4d2t2czchfaml2l3ad3gwde2qxpd0srhc7wkpnvtg99cnxyz8c3pnvvhnhumhwhqthmlxmdryakwx99s6508y8dunj9sty2p5mr7unh5re63"));
+            Is.EqualTo("tark1qz4d2t2czchfaml2l3ad3gwde2qxpd0srhc7wkpnvtg99cnxyz8c3pnvvhnhumhwhqthmlxmdryakwx99s6508y8dunj9sty2p5mr7unh5re63"));
     }
 
+    // valid[1]: CSV locktime <= 16
+    [Test]
+    public void CanCreateValidContract_CSVLockTimeLte16()
+    {
+        var contract = new VHTLCContract(Server, Sender, Receiver,
+            new uint160(ValidHashBytes, false), new LockTime(265),
+            new Sequence(16), new Sequence(144), new Sequence(144));
+        Assert.That(contract.GetArkAddress().ToString(false),
+            Is.EqualTo("tark1qz4d2t2czchfaml2l3ad3gwde2qxpd0srhc7wkpnvtg99cnxyz8c3vyn9exe9gjwcjp5ez0wfhhawvvg0xfenzztjmgp3ddrvkwhw04eztqjn6"));
+    }
+
+    // valid[2]: seconds CSV timelock
     [Test]
     public void CanCreateValidContract_SecondsCSVLockTime()
     {
-        var server =
-            KeyExtensions.ParseOutputDescriptor(
-                "03aad52d58162e9eefeafc7ad8a1cdca8060b5f01df1e7583362d052e266208f88", Network.RegTest);
-        var sender =
-            KeyExtensions.ParseOutputDescriptor("030192e796452d6df9697c280542e1560557bcf79a347d925895043136225c7cb4",
-                Network.RegTest);
-        var receiver =
-            KeyExtensions.ParseOutputDescriptor("021e1bb85455fe3f5aed60d101aa4dbdb9e7714f6226769a97a17a5331dadcd53b",
-                Network.RegTest);
-        var hash = Convert.FromHexString("4d487dd3753a89bc9fe98401d1196523058251fc");
-        var contract =
-            new VHTLCContract(server, sender, receiver, new uint160(hash, false), new LockTime(265), new Sequence(TimeSpan.FromSeconds(512)), new Sequence(TimeSpan.FromSeconds(1024)), new Sequence(TimeSpan.FromSeconds(1536)));
+        var contract = new VHTLCContract(Server, Sender, Receiver,
+            new uint160(ValidHashBytes, false), new LockTime(265),
+            new Sequence(TimeSpan.FromSeconds(512)), new Sequence(TimeSpan.FromSeconds(1024)), new Sequence(TimeSpan.FromSeconds(1536)));
         Assert.That(contract.GetArkAddress().ToString(false),
-            Is.EqualTo(
-                "tark1qz4d2t2czchfaml2l3ad3gwde2qxpd0srhc7wkpnvtg99cnxyz8c3f354ncawvx3enha2ydyrmactc6fyuvqppsqpl5k63hzupmrl7ndmz8pnu"));
+            Is.EqualTo("tark1qz4d2t2czchfaml2l3ad3gwde2qxpd0srhc7wkpnvtg99cnxyz8c3f354ncawvx3enha2ydyrmactc6fyuvqppsqpl5k63hzupmrl7ndmz8pnu"));
+    }
+
+    // invalid[0]: preimage hash too short (19 bytes)
+    [Test]
+    public void ThrowsOnPreimageHashTooShort()
+    {
+        var shortHash = Convert.FromHexString("4d487dd3753a89bc9fe98401d1196523058251"); // 19 bytes
+        Assert.Throws<ArgumentException>(() =>
+            VHTLCContract.Create(Server, Sender, Receiver, shortHash, new LockTime(265),
+                VHtlcDelay.Blocks(17), VHtlcDelay.Blocks(144), VHtlcDelay.Blocks(144)));
+    }
+
+    // invalid[1]: preimage hash too long (28 bytes)
+    [Test]
+    public void ThrowsOnPreimageHashTooLong()
+    {
+        var longHash = Convert.FromHexString("4d487dd3753a89bc9fe98401d1196523058251fc1234567890abcdef"); // 28 bytes
+        Assert.Throws<ArgumentException>(() =>
+            VHTLCContract.Create(Server, Sender, Receiver, longHash, new LockTime(265),
+                VHtlcDelay.Blocks(17), VHtlcDelay.Blocks(144), VHtlcDelay.Blocks(144)));
+    }
+
+    // invalid[2]: zero timelock value (unilateralClaimDelay = 0 blocks)
+    [Test]
+    public void ThrowsOnZeroTimelockValue()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            VHTLCContract.Create(Server, Sender, Receiver, ValidHashBytes, new LockTime(265),
+                VHtlcDelay.Blocks(0), VHtlcDelay.Blocks(144), VHtlcDelay.Blocks(144)));
+    }
+
+    // invalid[3]: refund locktime = 0
+    [Test]
+    public void ThrowsOnZeroRefundLocktime()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            VHTLCContract.Create(Server, Sender, Receiver, ValidHashBytes, new LockTime(0),
+                VHtlcDelay.Blocks(17), VHtlcDelay.Blocks(144), VHtlcDelay.Blocks(144)));
+    }
+
+    // invalid[4]: seconds timelock not a multiple of 512 (value = 1000)
+    [Test]
+    public void ThrowsOnSecondsTimelockNotMultipleOf512()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            VHTLCContract.Create(Server, Sender, Receiver, ValidHashBytes, new LockTime(265),
+                VHtlcDelay.Seconds(1000), VHtlcDelay.Seconds(1024), VHtlcDelay.Seconds(1536)));
+    }
+
+    // invalid[5]: seconds timelock less than 512 (unilateralRefundDelay = 511)
+    [Test]
+    public void ThrowsOnSecondsTimelockLessThan512()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            VHTLCContract.Create(Server, Sender, Receiver, ValidHashBytes, new LockTime(265),
+                VHtlcDelay.Seconds(512), VHtlcDelay.Seconds(511), VHtlcDelay.Seconds(1536)));
     }
 }


### PR DESCRIPTION
Implements all valid and invalid cases from vhtlc.json.

Also fixes a validation gap: ValidTimeLock checked LockPeriod.TotalSeconds % 512 after NBitcoin had already encoded the value (silently rounding 1000s → 512s), making the "not a multiple of 512" error undetectable. The new VHtlcDelay type and VHTLCContract.Create factory validate raw seconds before encoding.