### PR TITLE
fix(swaps): model restore claimDetails.transaction as an object

### DIFF
--- a/NArk.Swaps/Boltz/Models/Restore/RestoreResponse.cs
+++ b/NArk.Swaps/Boltz/Models/Restore/RestoreResponse.cs
@@ -44,16 +44,34 @@ public record SwapDetails
     public long? Amount { get; init; }
 
     /// <summary>
-    /// Transaction hex (if available).
+    /// Lockup transaction reference (if available).
     /// </summary>
     [JsonPropertyName("transaction")]
-    public string? Transaction { get; init; }
+    public RestoreTransaction? Transaction { get; init; }
 
     /// <summary>
     /// Blinding key for Liquid swaps (optional).
     /// </summary>
     [JsonPropertyName("blindingKey")]
     public string? BlindingKey { get; init; }
+}
+
+/// <summary>
+/// Reference to the lockup transaction of a restorable swap.
+/// </summary>
+public record RestoreTransaction
+{
+    /// <summary>
+    /// ID of the lockup transaction.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Index of the lockup output in the transaction.
+    /// </summary>
+    [JsonPropertyName("vout")]
+    public required long Vout { get; init; }
 }
 
 /// <summary>


### PR DESCRIPTION
The Boltz /v2/swap/restore endpoint serializes the lockup transaction
reference differenently, see https://api.boltz.exchange/swagger#/Swap/post_swap_restore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restore response handling by representing lockup transactions with structured transaction details.
  * Restore data now includes the transaction ID and lockup output index for more reliable processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->