### PR TITLE
fix(exit): map virtual-tx hexes to the txid

### DIFF
--- a/NArk.Core/Services/VirtualTxService.cs
+++ b/NArk.Core/Services/VirtualTxService.cs
@@ -94,23 +94,20 @@ public class VirtualTxService(
             if (txidsToFetch.Count > 0)
             {
                 var hexList = await transport.GetVirtualTxsAsync(txidsToFetch, cancellationToken);
-                if (hexList.Count == txidsToFetch.Count)
+                // arkd's GetVirtualTxs (GetTxsWithTxids → SQL `WHERE id IN (...)`) does NOT return
+                // hexes in request order, so pairing them positionally (Zip) crosses txid↔hex. Key
+                // each hex by the txid parsed from the hex itself — order-proof.
+                var network = (await transport.GetServerInfoAsync(cancellationToken)).Network;
+                var hexByTxid = MapHexByTxid(hexList, network, vtxoOutpoint);
+                for (var i = 0; i < virtualTxs.Count; i++)
                 {
-                    var hexByTxid = txidsToFetch
-                        .Zip(hexList, (id, hex) => (id, hex))
-                        .ToDictionary(t => t.id, t => t.hex);
-                    for (var i = 0; i < virtualTxs.Count; i++)
-                    {
-                        if (hexByTxid.TryGetValue(virtualTxs[i].Txid, out var hex))
-                            virtualTxs[i] = virtualTxs[i] with { Hex = hex };
-                    }
+                    if (hexByTxid.TryGetValue(virtualTxs[i].Txid, out var hex))
+                        virtualTxs[i] = virtualTxs[i] with { Hex = hex };
                 }
-                else
-                {
+                if (hexByTxid.Count != txidsToFetch.Count)
                     logger?.LogWarning(
                         "Virtual tx hex count mismatch for VTXO {Outpoint}: expected {Expected}, got {Actual}",
-                        vtxoOutpoint, txidsToFetch.Count, hexList.Count);
-                }
+                        vtxoOutpoint, txidsToFetch.Count, hexByTxid.Count);
             }
         }
 
@@ -174,6 +171,35 @@ public class VirtualTxService(
     /// Ensure all virtual txs in a VTXO's branch have hex populated.
     /// Upgrades Lite → Full by fetching missing hex on demand.
     /// </summary>
+    /// <summary>
+    /// Maps virtual-tx hexes to the txid parsed from each hex (its PSBT global tx). arkd's
+    /// GetVirtualTxs (GetTxsWithTxids → SQL <c>WHERE id IN (...)</c>) returns hexes in DB order,
+    /// not request order, so callers must key by the parsed txid rather than trusting positional
+    /// pairing — otherwise a tree node's txid gets attached to a sibling's hex and the exit
+    /// broadcasts the wrong tx (bad-txns-inputs-missingorspent). ts-sdk sidesteps this by fetching
+    /// one txid at a time; we fetch the branch in one batch, so we self-key by the returned tx.
+    /// Unparseable hexes are skipped with a warning rather than aborting the whole batch.
+    /// </summary>
+    private Dictionary<string, string> MapHexByTxid(
+        IReadOnlyList<string> hexes, Network network, OutPoint vtxoOutpoint)
+    {
+        var map = new Dictionary<string, string>();
+        foreach (var hex in hexes)
+        {
+            try
+            {
+                var txid = PSBT.Parse(hex, network).GetGlobalTransaction().GetHash().ToString();
+                map[txid] = hex;
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex,
+                    "Skipping unparseable virtual tx hex while populating VTXO {Outpoint}", vtxoOutpoint);
+            }
+        }
+        return map;
+    }
+
     public async Task EnsureHexPopulatedAsync(
         OutPoint vtxoOutpoint,
         CancellationToken cancellationToken = default)
