### PR TITLE
fix(core): propagate CLTV locktime to the ark tx, not just the checkpoint

### DIFF
--- a/NArk.Core/Helpers/TransactionHelpers.cs
+++ b/NArk.Core/Helpers/TransactionHelpers.cs
@@ -114,7 +114,41 @@ public static class TransactionHelpers
 
             var arkTx = CreateArkTxBuilder(serverInfo.Network);
             // arkTx.Send(p2a, Money.Zero);
-            arkTx.AddCoins(checkpointCoins);
+            // The checkpoint's collaborative leaf preserves the original VTXO leaf's CLTV, so arkd's
+            // offchain.buildArkTx re-derives the ark tx's locktime + a non-final input sequence
+            // (cltvSequence = 0xFFFFFFFE) from that closure when rebuilding it. We must match exactly or
+            // arkd rejects the spend with ARK_TX_MISMATCH (the checkpoint txids already agree; only the
+            // ark tx diverges). A non-CLTV path (e.g. a hashlock claim) leaves LockTime null → locktime
+            // 0 and final sequences, so this is a no-op there.
+            var arkLockTime = LockTime.Zero;
+            foreach (var cc in checkpointCoins)
+            {
+                if (cc.LockTime is not { } lt || lt == LockTime.Zero) continue;
+                // Match arkd/ts-sdk buildVirtualTx: absolute locktimes across inputs must share a unit
+                // (all block-height or all timestamp) — nLockTime is a single field that can't encode
+                // both, so a mixed tx is unrepresentable. Fail loudly rather than emit a tx arkd rejects.
+                if (arkLockTime != LockTime.Zero && arkLockTime.IsTimeLock != lt.IsTimeLock)
+                    throw new InvalidOperationException(
+                        "cannot mix seconds and blocks absolute locktimes across inputs of one ark tx");
+                if (lt.Value > arkLockTime.Value)
+                    arkLockTime = lt;
+            }
+            if (arkLockTime != LockTime.Zero)
+            {
+                arkTx.SetLockTime(arkLockTime);
+                foreach (var cc in checkpointCoins)
+                {
+                    var hasLocktime = cc.LockTime is not null && cc.LockTime != LockTime.Zero;
+                    arkTx.AddCoin(cc, new CoinOptions
+                    {
+                        Sequence = cc.Sequence ?? (hasLocktime ? new Sequence(0xFFFFFFFE) : new Sequence(0xFFFFFFFF)),
+                    });
+                }
+            }
+            else
+            {
+                arkTx.AddCoins(checkpointCoins);
+            }
 
             // Track OP_RETURN outputs to enforce the limit
             // Use server-configured limit, falling back to the const default


### PR DESCRIPTION
An Ark checkpoint's collaborative leaf preserves the original VTXO leaf it spends — including its CLTV. So arkd's offchain.buildArkTx re-derives the ark tx's nLockTime (max absolute locktime across inputs) and a non-final input sequence (cltvSequence = 0xFFFFFFFE) from that closure when it rebuilds the tx to verify the client's txid.

ConstructArkTransaction set the locktime on the checkpoint tx but built the ark tx with a plain AddCoins (locktime 0, final sequences), so for a CLTV spend the ark tx txid diverged from arkd's rebuild → ARK_TX_MISMATCH (the checkpoint txids already agreed). A hashlock/non-CLTV path was unaffected, which is why it only surfaced on the covenant refund path.

Mirror arkd/ts-sdk buildVirtualTx: when a checkpoint coin carries a locktime, set the ark tx locktime to the max and its inputs to 0xFFFFFFFE, and reject mixed seconds/blocks locktimes. No-op for every non-CLTV spend (the AddCoins path is unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transactions now apply checkpoint locktimes automatically, supporting both time-based and block-based conditions.
  * Checkpoint inputs use appropriate confirmation behavior based on their locktime requirements.

* **Bug Fixes**
  * Prevented transactions from combining incompatible locktime types.
  * Preserved existing behavior when no checkpoint locktime is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->