### PR TITLE
fix(core): reorder delegate contract tapscript leaves to match ts-sdk

### DIFF
--- a/NArk.Core/Contracts/ArkDelegateContract.cs
+++ b/NArk.Core/Contracts/ArkDelegateContract.cs
@@ -35,14 +35,14 @@ public class ArkDelegateContract : ArkContract
     }
 
     /// <summary>
-    /// Leaf ordering follows canonical Ark SDK convention: [delegate, forfeit, exit].
+    /// Leaf ordering follows canonical Arkade SDK convention: [forfeit, exit, delegate].
     /// </summary>
     protected override IEnumerable<ScriptBuilder> GetScriptBuilders()
     {
         return [
-            DelegatePath(),
             CollaborativePath(),
-            ExitPath()
+            ExitPath(),
+            DelegatePath()
         ];
     }
 

--- a/NArk.Tests.End2End/DelegationTests.cs
+++ b/NArk.Tests.End2End/DelegationTests.cs
@@ -96,7 +96,7 @@ public class DelegationTests
         // 3. Verify the contract has the expected structure
         var tapLeaves = delegateContract.GetTapScriptList();
         Assert.That(tapLeaves.Length, Is.EqualTo(3),
-            "Delegate contract should have 3 tap leaves (delegate, forfeit, exit)");
+            "Delegate contract should have 3 tap leaves (forfeit, exit, delegate)");
 
         // 4. Verify round-trip parse via entity serialization
         var entity = delegateContract.ToEntity("test-wallet");

--- a/NArk.Tests/DelegateContractTests.cs
+++ b/NArk.Tests/DelegateContractTests.cs
@@ -53,13 +53,13 @@ public class DelegateContractTests
         Assert.That(leaves, Has.Length.EqualTo(3));
     }
 
-    // Leaf ordering: [0] delegate, [1] forfeit, [2] exit
+    // Leaf ordering: [0] forfeit, [1] exit, [2] delegate
 
     [Test]
     public void DelegateContract_DelegatePath_WithCLTV_HasCltvGate()
     {
         var contract = CreateContract();
-        var delegateScript = contract.GetTapScriptList()[0].Script;
+        var delegateScript = contract.GetTapScriptList()[2].Script;
 
         Assert.That(delegateScript.ToString(), Does.Contain("OP_CLTV"));
         Assert.That(delegateScript.ToString(), Does.Contain("OP_CHECKSIGVERIFY"));
@@ -69,7 +69,7 @@ public class DelegateContractTests
     public void DelegateContract_DelegatePath_WithoutCLTV_NoCltvGate()
     {
         var contract = CreateContract(useCltv: false);
-        var delegateScript = contract.GetTapScriptList()[0].Script;
+        var delegateScript = contract.GetTapScriptList()[2].Script;
 
         Assert.That(delegateScript.ToString(), Does.Not.Contain("OP_CLTV"));
         // Still has multisig: user + delegate CHECKSIGVERIFY, server CHECKSIG
@@ -81,7 +81,7 @@ public class DelegateContractTests
     public void DelegateContract_CollaborativePath_HasChecksigVerify()
     {
         var contract = CreateContract();
-        var forfeitScript = contract.GetTapScriptList()[1].Script;
+        var forfeitScript = contract.GetTapScriptList()[0].Script;
 
         Assert.That(forfeitScript.ToString(), Does.Contain("OP_CHECKSIGVERIFY"));
         Assert.That(forfeitScript.ToString(), Does.Contain("OP_CHECKSIG"));
@@ -91,7 +91,7 @@ public class DelegateContractTests
     public void DelegateContract_ExitPath_HasCSV()
     {
         var contract = CreateContract();
-        var exitScript = contract.GetTapScriptList()[2].Script;
+        var exitScript = contract.GetTapScriptList()[1].Script;
 
         Assert.That(exitScript.ToString(), Does.Contain("OP_CSV"));
     }


### PR DESCRIPTION
Reorder delegate contract tapscript leaves to [forfeit, exit, delegate]

The delegate contract built its script tree as [delegate, forfeit, exit]. Align with the canonical Arkade SDK convention: [forfeit, exit, delegate].

This changes the taproot tree, and therefore the derived address, for delegate contracts.

Index-based leaf assertions in the unit and E2E tests are updated to match.

Addressing https://github.com/arkade-os/dotnet-sdk/issues/162