@@ -204,19 +230,22 @@ public class VirtualTxService(
         var txids = missingHex.Select(tx => tx.Txid).ToList();
         var hexList = await transport.GetVirtualTxsAsync(txids, cancellationToken);
 
-        if (hexList.Count != txids.Count)
+        // Key by the txid parsed from each hex — arkd doesn't preserve request order (see
+        // FetchAndStoreBranchAsync), so index-pairing would attach the wrong hex to a txid.
+        var network = (await transport.GetServerInfoAsync(cancellationToken)).Network;
+        var hexByTxid = MapHexByTxid(hexList, network, vtxoOutpoint);
+
+        var updates = new List<VirtualTx>();
+        foreach (var mh in missingHex)
         {
-            logger?.LogWarning(
-                "Hex count mismatch when populating VTXO {Outpoint}: expected {Expected}, got {Actual}",
-                vtxoOutpoint, txids.Count, hexList.Count);
+            if (hexByTxid.TryGetValue(mh.Txid, out var hex))
+                updates.Add(new VirtualTx(mh.Txid, hex, mh.ExpiresAt));
         }
 
-        // Update existing records with hex
-        var updates = new List<VirtualTx>();
-        for (var i = 0; i < Math.Min(txids.Count, hexList.Count); i++)
-        {
-            updates.Add(new VirtualTx(txids[i], hexList[i], missingHex[i].ExpiresAt));
-        }
+        if (updates.Count != missingHex.Count)
+            logger?.LogWarning(
+                "Populated hex for {Actual}/{Expected} virtual txs for VTXO {Outpoint} — some txids missing from the indexer response",
+                updates.Count, missingHex.Count, vtxoOutpoint);
 
         await storage.UpsertVirtualTxsAsync(updates, cancellationToken);
 

--- a/NArk.Tests/VirtualTxServiceTests.cs
+++ b/NArk.Tests/VirtualTxServiceTests.cs
@@ -1,8 +1,12 @@
+using NArk.Abstractions.Extensions;
 using NArk.Abstractions.VirtualTxs;
+using NArk.Core;
 using NArk.Core.Services;
 using NArk.Core.Transport;
 using NArk.Core.Transport.Models;
 using NBitcoin;
+using NBitcoin.Scripting;
+using NBitcoin.Secp256k1;
 using NSubstitute;
 
 namespace NArk.Tests;
@@ -25,53 +29,59 @@ public class VirtualTxServiceTests
         // Default: no proof available → service falls back to anonymous lookup (null proof/message).
         _proofProvider.TryCreateProofAsync(Arg.Any<OutPoint>(), Arg.Any<CancellationToken>())
             .Returns((ValueTuple<string, string>?)null);
+        // The service resolves a network (to parse each returned hex back to its txid).
+        _transport.GetServerInfoAsync(Arg.Any<CancellationToken>()).Returns(CreateServerInfo());
         _service = new VirtualTxService(_transport, _storage, _proofProvider);
     }
 
     [Test]
