### PR TITLE
feat: intent-authenticated GetVtxoChain pagination

### DIFF
--- a/NArk.Core/Helpers/IntentProofHelper.cs
+++ b/NArk.Core/Helpers/IntentProofHelper.cs
@@ -66,6 +66,36 @@ public static class IntentProofHelper
     }
 
     /// <summary>
+    /// Creates a signed BIP-322 proof for <see cref="Transport.IClientTransport.GetVtxoChainAsync"/>:
+    /// the SDK proves it owns the given VTXO so the Arkade indexer returns the fully-signed virtual-tx
+    /// chain (rather than stripping the signer signatures) and issues an auth token for paginating it.
+    /// Mirrors the <c>{"type":"get-data","expire_at":0}</c> envelope arkd decodes as its
+    /// <c>GetDataMessage</c> for the indexer intent flow.
+    /// </summary>
+    /// <param name="coin">The VTXO coin whose ownership is being proved (becomes input[1] of the proof)</param>
+    /// <param name="signer">Wallet signer for the coin</param>
+    /// <param name="network">Bitcoin network</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Tuple of (base64-encoded PSBT proof, JSON message string)</returns>
+    public static async Task<(string Proof, string Message)> CreateGetVtxoChainOwnershipProofAsync(
+        ArkCoin coin,
+        IArkadeWalletSigner signer,
+        Network network,
+        CancellationToken cancellationToken = default)
+    {
+        var message = JsonSerializer.Serialize(new
+        {
+            type = "get-data",
+            expire_at = 0
+        });
+
+        var psbt = CreateBip322Psbt(message, network, coin);
+        psbt = await SignBip322Proof(psbt, coin, signer, network, cancellationToken);
+
+        return (psbt.ToBase64(), message);
+    }
+
+    /// <summary>
     /// Creates the unsigned BIP-322-style PSBT structure (toSpend → toSign) for a single coin.
     /// Reused by delegation and intent proof flows.
     /// </summary>