-    public async Task FetchAndStoreBranch_FullMode_StoresWholeChainWithTypes()
+    public async Task FetchAndStoreBranch_FullMode_PairsHexByParsedTxid_RegardlessOfResponseOrder()
     {
         // Arrange
         _storage.HasBranchAsync(_testOutpoint, Arg.Any<CancellationToken>()).Returns(false);
 
+        // Real virtual txs so the service can parse each hex back to its own txid — the correct,
+        // order-proof pairing key. arkd's GetVirtualTxs (SQL `WHERE id IN (...)`) does NOT preserve
+        // request order, so the fix must not rely on positional pairing.
+        var tree1 = MakeVirtualTx(0x11);
+        var tree2 = MakeVirtualTx(0x22);
+
         var chainEntries = new List<VtxoChainEntry>
         {
             new("commitmenttxid", DateTimeOffset.UtcNow.AddDays(30), ChainedTxType.Commitment, []),
-            new("treetxid1", DateTimeOffset.UtcNow.AddDays(30), ChainedTxType.Tree, []),
-            new("treetxid2", DateTimeOffset.UtcNow.AddDays(30), ChainedTxType.Tree, [])
+            new(tree1.Txid, DateTimeOffset.UtcNow.AddDays(30), ChainedTxType.Tree, []),
+            new(tree2.Txid, DateTimeOffset.UtcNow.AddDays(30), ChainedTxType.Tree, [])
         };
         _transport.GetVtxoChainAsync(_testOutpoint, Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(chainEntries);
 
-        // GetVirtualTxs is only called for non-Commitment txs
-        var hexList = new List<string> { "deadbeef01", "deadbeef02" };
+        // Return the hexes in REVERSED order relative to the request to prove the pairing is by
+        // parsed txid, not by position (the old Zip-by-index bug would attach tree2's hex to tree1).
         _transport.GetVirtualTxsAsync(
-            Arg.Is<IReadOnlyList<string>>(l => l.Count == 2 &&
-                l[0] == "treetxid1" && l[1] == "treetxid2"),
+            Arg.Is<IReadOnlyList<string>>(l => l.Count == 2 && l[0] == tree1.Txid && l[1] == tree2.Txid),
             Arg.Any<CancellationToken>())
-            .Returns(hexList);
+            .Returns(new List<string> { tree2.Hex, tree1.Hex });
 
         // Act
         await _service.FetchAndStoreBranchAsync(_testOutpoint, VirtualTxMode.Full);
 
-        // Assert — full chain stored, types preserved, commitment kept hex-null
+        // Assert — each tree tx got ITS OWN hex despite the reversed response order.
         await _storage.Received(1).UpsertVirtualTxsAsync(
             Arg.Is<IReadOnlyList<VirtualTx>>(txs =>
                 txs.Count == 3 &&
                 txs[0].Txid == "commitmenttxid" && txs[0].Hex == null && txs[0].Type == ChainedTxType.Commitment &&
-                txs[1].Txid == "treetxid1" && txs[1].Hex == "deadbeef01" && txs[1].Type == ChainedTxType.Tree &&
-                txs[2].Txid == "treetxid2" && txs[2].Hex == "deadbeef02" && txs[2].Type == ChainedTxType.Tree),
+                txs[1].Txid == tree1.Txid && txs[1].Hex == tree1.Hex && txs[1].Type == ChainedTxType.Tree &&
+                txs[2].Txid == tree2.Txid && txs[2].Hex == tree2.Hex && txs[2].Type == ChainedTxType.Tree),
             Arg.Any<CancellationToken>());
 
-        // Branch covers the whole chain so consumers can walk back to the
-        // anchor without re-querying the indexer.
+        // Branch covers the whole chain so consumers can walk back to the anchor.
         await _storage.Received(1).SetBranchAsync(
             _testOutpoint,
             Arg.Is<IReadOnlyList<VtxoBranch>>(b =>
                 b.Count == 3 &&
                 b[0].Position == 0 && b[0].VirtualTxid == "commitmenttxid" &&
-                b[1].Position == 1 && b[1].VirtualTxid == "treetxid1" &&
-                b[2].Position == 2 && b[2].VirtualTxid == "treetxid2"),
+                b[1].Position == 1 && b[1].VirtualTxid == tree1.Txid &&
+                b[2].Position == 2 && b[2].VirtualTxid == tree2.Txid),
             Arg.Any<CancellationToken>());
     }
 
@@ -123,23 +133,27 @@ public class VirtualTxServiceTests
         // ("deadbeef" won't parse to a finalizable witness). Full mode must NOT
         // treat that as done: it self-heals by re-fetching until the signed copy
         // lands, so unilateral exit can broadcast from storage without the operator.
+        var tree = MakeVirtualTx(0x33);
         _storage.HasBranchAsync(_testOutpoint, Arg.Any<CancellationToken>()).Returns(true);
         _storage.GetBranchAsync(_testOutpoint, Arg.Any<CancellationToken>())
-            .Returns(new List<VirtualTx> { new("treetxid", "deadbeef", null, ChainedTxType.Tree) });
+            .Returns(new List<VirtualTx> { new(tree.Txid, "deadbeef", null, ChainedTxType.Tree) });
 
         _transport.GetVtxoChainAsync(_testOutpoint, Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(new List<VtxoChainEntry>
             {
-                new("treetxid", DateTimeOffset.UtcNow.AddDays(30), ChainedTxType.Tree, [])
+                new(tree.Txid, DateTimeOffset.UtcNow.AddDays(30), ChainedTxType.Tree, [])
             });
         _transport.GetVirtualTxsAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
-            .Returns(new List<string> { "freshhex" });
+            .Returns(new List<string> { tree.Hex });
 
         // Act
         await _service.FetchAndStoreBranchAsync(_testOutpoint, VirtualTxMode.Full);
 
-        // Assert — did NOT short-circuit; re-fetched the chain to self-heal.
+        // Assert — did NOT short-circuit; re-fetched the chain to self-heal and stored the fresh hex.
         await _transport.Received().GetVtxoChainAsync(_testOutpoint, Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+        await _storage.Received(1).UpsertVirtualTxsAsync(
+            Arg.Is<IReadOnlyList<VirtualTx>>(txs => txs.Count == 1 && txs[0].Txid == tree.Txid && txs[0].Hex == tree.Hex),
+            Arg.Any<CancellationToken>());
     }
 
     [Test]
@@ -148,58 +162,63 @@ public class VirtualTxServiceTests
         // Arrange
         _storage.HasBranchAsync(_testOutpoint, Arg.Any<CancellationToken>()).Returns(false);
 
+        var tree = MakeVirtualTx(0x44);
         var chainEntries = new List<VtxoChainEntry>
         {
             new("commitmenttx", DateTimeOffset.UtcNow, ChainedTxType.Commitment, []),
-            new("treetx", DateTimeOffset.UtcNow, ChainedTxType.Tree, [])
+            new(tree.Txid, DateTimeOffset.UtcNow, ChainedTxType.Tree, [])
         };
         _transport.GetVtxoChainAsync(_testOutpoint, Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(chainEntries);
         _transport.GetVirtualTxsAsync(
-            Arg.Is<IReadOnlyList<string>>(l => l.Count == 1 && l[0] == "treetx"),
+            Arg.Is<IReadOnlyList<string>>(l => l.Count == 1 && l[0] == tree.Txid),
             Arg.Any<CancellationToken>())
-            .Returns(new List<string> { "hex1" });
+            .Returns(new List<string> { tree.Hex });
 
         // Act
         await _service.FetchAndStoreBranchAsync(_testOutpoint, VirtualTxMode.Full);
 
         // Assert — both entries stored (commitment with null hex, tree with
         // its fetched hex). arkd's GetVirtualTxs is the wrong endpoint for
-        // commitment txs (those live on-chain), so we never request hex
-        // for them.
+        // commitment txs (those live on-chain), so we never request hex for them.
         await _storage.Received(1).UpsertVirtualTxsAsync(
             Arg.Is<IReadOnlyList<VirtualTx>>(txs =>
                 txs.Count == 2 &&
                 txs[0].Txid == "commitmenttx" && txs[0].Hex == null &&
                     txs[0].Type == ChainedTxType.Commitment &&
-                txs[1].Txid == "treetx" && txs[1].Hex == "hex1" &&
+                txs[1].Txid == tree.Txid && txs[1].Hex == tree.Hex &&
                     txs[1].Type == ChainedTxType.Tree),
             Arg.Any<CancellationToken>());
     }
 
     [Test]
-    public async Task EnsureHexPopulated_FetchesMissingHex()
+    public async Task EnsureHexPopulated_PairsMissingHexByParsedTxid_RegardlessOfResponseOrder()
     {
-        // Arrange
+        // Arrange — two txs missing hex; the indexer returns them in reversed order.
+        var tx1 = MakeVirtualTx(0x55);
+        var tx2 = MakeVirtualTx(0x66);
         var branch = new List<VirtualTx>
         {
-            new("tx1", "existinghex", DateTimeOffset.UtcNow),
-            new("tx2", null, DateTimeOffset.UtcNow) // Missing hex
+            new("has-hex", "existinghex", DateTimeOffset.UtcNow),
+            new(tx1.Txid, null, DateTimeOffset.UtcNow),
+            new(tx2.Txid, null, DateTimeOffset.UtcNow)
         };
         _storage.GetBranchAsync(_testOutpoint, Arg.Any<CancellationToken>()).Returns(branch);
 
         _transport.GetVirtualTxsAsync(
-            Arg.Is<IReadOnlyList<string>>(l => l.Count == 1 && l[0] == "tx2"),
+            Arg.Is<IReadOnlyList<string>>(l => l.Count == 2 && l[0] == tx1.Txid && l[1] == tx2.Txid),
             Arg.Any<CancellationToken>())
-            .Returns(new List<string> { "newhex" });
+            .Returns(new List<string> { tx2.Hex, tx1.Hex }); // reversed
 
         // Act
         await _service.EnsureHexPopulatedAsync(_testOutpoint);
 
-        // Assert — only missing tx fetched and updated
+        // Assert — each missing tx got ITS OWN hex (paired by parsed txid, not position).
         await _storage.Received(1).UpsertVirtualTxsAsync(
             Arg.Is<IReadOnlyList<VirtualTx>>(txs =>
-                txs.Count == 1 && txs[0].Txid == "tx2" && txs[0].Hex == "newhex"),
+                txs.Count == 2 &&
+                txs.Any(t => t.Txid == tx1.Txid && t.Hex == tx1.Hex) &&
+                txs.Any(t => t.Txid == tx2.Txid && t.Hex == tx2.Hex)),
             Arg.Any<CancellationToken>());
     }
 