--- a/NArk.Core/Hosting/ServiceCollectionExtensions.cs
+++ b/NArk.Core/Hosting/ServiceCollectionExtensions.cs
@@ -128,6 +128,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddArkCoreServices(this IServiceCollection services)
     {
         services.AddSingleton<ICoinService, CoinService>();
+        services.AddSingleton<IVtxoChainProofProvider, VtxoChainProofProvider>();
         services.AddTransient<IContractTransformer, PaymentContractTransformer>();
         services.AddTransient<IContractTransformer, NoteContractTransformer>();
         services.AddTransient<IContractTransformer, HashLockedContractTransformer>();

--- a/NArk.Core/Services/UnilateralExitService.cs
+++ b/NArk.Core/Services/UnilateralExitService.cs
@@ -25,6 +25,7 @@ public class UnilateralExitService(
     IBitcoinBlockchain blockchain,
     IWalletProvider walletProvider,
     VirtualTxService virtualTxService,
+    IVtxoChainProofProvider proofProvider,
     IFeeWallet? feeWallet = null,
     ILogger<UnilateralExitService>? logger = null)
 {
@@ -201,9 +202,10 @@ public class UnilateralExitService(
         CancellationToken cancellationToken = default)
     {
         var serverInfo = await transport.GetServerInfoAsync(cancellationToken);
-
-        // 1. Fetch the chain fresh from arkd — no virtualTxStorage hit.
-        var chainEntries = await transport.GetVtxoChainAsync(vtxoOutpoint, cancellationToken);
+        
+        var proof = await proofProvider.TryCreateProofAsync(vtxoOutpoint, cancellationToken);
+        var chainEntries = await transport.GetVtxoChainAsync(
+            vtxoOutpoint, proof?.Proof, proof?.Message, cancellationToken);
         if (chainEntries.Count == 0)
             throw new InvalidOperationException(
                 $"arkd returned an empty virtual-tx chain for VTXO {vtxoOutpoint}; " +
@@ -353,7 +355,9 @@ public class UnilateralExitService(
             throw new InvalidOperationException(
                 $"arkd didn't return hex for leaf tx {plan.LeafTxid}; cannot build claim.");
 
-        var leafChainType = (await transport.GetVtxoChainAsync(vtxoOutpoint, cancellationToken))
+        var chainProof = await proofProvider.TryCreateProofAsync(vtxoOutpoint, cancellationToken);
+        var leafChainType = (await transport.GetVtxoChainAsync(
+                vtxoOutpoint, chainProof?.Proof, chainProof?.Message, cancellationToken))
             .LastOrDefault(e => e.Type is ChainedTxType.Tree or ChainedTxType.Ark or ChainedTxType.Checkpoint)?.Type
             ?? ChainedTxType.Unspecified;
         var parsedLeafTx = ParseVirtualTx(leafHexList[0], serverInfo.Network, leafChainType);

--- a/NArk.Core/Services/VirtualTxService.cs
+++ b/NArk.Core/Services/VirtualTxService.cs
@@ -13,6 +13,7 @@ namespace NArk.Core.Services;
 public class VirtualTxService(
     IClientTransport transport,
     IVirtualTxStorage storage,
+    IVtxoChainProofProvider proofProvider,
     ILogger<VirtualTxService>? logger = null)
 {
     /// <summary>
@@ -38,7 +39,10 @@ public class VirtualTxService(
         //    stored so consumers can walk back to the anchor without a
         //    second indexer call. Each row carries its ChainedTxType so
         //    UnilateralExitService can skip Commitment when broadcasting.
-        var chainEntries = await transport.GetVtxoChainAsync(vtxoOutpoint, cancellationToken);
+        
+        var proof = await proofProvider.TryCreateProofAsync(vtxoOutpoint, cancellationToken);
+        var chainEntries = await transport.GetVtxoChainAsync(
+            vtxoOutpoint, proof?.Proof, proof?.Message, cancellationToken);
 
         if (chainEntries.Count == 0)
         {

--- a/NArk.Core/Services/VtxoChainProofProvider.cs
+++ b/NArk.Core/Services/VtxoChainProofProvider.cs
@@ -1,0 +1,106 @@
+using Microsoft.Extensions.Logging;
+using NArk.Abstractions.Contracts;
+using NArk.Abstractions.VTXOs;
+using NArk.Abstractions.Wallets;
+using NArk.Core.Helpers;
+using NArk.Core.Transport;
+using NBitcoin;
+
+namespace NArk.Core.Services;
+
+/// <summary>
+/// Builds the BIP-322-style ownership proof that authenticates
+/// <see cref="IClientTransport.GetVtxoChainAsync"/> against the Arkade indexer. Given a VTXO the
+/// wallet owns, it resolves the backing contract, coin and signer and produces the
+/// <c>{"type":"get-data"}</c> intent proof arkd expects.
+/// </summary>
+public interface IVtxoChainProofProvider
+{
+    /// <summary>
+    /// Attempts to build an ownership proof for the VTXO at <paramref name="vtxoOutpoint"/>.
+    /// Returns <c>null</c> when the VTXO is unknown to this wallet, its contract cannot be
+    /// resolved, or no signer is registered — callers then fall back to the anonymous
+    /// (public-exposure) indexer lookup.
+    /// </summary>
+    Task<(string Proof, string Message)?> TryCreateProofAsync(
+        OutPoint vtxoOutpoint, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Attempts to build an ownership proof for an already-materialised <paramref name="vtxo"/>,
+    /// avoiding a storage round-trip. Returns <c>null</c> under the same conditions as
+    /// <see cref="TryCreateProofAsync(OutPoint, CancellationToken)"/>.
+    /// </summary>
+    Task<(string Proof, string Message)?> TryCreateProofAsync(
+        ArkVtxo vtxo, CancellationToken cancellationToken = default);
+}
+
+/// <inheritdoc />
+public class VtxoChainProofProvider(
+    IVtxoStorage vtxoStorage,
+    IContractStorage contractStorage,
+    ICoinService coinService,
+    IWalletProvider walletProvider,
+    IClientTransport transport,
+    ILogger<VtxoChainProofProvider>? logger = null) : IVtxoChainProofProvider
+{
+    /// <inheritdoc />
+    public async Task<(string Proof, string Message)?> TryCreateProofAsync(
+        OutPoint vtxoOutpoint, CancellationToken cancellationToken = default)
+    {
+        var vtxo = (await vtxoStorage.GetVtxos(
+                outpoints: [vtxoOutpoint], includeSpent: true, cancellationToken: cancellationToken))
+            .FirstOrDefault();
+
+        if (vtxo is null)
+        {
+            logger?.LogDebug("No tracked VTXO for {Outpoint}; falling back to anonymous chain lookup", vtxoOutpoint);
+            return null;
+        }
+
+        return await TryCreateProofAsync(vtxo, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<(string Proof, string Message)?> TryCreateProofAsync(
+        ArkVtxo vtxo, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var contract = (await contractStorage.GetContracts(
+                    scripts: [vtxo.Script], cancellationToken: cancellationToken))
+                .FirstOrDefault();
+
+            if (contract is null)
+            {
+                logger?.LogDebug(
+                    "No contract for VTXO {Outpoint} script; falling back to anonymous chain lookup",
+                    vtxo.OutPoint);
+                return null;
+            }
+
+            var signer = await walletProvider.GetSignerAsync(contract.WalletIdentifier, cancellationToken);
+            if (signer is null)
+            {
+                logger?.LogDebug(
+                    "No signer for wallet {WalletId}; falling back to anonymous chain lookup",
+                    contract.WalletIdentifier);
+                return null;
+            }
+
+            var coin = await coinService.GetCoin(contract, vtxo, cancellationToken);
+            var network = (await transport.GetServerInfoAsync(cancellationToken)).Network;
+
+            return await IntentProofHelper.CreateGetVtxoChainOwnershipProofAsync(
+                coin, signer, network, cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Proof construction is best-effort: any resolution failure degrades to the
+            // anonymous lookup rather than blocking chain retrieval outright.
+            logger?.LogDebug(ex,
+                "Failed to build chain ownership proof for VTXO {Outpoint}; falling back to anonymous lookup",
+                vtxo.OutPoint);
+            return null;
+        }
+    }
+}

--- a/NArk.Core/Transport/CachingClientTransport.cs
+++ b/NArk.Core/Transport/CachingClientTransport.cs
@@ -213,8 +213,9 @@ public class CachingClientTransport : IClientTransport, IServerInfoCacheInvalida
         CancellationToken cancellationToken = default)
         => Guard(() => _inner.GetPendingTxAsync(proof, message, cancellationToken));
 
-    public Task<IReadOnlyList<VtxoChainEntry>> GetVtxoChainAsync(OutPoint vtxoOutpoint, CancellationToken cancellationToken = default)
-        => Guard(() => _inner.GetVtxoChainAsync(vtxoOutpoint, cancellationToken));
+    public Task<IReadOnlyList<VtxoChainEntry>> GetVtxoChainAsync(OutPoint vtxoOutpoint,
+        string? intentProof = null, string? intentMessage = null, CancellationToken cancellationToken = default)
+        => Guard(() => _inner.GetVtxoChainAsync(vtxoOutpoint, intentProof, intentMessage, cancellationToken));
 
     public Task<IReadOnlyList<string>> GetVirtualTxsAsync(IReadOnlyList<string> txids, CancellationToken cancellationToken = default)
         => Guard(() => _inner.GetVirtualTxsAsync(txids, cancellationToken));

--- a/NArk.Core/Transport/GrpcClient/GrpcClientTransport.Exit.cs
+++ b/NArk.Core/Transport/GrpcClient/GrpcClientTransport.Exit.cs
@@ -8,36 +8,77 @@ namespace NArk.Transport.GrpcClient;
 public partial class GrpcClientTransport
 {
     public async Task<IReadOnlyList<VtxoChainEntry>> GetVtxoChainAsync(
-        OutPoint vtxoOutpoint, CancellationToken cancellationToken = default)
+        OutPoint vtxoOutpoint, string? intentProof = null, string? intentMessage = null,
+        CancellationToken cancellationToken = default)
     {
         var result = new List<VtxoChainEntry>();
-        var request = new GetVtxoChainRequest
+
+        if (intentProof is not null && intentMessage is not null)
+        {
+            var request = new GetVtxoChainRequest
+            {
+                Intent = new IndexerIntent { Proof = intentProof, Message = intentMessage }
+            };
+
+            var authToken = string.Empty;
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var response = await _indexerServiceClient.GetVtxoChainAsync(request, cancellationToken: cancellationToken);
+
+                foreach (var entry in response.Chain)
+                {
+                    result.Add(ToEntry(entry));
+                }
+
+                // the first response carries the auth token reused for every later page.
+                if (!string.IsNullOrEmpty(response.AuthToken))
+                {
+                    authToken = response.AuthToken;
+                }
+                // if there's no next page token, this is the last page 
+                if (string.IsNullOrEmpty(response.NextPageToken))
+                {
+                    break;
+                }
+
+                request = new GetVtxoChainRequest
+                {
+                    Outpoint = new IndexerOutpoint { Txid = vtxoOutpoint.Hash.ToString(), Vout = vtxoOutpoint.N },
+                    Token = authToken,
+                    PageToken = response.NextPageToken
+                };
+            }
+
+            return result;
+        }
+
+        // Legacy anonymous flow (public tx exposure): outpoint + page-number pagination.
+        var legacyRequest = new GetVtxoChainRequest
         {
             Outpoint = new IndexerOutpoint { Txid = vtxoOutpoint.Hash.ToString(), Vout = vtxoOutpoint.N },
             Page = new IndexerPageRequest { Index = 0, Size = 1000 }
         };
 
-        GetVtxoChainResponse? response = null;
-        while (response is null || response.Page.Next != response.Page.Total)
+        GetVtxoChainResponse? legacyResponse = null;
+        while (legacyResponse is null || legacyResponse.Page.Next != legacyResponse.Page.Total)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            response = await _indexerServiceClient.GetVtxoChainAsync(request, cancellationToken: cancellationToken);
+            legacyResponse = await _indexerServiceClient.GetVtxoChainAsync(legacyRequest, cancellationToken: cancellationToken);
 
-            foreach (var entry in response.Chain)
-            {
-                result.Add(new VtxoChainEntry(
-                    entry.Txid,
-                    DateTimeOffset.FromUnixTimeSeconds(entry.ExpiresAt),
-                    MapChainedTxType(entry.Type),
-                    entry.Spends.ToList()
-                ));
-            }
+            result.AddRange(legacyResponse.Chain.Select(ToEntry));
 
-            request.Page.Index = response.Page.Next;
+            legacyRequest.Page.Index = legacyResponse.Page.Next;
         }
 
         return result;
     }
+
+    private static VtxoChainEntry ToEntry(IndexerChain entry) => new(
+        entry.Txid,
+        DateTimeOffset.FromUnixTimeSeconds(entry.ExpiresAt),
+        MapChainedTxType(entry.Type),
+        entry.Spends.ToList());
 
     public async Task<IReadOnlyList<string>> GetVirtualTxsAsync(
         IReadOnlyList<string> txids, CancellationToken cancellationToken = default)

--- a/NArk.Core/Transport/GrpcClient/Protos/ark/v1/indexer.proto
+++ b/NArk.Core/Transport/GrpcClient/Protos/ark/v1/indexer.proto
@@ -204,12 +204,14 @@ message GetVtxosRequest {
   repeated string scripts = 1;
   // Or specify a list of vtxo outpoints. The 2 filters are mutually exclusive.
   repeated string outpoints = 2;
+  // The spendable_only, spent_only, recoverable_only, pending_only and
+  // renewable_only filters are mutually exclusive, and are applied only when
+  // the scripts filter is used. They are ignored when querying by outpoints.
   // Retrieve only spendable vtxos
   bool spendable_only = 3;
   // Retrieve only spent vtxos.
   bool spent_only = 4;
   // Retrieve only recoverable vtxos (notes, subdust or swept vtxos).
-  // The 3 filters are mutually exclusive,
   bool recoverable_only = 5;
   IndexerPageRequest page = 6;
   // Include only spent vtxos that are not finalized.
@@ -219,7 +221,9 @@ message GetVtxosRequest {
   int64 after = 8;
   // Include only vtxos with last update before the given unix time in milliseconds,
   // greater value than the after when specified. A value of 0 means no upper bound.
-  int64 before = 9; 
+  int64 before = 9;
+  // Retrieve the union of the spendable and recoverable vtxos.
+  bool renewable_only = 10;
 }
 message GetVtxosResponse {
   repeated IndexerVtxo vtxos = 1;
@@ -327,6 +331,7 @@ message IndexerVtxo {
   string settled_by = 12;
   string ark_txid = 13;
   repeated IndexerAsset assets = 14;
+  uint32 depth = 15;
 }
 
 message IndexerAsset {

--- a/NArk.Core/Transport/GrpcClient/Protos/ark/v1/types.proto
+++ b/NArk.Core/Transport/GrpcClient/Protos/ark/v1/types.proto
@@ -29,6 +29,7 @@ message Vtxo {
   string settled_by = 12;
   string ark_txid = 13;
   repeated Asset assets = 14;
+  uint32 depth = 15;
 }
 
 message Asset {

--- a/NArk.Core/Transport/IClientTransport.cs
+++ b/NArk.Core/Transport/IClientTransport.cs
@@ -92,8 +92,24 @@ public interface IClientTransport
 
     /// <summary>
     /// Returns the chain of virtual txs from commitment tx to the given VTXO leaf.
+    /// <para>
+    /// When <paramref name="intentProof"/> and <paramref name="intentMessage"/> are supplied
+    /// (a BIP-322-style ownership proof built by
+    /// <see cref="Helpers.IntentProofHelper.CreateGetVtxoChainOwnershipProofAsync"/>), the call
+    /// authenticates against the Arkade indexer: on servers running with withheld/private tx
+    /// exposure this is what makes the indexer return the chain (and, for withheld, the
+    /// fully-signed virtual txs) instead of stripping it. The proof is presented on the first
+    /// page; the server issues an auth token that transparently drives cursor pagination for the
+    /// remaining pages.
+    /// </para>
+    /// <para>
+    /// When the proof is omitted the call uses the legacy anonymous outpoint lookup, which only
+    /// returns data on servers configured with public tx exposure.
+    /// </para>
     /// </summary>
-    Task<IReadOnlyList<VtxoChainEntry>> GetVtxoChainAsync(OutPoint vtxoOutpoint, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<VtxoChainEntry>> GetVtxoChainAsync(OutPoint vtxoOutpoint,
+        string? intentProof = null, string? intentMessage = null,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Returns raw tx hex for the given virtual transaction IDs.

--- a/NArk.Core/Transport/RestClient/RestClientTransport.Exit.cs
+++ b/NArk.Core/Transport/RestClient/RestClientTransport.Exit.cs
@@ -10,38 +10,74 @@ namespace NArk.Transport.RestClient;
 public partial class RestClientTransport
 {
     public async Task<IReadOnlyList<VtxoChainEntry>> GetVtxoChainAsync(
-        OutPoint vtxoOutpoint, CancellationToken cancellationToken = default)
+        OutPoint vtxoOutpoint, string? intentProof = null, string? intentMessage = null,
+        CancellationToken cancellationToken = default)
     {
         var result = new List<VtxoChainEntry>();
+        var basePath = $"/v1/indexer/vtxo/{vtxoOutpoint.Hash}/{vtxoOutpoint.N}/chain";
+
+        if (intentProof is not null && intentMessage is not null)
+        {
+            var url = $"{basePath}?intent.proof={Uri.EscapeDataString(intentProof)}"
+                    + $"&intent.message={Uri.EscapeDataString(intentMessage)}";
+            var authToken = string.Empty;
+
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var response = await _http.GetFromJsonAsync<VtxoChainResponse>(url, JsonOpts, cancellationToken);
+                if (response is null) break;
+
+                AppendEntries(result, response.Chain);
+
+                if (!string.IsNullOrEmpty(response.AuthToken))
+                    authToken = response.AuthToken;
+
+                if (string.IsNullOrEmpty(response.NextPageToken))
+                    break;
+
+                url = $"{basePath}?token={Uri.EscapeDataString(authToken)}"
+                    + $"&page_token={Uri.EscapeDataString(response.NextPageToken)}";
+            }
+
+            return result;
+        }
+
+        // Legacy anonymous flow (public tx exposure): outpoint + page-number pagination.
         var pageIndex = 0;
         int? pageTotal = null;
 
         while (pageTotal is null || pageIndex < pageTotal)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var url = $"/v1/indexer/vtxo/{vtxoOutpoint.Hash}/{vtxoOutpoint.N}/chain?page.index={pageIndex}&page.size=1000";
+            var url = $"{basePath}?page.index={pageIndex}&page.size=1000";
             var response = await _http.GetFromJsonAsync<VtxoChainResponse>(url, JsonOpts, cancellationToken);
             if (response is null) break;
 
-            foreach (var entry in response.Chain ?? [])
-            {
-                var expiresAt = long.TryParse(entry.ExpiresAt, out var epoch)
-                    ? DateTimeOffset.FromUnixTimeSeconds(epoch)
-                    : DateTimeOffset.MaxValue;
-
-                result.Add(new VtxoChainEntry(
-                    entry.Txid,
-                    expiresAt,
-                    Enum.TryParse<ChainedTxType>(entry.Type, true, out var t) ? t : ChainedTxType.Unspecified,
-                    entry.Spends ?? []
-                ));
-            }
+            AppendEntries(result, response.Chain);
 
             pageTotal = response.Page?.Total ?? 0;
             pageIndex = response.Page?.Next ?? pageTotal.Value;
         }
 
         return result;
+    }
+
+    private static void AppendEntries(List<VtxoChainEntry> result, List<VtxoChainEntryDto>? chain)
+    {
+        foreach (var entry in chain ?? [])
+        {
+            var expiresAt = long.TryParse(entry.ExpiresAt, out var epoch)
+                ? DateTimeOffset.FromUnixTimeSeconds(epoch)
+                : DateTimeOffset.MaxValue;
+
+            result.Add(new VtxoChainEntry(
+                entry.Txid,
+                expiresAt,
+                Enum.TryParse<ChainedTxType>(entry.Type, true, out var t) ? t : ChainedTxType.Unspecified,
+                entry.Spends ?? []
+            ));
+        }
     }
 
     public async Task<IReadOnlyList<string>> GetVirtualTxsAsync(
@@ -104,7 +140,9 @@ public partial class RestClientTransport
     // JSON DTOs for deserialization
     private record VtxoChainResponse(
         [property: JsonPropertyName("chain")] List<VtxoChainEntryDto>? Chain,
-        [property: JsonPropertyName("page")] PageDto? Page);
+        [property: JsonPropertyName("page")] PageDto? Page,
+        [property: JsonPropertyName("auth_token")] string? AuthToken = null,
+        [property: JsonPropertyName("next_page_token")] string? NextPageToken = null);
 
     private record VtxoChainEntryDto(
         [property: JsonPropertyName("txid")] string Txid,

--- a/NArk.Tests.End2End/BatchSessionTests.cs
+++ b/NArk.Tests.End2End/BatchSessionTests.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Options;
 using NArk.Abstractions;
 using NArk.Abstractions.Batches;
-using NArk.Abstractions.Contracts;
 using NArk.Abstractions.Wallets;
 using NArk.Abstractions.Batches.ServerEvents;
 using NArk.Abstractions.Intents;
@@ -313,8 +312,8 @@ public class BatchSessionTests
             => inner.GetIntentsByProofAsync(proof, message, cancellationToken);
         public Task<PendingArkTransaction[]> GetPendingTxAsync(string proof, string message, CancellationToken cancellationToken = default)
             => inner.GetPendingTxAsync(proof, message, cancellationToken);
-        public Task<IReadOnlyList<VtxoChainEntry>> GetVtxoChainAsync(OutPoint vtxoOutpoint, CancellationToken cancellationToken = default)
-            => inner.GetVtxoChainAsync(vtxoOutpoint, cancellationToken);
+        public Task<IReadOnlyList<VtxoChainEntry>> GetVtxoChainAsync(OutPoint vtxoOutpoint, string? intentProof = null, string? intentMessage = null, CancellationToken cancellationToken = default)
+            => inner.GetVtxoChainAsync(vtxoOutpoint, intentProof, intentMessage, cancellationToken);
         public Task<IReadOnlyList<string>> GetVirtualTxsAsync(IReadOnlyList<string> txids, CancellationToken cancellationToken = default)
             => inner.GetVirtualTxsAsync(txids, cancellationToken);
         public Task<IReadOnlyList<VtxoTreeNode>> GetVtxoTreeAsync(OutPoint batchOutpoint, CancellationToken cancellationToken = default)

--- a/NArk.Tests.End2End/PendingArkTransactionRecoveryTests.cs
+++ b/NArk.Tests.End2End/PendingArkTransactionRecoveryTests.cs
@@ -200,8 +200,8 @@ public class PendingArkTransactionRecoveryTests
             CancellationToken cancellationToken = default)
             => _inner.GetPendingTxAsync(proof, message, cancellationToken);
 
-        public Task<IReadOnlyList<VtxoChainEntry>> GetVtxoChainAsync(OutPoint vtxoOutpoint, CancellationToken cancellationToken = default)
-            => _inner.GetVtxoChainAsync(vtxoOutpoint, cancellationToken);
+        public Task<IReadOnlyList<VtxoChainEntry>> GetVtxoChainAsync(OutPoint vtxoOutpoint, string? intentProof = null, string? intentMessage = null, CancellationToken cancellationToken = default)
+            => _inner.GetVtxoChainAsync(vtxoOutpoint, intentProof, intentMessage, cancellationToken);
 
         public Task<IReadOnlyList<string>> GetVirtualTxsAsync(IReadOnlyList<string> txids, CancellationToken cancellationToken = default)
             => _inner.GetVirtualTxsAsync(txids, cancellationToken);

--- a/NArk.Tests.End2End/UnilateralExitTests.cs
+++ b/NArk.Tests.End2End/UnilateralExitTests.cs
@@ -483,9 +483,12 @@ public class UnilateralExitTests
             DefaultMode = VirtualTxMode.Full,
             MinExitWorthAmount = 1000,
         });
+        var chainProofProvider = new VtxoChainProofProvider(
+            vtxoStorage, contractStorage, coinService, walletProvider, clientTransport,
+            loggerFactory.CreateLogger<VtxoChainProofProvider>());
         var autoFetchService = new VtxoChainAutoFetchService(
             vtxoStorage,
-            new VirtualTxService(clientTransport, virtualTxStorage,
+            new VirtualTxService(clientTransport, virtualTxStorage, chainProofProvider,
                 loggerFactory.CreateLogger<VirtualTxService>()),
             virtualTxOptions,
             loggerFactory.CreateLogger<VtxoChainAutoFetchService>());
@@ -506,7 +509,7 @@ public class UnilateralExitTests
         var broadcaster = new NBXplorerBlockchain(
             explorerClient, loggerFactory.CreateLogger<NBXplorerBlockchain>());
         var virtualTxService = new VirtualTxService(
-            clientTransport, virtualTxStorage,
+            clientTransport, virtualTxStorage, chainProofProvider,
             loggerFactory.CreateLogger<VirtualTxService>());
 
         // Tree txs are v3 (TRUC). Bitcoin Core won't accept a v3 child of a
@@ -527,6 +530,7 @@ public class UnilateralExitTests
             broadcaster,
             walletProvider,
             virtualTxService,
+            chainProofProvider,
             feeWallet: feeWallet,
             logger: loggerFactory.CreateLogger<UnilateralExitService>());
 

--- a/NArk.Tests/VirtualTxServiceTests.cs
+++ b/NArk.Tests/VirtualTxServiceTests.cs
@@ -12,6 +12,7 @@ public class VirtualTxServiceTests
 {
     private IClientTransport _transport = null!;
     private IVirtualTxStorage _storage = null!;
+    private IVtxoChainProofProvider _proofProvider = null!;
     private VirtualTxService _service = null!;
     private readonly OutPoint _testOutpoint = new(uint256.Parse("abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234"), 0);
 
@@ -20,7 +21,11 @@ public class VirtualTxServiceTests
     {
         _transport = Substitute.For<IClientTransport>();
         _storage = Substitute.For<IVirtualTxStorage>();
-        _service = new VirtualTxService(_transport, _storage);
+        _proofProvider = Substitute.For<IVtxoChainProofProvider>();
+        // Default: no proof available → service falls back to anonymous lookup (null proof/message).
+        _proofProvider.TryCreateProofAsync(Arg.Any<OutPoint>(), Arg.Any<CancellationToken>())
+            .Returns((ValueTuple<string, string>?)null);
+        _service = new VirtualTxService(_transport, _storage, _proofProvider);
     }
 
     [Test]
@@ -35,7 +40,7 @@ public class VirtualTxServiceTests
             new("treetxid1", DateTimeOffset.UtcNow.AddDays(30), ChainedTxType.Tree, []),
             new("treetxid2", DateTimeOffset.UtcNow.AddDays(30), ChainedTxType.Tree, [])
         };
-        _transport.GetVtxoChainAsync(_testOutpoint, Arg.Any<CancellationToken>())
+        _transport.GetVtxoChainAsync(_testOutpoint, Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(chainEntries);
 
         // GetVirtualTxs is only called for non-Commitment txs
@@ -80,7 +85,7 @@ public class VirtualTxServiceTests
         {
             new("treetxid1", DateTimeOffset.UtcNow.AddDays(30), ChainedTxType.Tree, [])
         };
-        _transport.GetVtxoChainAsync(_testOutpoint, Arg.Any<CancellationToken>())
+        _transport.GetVtxoChainAsync(_testOutpoint, Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(chainEntries);
 
         // Act
@@ -107,7 +112,7 @@ public class VirtualTxServiceTests
 
         // Assert — should not fetch anything
         await _transport.DidNotReceive().GetVtxoChainAsync(
-            Arg.Any<OutPoint>(), Arg.Any<CancellationToken>());
+            Arg.Any<OutPoint>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 
     [Test]
@@ -121,7 +126,7 @@ public class VirtualTxServiceTests
             new("commitmenttx", DateTimeOffset.UtcNow, ChainedTxType.Commitment, []),
             new("treetx", DateTimeOffset.UtcNow, ChainedTxType.Tree, [])
         };
-        _transport.GetVtxoChainAsync(_testOutpoint, Arg.Any<CancellationToken>())
+        _transport.GetVtxoChainAsync(_testOutpoint, Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(chainEntries);
         _transport.GetVirtualTxsAsync(
             Arg.Is<IReadOnlyList<string>>(l => l.Count == 1 && l[0] == "treetx"),
@@ -183,7 +188,7 @@ public class VirtualTxServiceTests
         {
             new("tx1", DateTimeOffset.UtcNow, ChainedTxType.Tree, [])
         };
-        _transport.GetVtxoChainAsync(_testOutpoint, Arg.Any<CancellationToken>())
+        _transport.GetVtxoChainAsync(_testOutpoint, Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(chainEntries);
         _transport.GetVirtualTxsAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
             .Returns(new List<string> { "hex1" });


### PR DESCRIPTION
Fetch VTXO chains with a BIP-322 ownership proof so withheld/private
indexers serve them. Cursor pagination via auth token; anonymous
fallback for public servers. gRPC + REST.