@@ -211,14 +230,15 @@ public class VirtualTxServiceTests
             .Returns(new List<VirtualTx>());
         _storage.HasBranchAsync(_testOutpoint, Arg.Any<CancellationToken>()).Returns(false);
 
+        var tree = MakeVirtualTx(0x77);
         var chainEntries = new List<VtxoChainEntry>
         {
-            new("tx1", DateTimeOffset.UtcNow, ChainedTxType.Tree, [])
+            new(tree.Txid, DateTimeOffset.UtcNow, ChainedTxType.Tree, [])
         };
         _transport.GetVtxoChainAsync(_testOutpoint, Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(chainEntries);
         _transport.GetVirtualTxsAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<CancellationToken>())
-            .Returns(new List<string> { "hex1" });
+            .Returns(new List<string> { tree.Hex });
 
         // Act
         await _service.EnsureHexPopulatedAsync(_testOutpoint);
@@ -244,5 +264,41 @@ public class VirtualTxServiceTests
         // Assert
         await _storage.Received(1).PruneForSpentVtxoAsync(outpoints[0], Arg.Any<CancellationToken>());
         await _storage.Received(1).PruneForSpentVtxoAsync(outpoints[1], Arg.Any<CancellationToken>());
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a real, self-consistent virtual tx: a minimal PSBT whose global-tx txid the service can
+    /// recover by parsing the hex. The random taproot output keeps every call's txid unique.
+    /// </summary>
+    private static (string Txid, string Hex) MakeVirtualTx(byte seed)
+    {
+        var tx = Transaction.Create(Network.RegTest);
+        tx.Inputs.Add(new OutPoint(new uint256(Enumerable.Repeat(seed, 32).ToArray()), 0));
+        tx.Outputs.Add(Money.Coins(1), new Key().PubKey.GetScriptPubKey(ScriptPubKeyType.TaprootBIP86));
+        var psbt = PSBT.FromTransaction(tx, Network.RegTest);
+        return (tx.GetHash().ToString(), psbt.ToBase64());
+    }
+
+    private static ArkServerInfo CreateServerInfo()
+    {
+        var signerKey = OutputDescriptor.Parse(
+            $"rawtr({Convert.ToHexString(new Key().PubKey.TaprootInternalKey.ToBytes()).ToLowerInvariant()})",
+            Network.RegTest);
+        var emptyMultisig = new NArk.Core.Scripts.NofNMultisigTapScript(Array.Empty<NBitcoin.Secp256k1.ECXOnlyPubKey>());
+
+        return new ArkServerInfo(
+            Dust: Money.Satoshis(546),
+            SignerKey: signerKey,
+            DeprecatedSigners: new Dictionary<NBitcoin.Secp256k1.ECXOnlyPubKey, long>(ECXOnlyPubKeyComparer.Instance),
+            Network: Network.RegTest,
+            UnilateralExit: new Sequence(144),
+            BoardingExit: new Sequence(144),
+            ForfeitAddress: BitcoinAddress.Create("bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080", Network.RegTest),
+            ForfeitPubKey: NBitcoin.Secp256k1.ECXOnlyPubKey.Create(new Key().PubKey.TaprootInternalKey.ToBytes()),
+            CheckpointTapScript: new NArk.Core.Scripts.UnilateralPathArkTapScript(new Sequence(144), emptyMultisig),
+            FeeTerms: new ArkOperatorFeeTerms("1", "0", "0", "0", "0"),
+            Digest: "");
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtual transaction data matching to use each transaction’s identifier rather than response order.
  * Ensured transaction hex data is stored with the correct virtual transaction, even when results are returned in a different order.
  * Added warnings when expected transaction data cannot be matched or parsed.

* **Tests**
  * Added coverage for order-independent transaction pairing and hex population.
  * Strengthened validation of stored transaction data and refetch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->